### PR TITLE
fix(cli) Make sure v is not included when testing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ brews:
     install: |
       bin.install "meroxa"
     test: |
-      shell_output("#{bin}/meroxa version").match(/{{ .Tag }}/)
+      shell_output("#{bin}/meroxa version").match(/{{ replace .Tag "v" "" }}/)
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
# Description of change

Something I should have done in https://github.com/meroxa/cli/pull/87.

Currently, version is shown as `meroxa/0.2.2 darwin/amd64` which wouldn't make the assertion to pass. This PR makes sure that's the case.

**Before**

```
 test do
    shell_output("#{bin}/meroxa version").match(/v0.2.2/)
  end
```

**Now**

```
...
  test do
    shell_output("#{bin}/meroxa version").match(/0.2.2/)
  end
```