### PR TITLE
fix(cli): Hide usage when errors come from API

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().BoolVar(&flagRootOutputJSON, "json", false, "output json")
+	rootCmd.SilenceUsage = true
 
 	// Here you will define your flags and configuration settings.
 	// Cobra supports persistent flags, which, if defined here,


### PR DESCRIPTION
# Description of change

Fixes https://meroxa.atlassian.net/browse/MEROXA-251

When something fails due to the API, the CLI outputs usage apart from the API error which makes understanding what happened harder. This PR takes the advantage of the `SilenceUsage`  flag in [Cobra](https://pkg.go.dev/github.com/spf13/cobra) to fix it.

It is worth noting that usage is still shown when needed. Example:

```
❯ .m add
Use the add command to add various Meroxa resources to your account.

Usage:
  meroxa add [command]

Available Commands:
  resource    Add a resource to your account

Flags:
  -h, --help   help for add

Global Flags:
      --json   output json

Use "meroxa add [command] --help" for more information about a command.

```

# Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Locally

# Additional references

**Before:**

```
❯ .m login
Username: raulb
Password: ********************
Error: unauthorized
Usage:
  meroxa login [flags]
  meroxa login [command]

Available Commands:
  whoami      retrieve currently logged in user

Flags:
  -h, --help              help for login
      --password string   password
      --username string   username

Global Flags:
      --json   output json

Use "meroxa login [command] --help" for more information about a command.

unauthorized
```

**After:**

```
❯ .m login
Username: raulb
Password: ********************
Error: unauthorized
unauthorized


```
