### PR TITLE
get version from ldflags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,9 +25,10 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
-
-const version = "v0.1.13"
+var (
+	meroxaVersion string
+	cfgFile       string
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -44,7 +45,8 @@ meroxa list resource-types`,
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
+func Execute(version string) {
+	meroxaVersion = version
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -26,7 +26,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "display the version of the Meroxa CLI",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Meroxa CLI version %s\n", version)
+		fmt.Printf("Meroxa CLI version %s\n", meroxaVersion)
 	},
 }
 
@@ -35,5 +35,5 @@ func init() {
 }
 
 func versionString() string {
-	return fmt.Sprintf("meroxa cli %s", version)
+	return fmt.Sprintf("meroxa cli %s", meroxaVersion)
 }

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ package main
 
 import "github.com/meroxa/cli/cmd"
 
+var version = "dev"
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version)
 }


### PR DESCRIPTION
# Description of change

*This commit prevents releases/tag version mismatch. By default goreleaser provides a `main.version` ldflag for the current git tag, this change refactors the cli to use that link for the version*

Fixes [MEROXA-81]

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [X]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Deployed to staging
- [X] Other:
Deplicated repo and tested github actions on release

# Additional references

*Any additional links (if appropriate)*
https://goreleaser.com/environment/#using-the-mainversion


[MEROXA-81]: https://meroxa.atlassian.net/browse/MEROXA-81