### PR TITLE
[MEROXA-173] Handle missing meroxa.config/user not logged in

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -48,6 +48,8 @@ var (
 
 	flagLoginUsername string
 	flagLoginPassword string
+
+	ErrNotLoggedIn = errors.New("you do not appear to be logged in to the Meroxa Platform")
 )
 
 var signupCmd = &cobra.Command{
@@ -202,8 +204,12 @@ func readCreds() (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+
 	dat, err := ioutil.ReadFile(filePath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return "", "", ErrNotLoggedIn
+		}
 		return "", "", err
 	}
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -42,55 +42,49 @@ var createConnectorCmd = &cobra.Command{
 	Use:   "connector",
 	Short: "create connector",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Resource Name
 		resName := args[0]
 
 		name, err := cmd.Flags().GetString("name")
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		cfgString, err := cmd.Flags().GetString("config")
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		cfg := &Config{}
 		if cfgString != "" {
 			err = json.Unmarshal([]byte(cfgString), cfg)
 			if err != nil {
-				fmt.Println("Error: ", err)
-				return
+				return err
 			}
 		}
 
 		// Process metadata
 		metadataString, err := cmd.Flags().GetString("metadata")
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 		metadata := map[string]string{}
 		if metadataString != "" {
 			err = json.Unmarshal([]byte(metadataString), &metadata)
 			if err != nil {
-				fmt.Println("Error: ", err)
-				return
+				return err
 			}
 		}
 
 		// merge in input
 		input, err := cmd.Flags().GetString("input")
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 		err = cfg.Set("input", input)
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		if !flagRootOutputJSON {
@@ -99,8 +93,7 @@ var createConnectorCmd = &cobra.Command{
 
 		con, err := createConnector(name, resName, cfg, metadata, input)
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		if flagRootOutputJSON {
@@ -109,6 +102,8 @@ var createConnectorCmd = &cobra.Command{
 			fmt.Println("Connector successfully created!")
 			prettyPrint("connector", con)
 		}
+
+		return nil
 	},
 }
 

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -39,12 +39,12 @@ var describeResourceCmd = &cobra.Command{
 	Use:   "resource <name>",
 	Short: "describe resource",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		name := args[0]
 
 		c, err := client()
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -52,7 +52,7 @@ var describeResourceCmd = &cobra.Command{
 
 		res, err := c.GetResourceByName(ctx, name)
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		if flagRootOutputJSON {
@@ -60,6 +60,7 @@ var describeResourceCmd = &cobra.Command{
 		} else {
 			prettyPrint("resource", res)
 		}
+		return nil
 	},
 }
 
@@ -72,13 +73,16 @@ var describeConnectorCmd = &cobra.Command{
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var (
 			err  error
 			conn *meroxa.Connector
 		)
 		name := args[0]
 		c, err := client()
+		if err != nil {
+			return err
+		}
 
 		ctx := context.Background()
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -86,8 +90,7 @@ var describeConnectorCmd = &cobra.Command{
 
 		conn, err = c.GetConnectorByName(ctx, name)
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		if flagRootOutputJSON {
@@ -95,6 +98,7 @@ var describeConnectorCmd = &cobra.Command{
 		} else {
 			prettyPrint("connector", conn)
 		}
+		return nil
 	},
 }
 

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -36,14 +36,13 @@ var destroyResourceCmd = &cobra.Command{
 	Use:   "resource <name>",
 	Short: "destroy resource",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Resource Name
 		resName := args[0]
 
 		c, err := client()
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		// get Resource ID from name
@@ -53,13 +52,12 @@ var destroyResourceCmd = &cobra.Command{
 
 		res, err := c.GetResourceByName(ctx, resName)
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		c, err = client()
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		ctx = context.Background()
@@ -68,10 +66,11 @@ var destroyResourceCmd = &cobra.Command{
 
 		err = c.DeleteResource(ctx, res.ID)
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		prettyPrint("resource destroyed", res)
+		return nil
 	},
 }
 
@@ -79,14 +78,13 @@ var destroyConnectorCmd = &cobra.Command{
 	Use:   "connector <name>",
 	Short: "destroy connector",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Connector Name
 		conName := args[0]
 
 		c, err := client()
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		// get Connector ID from name
@@ -96,13 +94,12 @@ var destroyConnectorCmd = &cobra.Command{
 
 		con, err := c.GetConnectorByName(ctx, conName)
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		c, err = client()
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		ctx = context.Background()
@@ -111,10 +108,11 @@ var destroyConnectorCmd = &cobra.Command{
 
 		err = c.DeleteConnector(ctx, con.ID)
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		prettyPrint("connector destroyed", con)
+		return nil
 	},
 }
 
@@ -130,14 +128,13 @@ var destroyPipelineCmd = &cobra.Command{
 	Use:   "pipeline <name>",
 	Short: "destroy pipeline",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Pipeline Name
 		pipelineName := args[0]
 
 		c, err := client()
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		// get Pipeline ID from name
@@ -147,13 +144,12 @@ var destroyPipelineCmd = &cobra.Command{
 
 		pipeline, err := c.GetPipelineByName(ctx, pipelineName)
 		if err != nil {
-			fmt.Println("Error: ", err)
-			return
+			return err
 		}
 
 		c, err = client()
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		ctx = context.Background()
@@ -162,10 +158,11 @@ var destroyPipelineCmd = &cobra.Command{
 
 		err = c.DeletePipeline(ctx, pipeline.ID)
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		prettyPrint("pipeline destroyed", pipeline)
+		return nil
 	},
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,7 +18,6 @@ limitations under the License.
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -35,10 +34,10 @@ var listCmd = &cobra.Command{
 var listResourcesCmd = &cobra.Command{
 	Use:   "resources",
 	Short: "list resources",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := client()
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		ctx := context.Background()
@@ -47,7 +46,7 @@ var listResourcesCmd = &cobra.Command{
 
 		rr, err := c.ListResources(ctx)
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		if flagRootOutputJSON {
@@ -55,16 +54,17 @@ var listResourcesCmd = &cobra.Command{
 		} else {
 			printResourcesTable(rr)
 		}
+		return nil
 	},
 }
 
 var listConnectorsCmd = &cobra.Command{
 	Use:   "connectors",
 	Short: "list connectors",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := client()
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		ctx := context.Background()
@@ -73,7 +73,7 @@ var listConnectorsCmd = &cobra.Command{
 
 		connectors, err := c.ListConnectors(ctx)
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		if flagRootOutputJSON {
@@ -81,16 +81,17 @@ var listConnectorsCmd = &cobra.Command{
 		} else {
 			printConnectorsTable(connectors)
 		}
+		return nil
 	},
 }
 
 var listResourceTypesCmd = &cobra.Command{
 	Use:   "resource-types",
 	Short: "list resources-types",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := client()
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		ctx := context.Background()
@@ -99,7 +100,7 @@ var listResourceTypesCmd = &cobra.Command{
 
 		resTypes, err := c.ListResourceTypes(ctx)
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		if flagRootOutputJSON {
@@ -107,16 +108,17 @@ var listResourceTypesCmd = &cobra.Command{
 		} else {
 			printResourceTypesTable(resTypes)
 		}
+		return nil
 	},
 }
 
 var listPipelinesCmd = &cobra.Command{
 	Use:   "pipelines",
 	Short: "list pipelines",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		c, err := client()
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		ctx := context.Background()
@@ -125,7 +127,7 @@ var listPipelinesCmd = &cobra.Command{
 
 		rr, err := c.ListPipelines(ctx)
 		if err != nil {
-			fmt.Println("Error: ", err)
+			return err
 		}
 
 		if flagRootOutputJSON {
@@ -133,6 +135,7 @@ var listPipelinesCmd = &cobra.Command{
 		} else {
 			prettyPrint("pipelines", rr)
 		}
+		return nil
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,7 +51,6 @@ meroxa list resource-types`,
 func Execute(version string) {
 	meroxaVersion = version
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
# Description of change

Previously if the `meroxa.config` file did not exist (e.g. the user was not logged in) running any command that initiated a client would result in a panic. This PR returns an error instead if the file is missing.

![handle-missing-meroxa-config](https://user-images.githubusercontent.com/57750952/102925279-eb8a2c80-4447-11eb-9527-a4dd6811a2b0.png)

Fixes [MEROXA-173]

# Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [x]  Deployed to staging

# Additional references

* Replaced `Run` options with `RunE` to handle errors in subcommands: https://github.com/spf13/cobra#returning-and-handling-errors


[MEROXA-173]: https://meroxa.atlassian.net/browse/MEROXA-173