### PR TITLE
Separate oauth scopes with URL-encoded space; fix default config name

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/fatih/color"
+	"github.com/spf13/viper"
 	"strings"
 
 	cv "github.com/nirasan/go-oauth-pkce-code-verifier"
@@ -134,12 +135,17 @@ func authorizeUser(clientID string, authDomain string, redirectURL string) {
 		cfg.Set("REFRESH_TOKEN", refreshToken)
 		err = cfg.WriteConfig()
 		if err != nil {
-			fmt.Println("meroxa: could not write config file")
-			io.WriteString(w, "Error: could not store access token\n")
+			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+				err = cfg.SafeWriteConfig()
+			}
+			if err != nil {
+				fmt.Printf("meroxa: could not write config file: %v", err)
+				io.WriteString(w, "Error: could not store access token\n")
 
-			// close the HTTP server and return
-			cleanup(server)
-			return
+				// close the HTTP server and return
+				cleanup(server)
+				return
+			}
 		}
 
 		// return an indication of success to the caller

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// The name of our config file, without the file extension because viper supports many different config file languages.
-	defaultConfigFilename = "meroxa.env"
+	defaultConfigFilename = "meroxa"
 
 	// The environment variable prefix of all environment variables bound to our command line flags.
 	envPrefix = "MEROXA"
@@ -98,7 +98,6 @@ func initConfig(cmd *cobra.Command) error {
 		cfg.AddConfigPath(home)
 	}
 	cfg.SetConfigType("env")
-
 	// Attempt to read the config file, gracefully ignoring errors
 	// caused by a config file not being found. Return an error
 	// if we cannot parse the config file.


### PR DESCRIPTION
# Description of change

As mentioned in https://meroxa.slack.com/archives/C01EV0UP210/p1614804137195500, the value of the `scope` param of the authorization URL is not separated by URL-encoded space. The browser wasn't opened due to this bug: https://github.com/meroxa/cli/blob/860ae625139927fe707f38112e02aa474baa185a/cmd/auth.go#L175. Replace the space with URL-encoded space `%20` opens the browser and I was able to authenticate successfully.

# Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Manual tests
- [ ]  Unit Tests
- [ ]  Deployed to staging

# Additional references

https://meroxa.slack.com/archives/C01EV0UP210/p1614804137195500