### PR TITLE
Print new line after end of logs reached

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -108,7 +108,7 @@ var createConnectorCmd = &cobra.Command{
 		if flagRootOutputJSON {
 			display.JSONPrint(c)
 		} else {
-			fmt.Printf("Connector %s successfully created!", c.Name)
+			fmt.Printf("Connector %s successfully created!\n", c.Name)
 		}
 
 		return nil

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -43,7 +43,12 @@ var logsConnectorCmd = &cobra.Command{
 		}
 
 		_, err = io.Copy(os.Stderr, resp.Body)
+		if err != nil {
+			return err
+		}
 
-		return err
+		os.Stderr.Write([]byte("\n"))
+
+		return nil
 	},
 }


### PR DESCRIPTION
# Description of change

Logan logs do not terminate with new lines when consumed by CLI, it will be better aesthetically if we terminate this
with a new line.

https://meroxa.atlassian.net/browse/PLATFORM-187

# Type of change

- [x]  New feature
- [x]  Bug fix
- [x]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Deployed to staging

# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

- [ ] Suggested an edit to the appropiate CLI version. To see the list of edits (e.g. v1.0): https://dash.readme.com/project/meroxa/v1.0/suggested

*Provide link:*
