### PR TITLE
[PLATFORM-399] feat(cli): Add —debug flag

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -116,13 +116,8 @@ func getAccessToken() (string, error) {
 }
 
 func isDebugEnabled() bool {
-	if val, ok := os.LookupEnv("MEROXA_DEBUG"); ok {
-		if val == "1" {
-			return true
-		}
-	}
-
-	return false
+	val, ok := os.LookupEnv("MEROXA_DEBUG")
+	return flagDebug || (ok && val == "1")
 }
 
 func client() (*meroxa.Client, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,13 +39,13 @@ const (
 )
 
 var (
-	meroxaVersion      string
-	cfgFile            string
-	source             string
-	destination        string
-	flagRootOutputJSON bool
-	meroxaCmd          *cobra.Command
-	cfg                *viper.Viper
+	meroxaVersion                 string
+	cfgFile                       string
+	source                        string
+	destination                   string
+	flagRootOutputJSON, flagDebug bool
+	meroxaCmd                     *cobra.Command
+	cfg                           *viper.Viper
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -69,6 +69,8 @@ meroxa list resource-types`,
 
 	rootCmd.PersistentFlags().BoolVar(&flagRootOutputJSON, "json", false, "output json")
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/meroxa.env)")
+	rootCmd.PersistentFlags().BoolVar(&flagDebug, "debug", false, "display any debugging information")
+
 	rootCmd.SilenceUsage = true
 	rootCmd.DisableAutoGenTag = true
 
@@ -85,9 +87,7 @@ meroxa list resource-types`,
 	rootCmd.AddCommand(LogoutCmd())
 	rootCmd.AddCommand(LogsCmd())
 	rootCmd.AddCommand(OpenCmd())
-
-	r := &Remove{}
-	rootCmd.AddCommand(r.command())
+	rootCmd.AddCommand((&Remove{}).command())
 	rootCmd.AddCommand(UpdateCmd())
 	rootCmd.AddCommand(VersionCmd())
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -36,6 +36,7 @@ func TestRootCmd(t *testing.T) {
 		{"version     Display the Meroxa CLI version"},
 		{"Flags:\n" +
 			"      --config string   config file (default is $HOME/meroxa.env)\n" +
+			"      --debug           display any debugging information\n" +
 			"  -h, --help            help for meroxa\n" +
 			"      --json            output json\n\n"},
 		{"Use \"meroxa [command] --help\" for more information about a command."},

--- a/docs/cmd/meroxa.md
+++ b/docs/cmd/meroxa.md
@@ -16,6 +16,7 @@ meroxa list resource-types
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
   -h, --help            help for meroxa
       --json            output json
 ```

--- a/docs/cmd/meroxa_add.md
+++ b/docs/cmd/meroxa_add.md
@@ -12,6 +12,7 @@ Add a resource to your Meroxa resource catalog
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_add_resource.md
+++ b/docs/cmd/meroxa_add_resource.md
@@ -35,6 +35,7 @@ meroxa add resource slack --type url -u $WEBHOOK_URL
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_api.md
+++ b/docs/cmd/meroxa_api.md
@@ -24,6 +24,7 @@ meroxa api POST /v1/endpoints '{"protocol": "HTTP", "stream": "resource-2-499379
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_billing.md
+++ b/docs/cmd/meroxa_billing.md
@@ -16,6 +16,7 @@ meroxa billing [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_completion.md
+++ b/docs/cmd/meroxa_completion.md
@@ -50,6 +50,7 @@ meroxa completion [bash|zsh|fish|powershell]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_connect.md
+++ b/docs/cmd/meroxa_connect.md
@@ -35,6 +35,7 @@ meroxa connect --from <resource-name> --to <resource-name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_create.md
+++ b/docs/cmd/meroxa_create.md
@@ -17,6 +17,7 @@ including connectors.
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_create_connector.md
+++ b/docs/cmd/meroxa_create_connector.md
@@ -31,6 +31,7 @@ meroxa create connector [<custom-connector-name>] --to pg2redshift --input order
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_create_endpoint.md
+++ b/docs/cmd/meroxa_create_endpoint.md
@@ -29,6 +29,7 @@ meroxa create endpoint my-endpoint --protocol http --stream my-stream
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_create_pipeline.md
+++ b/docs/cmd/meroxa_create_pipeline.md
@@ -17,6 +17,7 @@ meroxa create pipeline <name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_describe.md
+++ b/docs/cmd/meroxa_describe.md
@@ -16,6 +16,7 @@ Describe a component of the Meroxa data platform, including resources and connec
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_describe_connector.md
+++ b/docs/cmd/meroxa_describe_connector.md
@@ -16,6 +16,7 @@ meroxa describe connector [name] [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_describe_endpoint.md
+++ b/docs/cmd/meroxa_describe_endpoint.md
@@ -16,6 +16,7 @@ meroxa describe endpoint <name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_describe_resource.md
+++ b/docs/cmd/meroxa_describe_resource.md
@@ -16,6 +16,7 @@ meroxa describe resource <name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_list.md
+++ b/docs/cmd/meroxa_list.md
@@ -17,6 +17,7 @@ List the components of the Meroxa platform, including pipelines,
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_list_connectors.md
+++ b/docs/cmd/meroxa_list_connectors.md
@@ -16,6 +16,7 @@ meroxa list connectors [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_list_endpoint.md
+++ b/docs/cmd/meroxa_list_endpoint.md
@@ -16,6 +16,7 @@ meroxa list endpoint [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_list_pipelines.md
+++ b/docs/cmd/meroxa_list_pipelines.md
@@ -16,6 +16,7 @@ meroxa list pipelines [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_list_resource-types.md
+++ b/docs/cmd/meroxa_list_resource-types.md
@@ -16,6 +16,7 @@ meroxa list resource-types [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_list_resources.md
+++ b/docs/cmd/meroxa_list_resources.md
@@ -16,6 +16,7 @@ meroxa list resources [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_list_transforms.md
+++ b/docs/cmd/meroxa_list_transforms.md
@@ -16,6 +16,7 @@ meroxa list transforms [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_login.md
+++ b/docs/cmd/meroxa_login.md
@@ -16,6 +16,7 @@ meroxa login [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_logout.md
+++ b/docs/cmd/meroxa_logout.md
@@ -16,6 +16,7 @@ meroxa logout [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_logs.md
+++ b/docs/cmd/meroxa_logs.md
@@ -12,6 +12,7 @@ Print logs for a component
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_logs_connector.md
+++ b/docs/cmd/meroxa_logs_connector.md
@@ -16,6 +16,7 @@ meroxa logs connector <name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_open.md
+++ b/docs/cmd/meroxa_open.md
@@ -12,6 +12,7 @@ Open in a web browser
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_open_billing.md
+++ b/docs/cmd/meroxa_open_billing.md
@@ -16,6 +16,7 @@ meroxa open billing [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_remove.md
+++ b/docs/cmd/meroxa_remove.md
@@ -18,6 +18,7 @@ Deprovision a component of the Meroxa platform, including pipelines,
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_remove_connector.md
+++ b/docs/cmd/meroxa_remove_connector.md
@@ -16,6 +16,7 @@ meroxa remove connector <name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
   -f, --force           force delete without confirmation prompt
       --json            output json
 ```

--- a/docs/cmd/meroxa_remove_endpoint.md
+++ b/docs/cmd/meroxa_remove_endpoint.md
@@ -16,6 +16,7 @@ meroxa remove endpoint <name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
   -f, --force           force delete without confirmation prompt
       --json            output json
 ```

--- a/docs/cmd/meroxa_remove_pipeline.md
+++ b/docs/cmd/meroxa_remove_pipeline.md
@@ -16,6 +16,7 @@ meroxa remove pipeline <name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
   -f, --force           force delete without confirmation prompt
       --json            output json
 ```

--- a/docs/cmd/meroxa_remove_resource.md
+++ b/docs/cmd/meroxa_remove_resource.md
@@ -16,6 +16,7 @@ meroxa remove resource <name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
   -f, --force           force delete without confirmation prompt
       --json            output json
 ```

--- a/docs/cmd/meroxa_update.md
+++ b/docs/cmd/meroxa_update.md
@@ -16,6 +16,7 @@ Update a component of the Meroxa platform, including connectors
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_update_connector.md
+++ b/docs/cmd/meroxa_update_connector.md
@@ -17,6 +17,7 @@ meroxa update connector <name> --state <pause|resume|restart> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_update_pipeline.md
+++ b/docs/cmd/meroxa_update_pipeline.md
@@ -28,6 +28,7 @@ meroxa update pipeline pipeline-name --metadata '{"key":"value"}'
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_update_resource.md
+++ b/docs/cmd/meroxa_update_resource.md
@@ -23,6 +23,7 @@ meroxa update resource <resource-name> [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 

--- a/docs/cmd/meroxa_version.md
+++ b/docs/cmd/meroxa_version.md
@@ -16,6 +16,7 @@ meroxa version [flags]
 
 ```
       --config string   config file (default is $HOME/meroxa.env)
+      --debug           display any debugging information
       --json            output json
 ```
 


### PR DESCRIPTION
# Description of change

So far we've got `MEROXA_DEBUG=1` as an option to debug CLI commands, although this is not documented anywhere and really difficult for users to discover this option. 

By adding the flag `--debug` we'll be able to expose this so they could figure it out themselves and maybe reach out to us directly with more useful information to debug their issues.

ℹ️  We're still giving support to `MEROXA_DEBUG=1`.

Fixes https://meroxa.atlassian.net/browse/PLATFORM-399

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## Demo

```
❯ .m list connectors
 ID        NAME          TYPE                   STREAMS                STATE    PIPELINE
===== ============== ============= ================================= ========= ==========
 255   my-connector   jdbc-source   output:                           running   11
                                    resource-149-499379-public.User


❯ .m list connectors --debug
2021/04/06 11:38:33 GET /v1/connectors HTTP/1.1
Host: api.meroxa.io
User-Agent: Meroxa CLI dev
Accept: application/json
Authorization: REDACTED
Content-Type: application/json
Accept-Encoding: gzip

2021/04/06 11:38:33 HTTP/2.0 200 OK
Content-Length: 321
Content-Type: application/json; charset=utf-8
Date: Tue, 06 Apr 2021 09:38:33 GMT
Meroxa-Request-Id: 972b55e1-a521-42e0-b786-21ef1e113873
Vary: Origin

[{"id":255,"name":"my-connector","type":"jdbc-source","config":{},"state":"running","resource_id":149,"pipeline_id":11,"streams":{"output":["resource-149-499379-public.User"],"dynamic":false},"metadata":{"mx:connectorType":"source"},"created_at":"2021-03-31T20:52:34.776287Z","updated_at":"2021-04-06T09:38:26.378847Z"}]
 ID        NAME          TYPE                   STREAMS                STATE    PIPELINE
===== ============== ============= ================================= ========= ==========
 255   my-connector   jdbc-source   output:                           running   11
                                    resource-149-499379-public.User


❯ MEROXA_DEBUG=1 .m list connectors
2021/04/06 11:38:39 GET /v1/connectors HTTP/1.1
Host: api.meroxa.io
User-Agent: Meroxa CLI dev
Accept: application/json
Authorization: REDACTED
Content-Type: application/json
Accept-Encoding: gzip

2021/04/06 11:38:41 HTTP/2.0 200 OK
Content-Length: 321
Content-Type: application/json; charset=utf-8
Date: Tue, 06 Apr 2021 09:38:41 GMT
Meroxa-Request-Id: 30a09194-3afa-4e96-aadf-12bc9ff9b2d7
Vary: Origin

[{"id":255,"name":"my-connector","type":"jdbc-source","config":{},"state":"running","resource_id":149,"pipeline_id":11,"streams":{"output":["resource-149-499379-public.User"],"dynamic":false},"metadata":{"mx:connectorType":"source"},"created_at":"2021-03-31T20:52:34.776287Z","updated_at":"2021-04-06T09:38:36.904751Z"}]
 ID        NAME          TYPE                   STREAMS                STATE    PIPELINE
===== ============== ============= ================================= ========= ==========
 255   my-connector   jdbc-source   output:                           running   11
                                    resource-149-499379-public.User

```
