### PR TITLE
Update GH token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MEROXA_MACHINE }}


### PR DESCRIPTION
# Description of change

The secret used previously which I assumed would work to push to `meroxa/homebrew-taps` is not present in this repository. This PR updates it to the proper GitHub token.

This should fix an automated homebrew release to [`meroxa/homebrew-taps`](https://github.com/meroxa/homebrew-taps) which failed such as https://github.com/meroxa/cli/runs/2194410513?check_suite_focus=true.

See https://goreleaser.com/customization/homebrew/ for more information.



# Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation