### PR TITLE
[PLATFORM-420] feat(cli): Add man pages and completion scripts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,21 +2,20 @@
 # Make sure to check the documentation at http://goreleaser.com
 project_name: meroxa
 builds:
-- env:
-  - CGO_ENABLED=0
-  flags:
-  - -mod=vendor
-  goos:
-  - darwin
-  - linux
-  - windows
+  - env:
+      - CGO_ENABLED=0
+    flags:
+      - -mod=vendor
+    goos:
+      - darwin
+      - linux
+      - windows
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  - files:
+      - etc/*
+      - LICENSE
+      - README.md
+      - docs/*
 brews:
   - tap:
       owner: meroxa
@@ -29,10 +28,13 @@ brews:
       head "https://github.com/meroxa/cli.git"
     test: |
       shell_output("#{bin}/meroxa version").match(/{{ replace .Tag "v" "" }}/)
-    dependencies:
-    - name: go
     install: |-
       bin.install "meroxa"
+      prefix.install_metafiles
+      bash_completion.install "etc/completion/meroxa.completion.sh"
+      zsh_completion.install "etc/completion/meroxa.completion.zsh" => "meroxa"
+      fish_completion.install "etc/completion/meroxa.completion.fish"
+      man.install "etc/man/man1"
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,6 @@ test:
 
 .PHONY: docs
 docs:
+	rm -rf docs/cmd && mkdir docs/cmd
+	rm -rf etc && mkdir -p etc/man/man1 && mkdir -p etc/completion
 	go run gen-docs/main.go

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ git tag is pushed to the repo.
 * Tag - `git tag -a vX.X.X -m "<message goes here>"`
 * Push - `git push origin vX.X.X`
 
+With every release, a new Homebrew formula will be automatically updated on [meroxa/homebrew-taps](https://github.com/meroxa/homebrew-taps).
+
 ## Linting
 
 If you want to make sure everything's correct before pushing to GitHub, you'll need to install [`golangci-lint`](https://golangci-lint.run/) and run:
@@ -78,3 +80,9 @@ To run the test suite:
 ```
 make test
 ```
+
+## Shell Completion
+
+If you want to enable shell completion manually, you can generate your own using our `meroxa completion` command.
+
+Type `meroxa help completion` for more information, or simply take a look at our [documentation](docs/cmd/meroxa_completion.md).

--- a/cmd/add_resource.go
+++ b/cmd/add_resource.go
@@ -96,7 +96,7 @@ func (ar *AddResource) output(res *meroxa.Resource) {
 // AddResourceCmd represents the `meroxa add resource` command
 func (ar *AddResource) command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "resource <resource-name> --type <resource-type>",
+		Use:   "resource [NAME] --type TYPE",
 		Short: "Add a resource to your Meroxa resource catalog",
 		Long:  `Use the add command to add resources to your Meroxa resource catalog.`,
 		Example: "\n" +

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -14,7 +14,7 @@ import (
 // ApiCmd represents the `meroxa api` command
 func ApiCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "api <method> <path> [body]",
+		Use:   "api METHOD PATH [body]",
 		Short: "Invoke Meroxa API",
 		Args:  cobra.MinimumNArgs(2),
 		Example: `

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -126,5 +126,5 @@ func client() (*meroxa.Client, error) {
 		return nil, err
 	}
 
-	return meroxa.New(accessToken, versionString(), isDebugEnabled())
+	return meroxa.New(accessToken, VersionString(), isDebugEnabled())
 }

--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -73,7 +73,7 @@ func (conn *Connect) execute(ctx context.Context, c CreateConnectorClient) (*mer
 // command returns the cobra Command for `connect`
 func (conn *Connect) command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "connect --from <resource-name> --to <resource-name>",
+		Use:   "connect --from RESOURCE-NAME --to RESOURCE-NAME",
 		Short: "Connect two resources together",
 		Long: `Use the connect command to automatically configure the connectors required to pull data from one resource 
 (source) to another (destination).
@@ -81,7 +81,7 @@ func (conn *Connect) command() *cobra.Command {
 This command is equivalent to creating two connectors separately, one from the source to Meroxa and another from Meroxa 
 to the destination:
 
-meroxa connect --from <resource-name> --to <resource-name> --input <source-input>
+meroxa connect --from RESOURCE-NAME --to RESOURCE-NAME --input SOURCE-INPUT
 
 or
 

--- a/cmd/create_connector.go
+++ b/cmd/create_connector.go
@@ -38,7 +38,7 @@ type CreateConnector struct {
 
 func (cc *CreateConnector) setArgs(args []string) error {
 	if cc.source == "" && cc.destination == "" {
-		return errors.New("requires either a source (--from) or a destination (--to)\n\nUsage:\n  meroxa create connector <custom-connector-name> [--from | --to]")
+		return errors.New("requires either a source (--from) or a destination (--to)\n\nUsage:\n  meroxa create connector NAME [--from | --to]")
 	}
 
 	// If user specified an optional connector name
@@ -132,13 +132,13 @@ func (cc *CreateConnector) output(con *meroxa.Connector) {
 // command returns the cobra Command for `create connector`
 func (cc *CreateConnector) command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "connector [<custom-connector-name>] [flags]",
+		Use:   "connector [NAME] [flags]",
 		Short: "Create a connector",
 		Long:  "Use create connector to create a connector from a source (--from) or to a destination (--to)",
 		Example: "\n" +
-			"meroxa create connector [<custom-connector-name>] --from pg2kafka --input accounts \n" +
-			"meroxa create connector [<custom-connector-name>] --to pg2redshift --input orders # --input will be the desired stream \n" +
-			"meroxa create connector [<custom-connector-name>] --to pg2redshift --input orders --pipeline my-pipeline\n",
+			"meroxa create connector [NAME] --from pg2kafka --input accounts \n" +
+			"meroxa create connector [NAME] --to pg2redshift --input orders # --input will be the desired stream \n" +
+			"meroxa create connector [NAME] --to pg2redshift --input orders --pipeline my-pipeline\n",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return cc.setArgs(args)
 		},

--- a/cmd/create_endpoint.go
+++ b/cmd/create_endpoint.go
@@ -29,7 +29,7 @@ var (
 // CreateEndpointCmd represents the `meroxa create endpoint` command
 func CreateEndpointCmd() *cobra.Command {
 	createEndpointCmd := &cobra.Command{
-		Use:     "endpoint [<custom-endpoint-name>] [flags]",
+		Use:     "endpoint [NAME] [flags]",
 		Aliases: []string{"endpoints"},
 		Short:   "Create an endpoint",
 		Long:    "Use create endpoint to expose an endpoint to a connector stream",

--- a/cmd/create_pipeline.go
+++ b/cmd/create_pipeline.go
@@ -29,11 +29,11 @@ import (
 // CreatePipelineCmd represents the `meroxa create pipeline` command
 func CreatePipelineCmd() *cobra.Command {
 	createPipelineCmd := &cobra.Command{
-		Use:   "pipeline <name>",
+		Use:   "pipeline NAME",
 		Short: "Create a pipeline",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("requires a pipeline name\n\nUsage:\n  meroxa create pipeline <name> [flags]")
+				return errors.New("requires a pipeline name\n\nUsage:\n  meroxa create pipeline NAME [flags]")
 			}
 			pipelineName := args[0]
 

--- a/cmd/describe_connector.go
+++ b/cmd/describe_connector.go
@@ -31,7 +31,7 @@ func DescribeConnectorCmd() *cobra.Command {
 		Short: "Describe connector",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("requires connector name\n\nUsage:\n  meroxa describe connector <name> [flags]")
+				return errors.New("requires connector name\n\nUsage:\n  meroxa describe connector NAME [flags]")
 			}
 			var (
 				err  error

--- a/cmd/describe_endpoint.go
+++ b/cmd/describe_endpoint.go
@@ -27,12 +27,12 @@ import (
 // DescribeEndpointCmd represents the `meroxa describe endpoint` command
 func DescribeEndpointCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "endpoint <name>",
+		Use:     "endpoint NAME",
 		Aliases: []string{"endpoints"},
 		Short:   "Describe endpoint",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return fmt.Errorf("requires endpoint name\n\nUsage:\n  meroxa describe endpoint <name> [flags]")
+				return fmt.Errorf("requires endpoint name\n\nUsage:\n  meroxa describe endpoint NAME [flags]")
 			}
 			name := args[0]
 

--- a/cmd/describe_resource.go
+++ b/cmd/describe_resource.go
@@ -11,11 +11,11 @@ import (
 // DescribeResourceCmd represents the `meroxa describe resource` command
 func DescribeResourceCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "resource <name>",
+		Use:   "resource NAME",
 		Short: "Describe resource",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("requires resource name\n\nUsage:\n  meroxa describe resource <name> [flags]")
+				return errors.New("requires resource name\n\nUsage:\n  meroxa describe resource NAME [flags]")
 			}
 			name := args[0]
 

--- a/cmd/logs_connector.go
+++ b/cmd/logs_connector.go
@@ -28,11 +28,11 @@ import (
 // LogsConnectorCmd represents the `meroxa logs connector` command
 func LogsConnectorCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "connector <name>",
+		Use:   "connector NAME",
 		Short: "Print logs for a connector",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("requires connector name\n\nUsage:\n  meroxa logs connector <name>")
+				return errors.New("requires connector name\n\nUsage:\n  meroxa logs connector NAME")
 			}
 			connector := args[0]
 

--- a/cmd/remove_connector.go
+++ b/cmd/remove_connector.go
@@ -39,7 +39,7 @@ type RemoveConnectorClient interface {
 
 func (rc *RemoveConnector) setArgs(args []string) error {
 	if len(args) < 1 {
-		return errors.New("requires connector name\n\nUsage:\n  meroxa remove connector <name>")
+		return errors.New("requires connector name\n\nUsage:\n  meroxa remove connector NAME")
 	}
 	// Connector Name
 	rc.name = args[0]
@@ -70,7 +70,7 @@ func (rc *RemoveConnector) output(c *meroxa.Connector) {
 // command represents the `meroxa remove connector` command
 func (rc *RemoveConnector) command() *cobra.Command {
 	return &cobra.Command{
-		Use:   "connector <name>",
+		Use:   "connector NAME",
 		Short: "Remove connector",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return rc.setArgs(args)

--- a/cmd/remove_connector_test.go
+++ b/cmd/remove_connector_test.go
@@ -20,7 +20,7 @@ func TestRemoveConnectorArgs(t *testing.T) {
 		err  error
 		name string
 	}{
-		{nil, errors.New("requires connector name\n\nUsage:\n  meroxa remove connector <name>"), ""},
+		{nil, errors.New("requires connector name\n\nUsage:\n  meroxa remove connector NAME"), ""},
 		{[]string{"resName"}, nil, "resName"},
 	}
 

--- a/cmd/remove_endpoint.go
+++ b/cmd/remove_endpoint.go
@@ -35,7 +35,7 @@ type RemoveEndpointClient interface {
 
 func (re *RemoveEndpoint) setArgs(args []string) error {
 	if len(args) < 1 {
-		return errors.New("requires endpoint name\n\nUsage:\n  meroxa remove endpoint <name> [flags]")
+		return errors.New("requires endpoint name\n\nUsage:\n  meroxa remove endpoint NAME [flags]")
 	}
 	// endpoint name
 	re.name = args[0]
@@ -57,7 +57,7 @@ func (re *RemoveEndpoint) output() {
 // command represents the `meroxa remove endpoint` command
 func (re *RemoveEndpoint) command() *cobra.Command {
 	return &cobra.Command{
-		Use:     "endpoint <name>",
+		Use:     "endpoint NAME",
 		Aliases: []string{"endpoints"},
 		Short:   "Remove endpoint",
 		PreRunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/remove_endpoint_test.go
+++ b/cmd/remove_endpoint_test.go
@@ -17,7 +17,7 @@ func TestRemoveEndpointArgs(t *testing.T) {
 		err  error
 		name string
 	}{
-		{nil, errors.New("requires endpoint name\n\nUsage:\n  meroxa remove endpoint <name> [flags]"), ""},
+		{nil, errors.New("requires endpoint name\n\nUsage:\n  meroxa remove endpoint NAME [flags]"), ""},
 		{[]string{"endpoint-name"}, nil, "endpoint-name"},
 	}
 

--- a/cmd/remove_pipeline.go
+++ b/cmd/remove_pipeline.go
@@ -38,7 +38,7 @@ type RemovePipelineClient interface {
 
 func (rp *RemovePipeline) setArgs(args []string) error {
 	if len(args) < 1 {
-		return errors.New("requires pipeline name\n\nUsage:\n  meroxa remove pipeline <name>")
+		return errors.New("requires pipeline name\n\nUsage:\n  meroxa remove pipeline NAME")
 	}
 	// endpoint name
 	rp.name = args[0]
@@ -69,7 +69,7 @@ func (rp *RemovePipeline) output(p *meroxa.Pipeline) {
 // command represents the `meroxa remove pipeline` command
 func (rp *RemovePipeline) command() *cobra.Command {
 	return &cobra.Command{
-		Use:   "pipeline <name>",
+		Use:   "pipeline NAME",
 		Short: "Remove pipeline",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return rp.setArgs(args)

--- a/cmd/remove_pipeline_test.go
+++ b/cmd/remove_pipeline_test.go
@@ -20,7 +20,7 @@ func TestRemovePipelineArgs(t *testing.T) {
 		err  error
 		name string
 	}{
-		{nil, errors.New("requires pipeline name\n\nUsage:\n  meroxa remove pipeline <name>"), ""},
+		{nil, errors.New("requires pipeline name\n\nUsage:\n  meroxa remove pipeline NAME"), ""},
 		{[]string{"endpoint-name"}, nil, "endpoint-name"},
 	}
 

--- a/cmd/remove_resource.go
+++ b/cmd/remove_resource.go
@@ -38,7 +38,7 @@ type RemoveResourceClient interface {
 
 func (rr *RemoveResource) setArgs(args []string) error {
 	if len(args) < 1 {
-		return errors.New("requires resource name\n\nUsage:\n  meroxa remove resource <name>")
+		return errors.New("requires resource name\n\nUsage:\n  meroxa remove resource NAME")
 	}
 	// Resource Name
 	rr.name = args[0]
@@ -68,7 +68,7 @@ func (rr *RemoveResource) output(r *meroxa.Resource) {
 // command represents the `meroxa remove resource` command
 func (rr *RemoveResource) command() *cobra.Command {
 	return &cobra.Command{
-		Use:   "resource <name>",
+		Use:   "resource NAME",
 		Short: "Remove resource",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			return rr.setArgs(args)

--- a/cmd/remove_resource_test.go
+++ b/cmd/remove_resource_test.go
@@ -20,7 +20,7 @@ func TestRemoveResourceArgs(t *testing.T) {
 		err  error
 		name string
 	}{
-		{nil, errors.New("requires resource name\n\nUsage:\n  meroxa remove resource <name>"), ""},
+		{nil, errors.New("requires resource name\n\nUsage:\n  meroxa remove resource NAME"), ""},
 		{[]string{"resName"}, nil, "resName"},
 	}
 

--- a/cmd/update_connector.go
+++ b/cmd/update_connector.go
@@ -31,12 +31,12 @@ func UpdateConnectorCmd() *cobra.Command {
 	var state string
 
 	updateConnectorCmd := &cobra.Command{
-		Use:     "connector <name> --state <pause|resume|restart>",
+		Use:     "connector NAME --state pause | resume | restart",
 		Aliases: []string{"connectors"},
 		Short:   "Update connector state",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("requires connector name\n\nUsage:\n  meroxa update connector <name> --state <pause|resume|restart>")
+				return errors.New("requires connector name\n\nUsage:\n  meroxa update connector NAME --state pause | resume | restart")
 			}
 
 			return nil

--- a/cmd/update_pipeline.go
+++ b/cmd/update_pipeline.go
@@ -115,7 +115,7 @@ func (up *UpdatePipeline) output(p *meroxa.Pipeline) {
 // command represents the `meroxa update pipeline` command
 func (up *UpdatePipeline) command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "pipeline <name>",
+		Use:     "pipeline NAME",
 		Aliases: []string{"pipelines"},
 		Short:   "Update pipeline state",
 		Example: "\n" +

--- a/cmd/update_resource.go
+++ b/cmd/update_resource.go
@@ -37,7 +37,7 @@ var updateResourceCmd UpdateResource
 // UpdateResourceCmd represents the `meroxa update resource` command
 func (UpdateResource) command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "resource <resource-name>",
+		Use:     "resource NAME",
 		Short:   "Update a resource",
 		Long:    `Use the update command to update various Meroxa resources.`,
 		Aliases: []string{"resources"},
@@ -45,7 +45,7 @@ func (UpdateResource) command() *cobra.Command {
 		// meroxa update resource <old-resource-name> --name <new-resource-name>
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 || (updateResourceCmd.url == "" && updateResourceCmd.metadata == "" && updateResourceCmd.credentials == "") {
-				return errors.New("requires a resource name and either `--metadata`, `--url` or `--credentials` to update the resource \n\nUsage:\n  meroxa update resource <resource-name> [--url <url> | --metadata <metadata> | --credentials <credentials>]")
+				return errors.New("requires a resource name and either `--metadata`, `--url` or `--credentials` to update the resource \n\nUsage:\n  meroxa update resource NAME [--url URL | --metadata <metadata> | --credentials <credentials>]")
 			}
 
 			return nil

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -35,6 +35,6 @@ func VersionCmd() *cobra.Command {
 
 // Before changing this function, we'll need to update how the we're using the User-Agent when interacting with
 // Platform-API: https://git.io/JtXCG
-func versionString() string {
+func VersionString() string {
 	return fmt.Sprintf("Meroxa CLI %s", meroxaVersion)
 }

--- a/docs/cmd/meroxa_add_resource.md
+++ b/docs/cmd/meroxa_add_resource.md
@@ -7,7 +7,7 @@ Add a resource to your Meroxa resource catalog
 Use the add command to add resources to your Meroxa resource catalog.
 
 ```
-meroxa add resource <resource-name> --type <resource-type> [flags]
+meroxa add resource [NAME] --type TYPE [flags]
 ```
 
 ### Examples

--- a/docs/cmd/meroxa_api.md
+++ b/docs/cmd/meroxa_api.md
@@ -3,7 +3,7 @@
 Invoke Meroxa API
 
 ```
-meroxa api <method> <path> [body] [flags]
+meroxa api METHOD PATH [body] [flags]
 ```
 
 ### Examples

--- a/docs/cmd/meroxa_connect.md
+++ b/docs/cmd/meroxa_connect.md
@@ -10,7 +10,7 @@ Use the connect command to automatically configure the connectors required to pu
 This command is equivalent to creating two connectors separately, one from the source to Meroxa and another from Meroxa 
 to the destination:
 
-meroxa connect --from <resource-name> --to <resource-name> --input <source-input>
+meroxa connect --from RESOURCE-NAME --to RESOURCE-NAME --input SOURCE-INPUT
 
 or
 
@@ -19,7 +19,7 @@ meroxa create connector --to redshift --input orders # Creates destination conne
 
 
 ```
-meroxa connect --from <resource-name> --to <resource-name> [flags]
+meroxa connect --from RESOURCE-NAME --to RESOURCE-NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_create_connector.md
+++ b/docs/cmd/meroxa_create_connector.md
@@ -7,16 +7,16 @@ Create a connector
 Use create connector to create a connector from a source (--from) or to a destination (--to)
 
 ```
-meroxa create connector [<custom-connector-name>] [flags]
+meroxa create connector [NAME] [flags]
 ```
 
 ### Examples
 
 ```
 
-meroxa create connector [<custom-connector-name>] --from pg2kafka --input accounts 
-meroxa create connector [<custom-connector-name>] --to pg2redshift --input orders # --input will be the desired stream 
-meroxa create connector [<custom-connector-name>] --to pg2redshift --input orders --pipeline my-pipeline
+meroxa create connector [NAME] --from pg2kafka --input accounts 
+meroxa create connector [NAME] --to pg2redshift --input orders # --input will be the desired stream 
+meroxa create connector [NAME] --to pg2redshift --input orders --pipeline my-pipeline
 
 ```
 

--- a/docs/cmd/meroxa_create_endpoint.md
+++ b/docs/cmd/meroxa_create_endpoint.md
@@ -7,7 +7,7 @@ Create an endpoint
 Use create endpoint to expose an endpoint to a connector stream
 
 ```
-meroxa create endpoint [<custom-endpoint-name>] [flags]
+meroxa create endpoint [NAME] [flags]
 ```
 
 ### Examples

--- a/docs/cmd/meroxa_create_pipeline.md
+++ b/docs/cmd/meroxa_create_pipeline.md
@@ -3,7 +3,7 @@
 Create a pipeline
 
 ```
-meroxa create pipeline <name> [flags]
+meroxa create pipeline NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_describe_endpoint.md
+++ b/docs/cmd/meroxa_describe_endpoint.md
@@ -3,7 +3,7 @@
 Describe endpoint
 
 ```
-meroxa describe endpoint <name> [flags]
+meroxa describe endpoint NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_describe_resource.md
+++ b/docs/cmd/meroxa_describe_resource.md
@@ -3,7 +3,7 @@
 Describe resource
 
 ```
-meroxa describe resource <name> [flags]
+meroxa describe resource NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_logs_connector.md
+++ b/docs/cmd/meroxa_logs_connector.md
@@ -3,7 +3,7 @@
 Print logs for a connector
 
 ```
-meroxa logs connector <name> [flags]
+meroxa logs connector NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_remove_connector.md
+++ b/docs/cmd/meroxa_remove_connector.md
@@ -3,7 +3,7 @@
 Remove connector
 
 ```
-meroxa remove connector <name> [flags]
+meroxa remove connector NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_remove_endpoint.md
+++ b/docs/cmd/meroxa_remove_endpoint.md
@@ -3,7 +3,7 @@
 Remove endpoint
 
 ```
-meroxa remove endpoint <name> [flags]
+meroxa remove endpoint NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_remove_pipeline.md
+++ b/docs/cmd/meroxa_remove_pipeline.md
@@ -3,7 +3,7 @@
 Remove pipeline
 
 ```
-meroxa remove pipeline <name> [flags]
+meroxa remove pipeline NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_remove_resource.md
+++ b/docs/cmd/meroxa_remove_resource.md
@@ -3,7 +3,7 @@
 Remove resource
 
 ```
-meroxa remove resource <name> [flags]
+meroxa remove resource NAME [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_update_connector.md
+++ b/docs/cmd/meroxa_update_connector.md
@@ -3,7 +3,7 @@
 Update connector state
 
 ```
-meroxa update connector <name> --state <pause|resume|restart> [flags]
+meroxa update connector NAME --state pause | resume | restart [flags]
 ```
 
 ### Options

--- a/docs/cmd/meroxa_update_pipeline.md
+++ b/docs/cmd/meroxa_update_pipeline.md
@@ -3,7 +3,7 @@
 Update pipeline state
 
 ```
-meroxa update pipeline <name> [flags]
+meroxa update pipeline NAME [flags]
 ```
 
 ### Examples

--- a/docs/cmd/meroxa_update_resource.md
+++ b/docs/cmd/meroxa_update_resource.md
@@ -7,7 +7,7 @@ Update a resource
 Use the update command to update various Meroxa resources.
 
 ```
-meroxa update resource <resource-name> [flags]
+meroxa update resource NAME [flags]
 ```
 
 ### Options

--- a/etc/completion/meroxa.completion.fish
+++ b/etc/completion/meroxa.completion.fish
@@ -1,0 +1,164 @@
+# fish completion for meroxa                               -*- shell-script -*-
+
+function __meroxa_debug
+    set file "$BASH_COMP_DEBUG_FILE"
+    if test -n "$file"
+        echo "$argv" >> $file
+    end
+end
+
+function __meroxa_perform_completion
+    __meroxa_debug "Starting __meroxa_perform_completion with: $argv"
+
+    set args (string split -- " " "$argv")
+    set lastArg "$args[-1]"
+
+    __meroxa_debug "args: $args"
+    __meroxa_debug "last arg: $lastArg"
+
+    set emptyArg ""
+    if test -z "$lastArg"
+        __meroxa_debug "Setting emptyArg"
+        set emptyArg \"\"
+    end
+    __meroxa_debug "emptyArg: $emptyArg"
+
+    if not type -q "$args[1]"
+        # This can happen when "complete --do-complete meroxa" is called when running this script.
+        __meroxa_debug "Cannot find $args[1]. No completions."
+        return
+    end
+
+    set requestComp "$args[1] __complete $args[2..-1] $emptyArg"
+    __meroxa_debug "Calling $requestComp"
+
+    set results (eval $requestComp 2> /dev/null)
+    set comps $results[1..-2]
+    set directiveLine $results[-1]
+
+    # For Fish, when completing a flag with an = (e.g., <program> -n=<TAB>)
+    # completions must be prefixed with the flag
+    set flagPrefix (string match -r -- '-.*=' "$lastArg")
+
+    __meroxa_debug "Comps: $comps"
+    __meroxa_debug "DirectiveLine: $directiveLine"
+    __meroxa_debug "flagPrefix: $flagPrefix"
+
+    for comp in $comps
+        printf "%s%s\n" "$flagPrefix" "$comp"
+    end
+
+    printf "%s\n" "$directiveLine"
+end
+
+# This function does three things:
+# 1- Obtain the completions and store them in the global __meroxa_comp_results
+# 2- Set the __meroxa_comp_do_file_comp flag if file completion should be performed
+#    and unset it otherwise
+# 3- Return true if the completion results are not empty
+function __meroxa_prepare_completions
+    # Start fresh
+    set --erase __meroxa_comp_do_file_comp
+    set --erase __meroxa_comp_results
+
+    # Check if the command-line is already provided.  This is useful for testing.
+    if not set --query __meroxa_comp_commandLine
+        # Use the -c flag to allow for completion in the middle of the line
+        set __meroxa_comp_commandLine (commandline -c)
+    end
+    __meroxa_debug "commandLine is: $__meroxa_comp_commandLine"
+
+    set results (__meroxa_perform_completion "$__meroxa_comp_commandLine")
+    set --erase __meroxa_comp_commandLine
+    __meroxa_debug "Completion results: $results"
+
+    if test -z "$results"
+        __meroxa_debug "No completion, probably due to a failure"
+        # Might as well do file completion, in case it helps
+        set --global __meroxa_comp_do_file_comp 1
+        return 1
+    end
+
+    set directive (string sub --start 2 $results[-1])
+    set --global __meroxa_comp_results $results[1..-2]
+
+    __meroxa_debug "Completions are: $__meroxa_comp_results"
+    __meroxa_debug "Directive is: $directive"
+
+    set shellCompDirectiveError 1
+    set shellCompDirectiveNoSpace 2
+    set shellCompDirectiveNoFileComp 4
+    set shellCompDirectiveFilterFileExt 8
+    set shellCompDirectiveFilterDirs 16
+
+    if test -z "$directive"
+        set directive 0
+    end
+
+    set compErr (math (math --scale 0 $directive / $shellCompDirectiveError) % 2)
+    if test $compErr -eq 1
+        __meroxa_debug "Received error directive: aborting."
+        # Might as well do file completion, in case it helps
+        set --global __meroxa_comp_do_file_comp 1
+        return 1
+    end
+
+    set filefilter (math (math --scale 0 $directive / $shellCompDirectiveFilterFileExt) % 2)
+    set dirfilter (math (math --scale 0 $directive / $shellCompDirectiveFilterDirs) % 2)
+    if test $filefilter -eq 1; or test $dirfilter -eq 1
+        __meroxa_debug "File extension filtering or directory filtering not supported"
+        # Do full file completion instead
+        set --global __meroxa_comp_do_file_comp 1
+        return 1
+    end
+
+    set nospace (math (math --scale 0 $directive / $shellCompDirectiveNoSpace) % 2)
+    set nofiles (math (math --scale 0 $directive / $shellCompDirectiveNoFileComp) % 2)
+
+    __meroxa_debug "nospace: $nospace, nofiles: $nofiles"
+
+    # Important not to quote the variable for count to work
+    set numComps (count $__meroxa_comp_results)
+    __meroxa_debug "numComps: $numComps"
+
+    if test $numComps -eq 1; and test $nospace -ne 0
+        # To support the "nospace" directive we trick the shell
+        # by outputting an extra, longer completion.
+        __meroxa_debug "Adding second completion to perform nospace directive"
+        set --append __meroxa_comp_results $__meroxa_comp_results[1].
+    end
+
+    if test $numComps -eq 0; and test $nofiles -eq 0
+        __meroxa_debug "Requesting file completion"
+        set --global __meroxa_comp_do_file_comp 1
+    end
+
+    # If we don't want file completion, we must return true even if there
+    # are no completions found.  This is because fish will perform the last
+    # completion command, even if its condition is false, if no other
+    # completion command was triggered
+    return (not set --query __meroxa_comp_do_file_comp)
+end
+
+# Since Fish completions are only loaded once the user triggers them, we trigger them ourselves
+# so we can properly delete any completions provided by another script.
+# The space after the the program name is essential to trigger completion for the program
+# and not completion of the program name itself.
+complete --do-complete "meroxa " > /dev/null 2>&1
+# Using '> /dev/null 2>&1' since '&>' is not supported in older versions of fish.
+
+# Remove any pre-existing completions for the program since we will be handling all of them.
+complete -c meroxa -e
+
+# The order in which the below two lines are defined is very important so that __meroxa_prepare_completions
+# is called first.  It is __meroxa_prepare_completions that sets up the __meroxa_comp_do_file_comp variable.
+#
+# This completion will be run second as complete commands are added FILO.
+# It triggers file completion choices when __meroxa_comp_do_file_comp is set.
+complete -c meroxa -n 'set --query __meroxa_comp_do_file_comp'
+
+# This completion will be run first as complete commands are added FILO.
+# The call to __meroxa_prepare_completions will setup both __meroxa_comp_results and __meroxa_comp_do_file_comp.
+# It provides the program's completion choices.
+complete -c meroxa -n '__meroxa_prepare_completions' -f -a '$__meroxa_comp_results'
+

--- a/etc/completion/meroxa.completion.ps1
+++ b/etc/completion/meroxa.completion.ps1
@@ -1,0 +1,225 @@
+# powershell completion for meroxa                               -*- shell-script -*-
+
+function __meroxa_debug {
+    if ($env:BASH_COMP_DEBUG_FILE) {
+        "$args" | Out-File -Append -FilePath "$env:BASH_COMP_DEBUG_FILE"
+    }
+}
+
+filter __meroxa_escapeStringWithSpecialChars {
+    $_ -replace '\s|#|@|\$|;|,|''|\{|\}|\(|\)|"|`|\||<|>|&','`$&'
+}
+
+Register-ArgumentCompleter -CommandName 'meroxa' -ScriptBlock {
+    param(
+            $WordToComplete,
+            $CommandAst,
+            $CursorPosition
+        )
+
+    # Get the current command line and convert into a string
+    $Command = $CommandAst.CommandElements
+    $Command = "$Command"
+
+    __meroxa_debug ""
+    __meroxa_debug "========= starting completion logic =========="
+    __meroxa_debug "WordToComplete: $WordToComplete Command: $Command CursorPosition: $CursorPosition"
+
+    # The user could have moved the cursor backwards on the command-line.
+    # We need to trigger completion from the $CursorPosition location, so we need
+    # to truncate the command-line ($Command) up to the $CursorPosition location.
+    # Make sure the $Command is longer then the $CursorPosition before we truncate.
+    # This happens because the $Command does not include the last space.
+    if ($Command.Length -gt $CursorPosition) {
+        $Command=$Command.Substring(0,$CursorPosition)
+    }
+	__meroxa_debug "Truncated command: $Command"
+
+    $ShellCompDirectiveError=1
+    $ShellCompDirectiveNoSpace=2
+    $ShellCompDirectiveNoFileComp=4
+    $ShellCompDirectiveFilterFileExt=8
+    $ShellCompDirectiveFilterDirs=16
+
+	# Prepare the command to request completions for the program.
+    # Split the command at the first space to separate the program and arguments.
+    $Program,$Arguments = $Command.Split(" ",2)
+    $RequestComp="$Program __completeNoDesc $Arguments"
+    __meroxa_debug "RequestComp: $RequestComp"
+
+    # we cannot use $WordToComplete because it
+    # has the wrong values if the cursor was moved
+    # so use the last argument
+    if ($WordToComplete -ne "" ) {
+        $WordToComplete = $Arguments.Split(" ")[-1]
+    }
+    __meroxa_debug "New WordToComplete: $WordToComplete"
+
+
+    # Check for flag with equal sign
+    $IsEqualFlag = ($WordToComplete -Like "--*=*" )
+    if ( $IsEqualFlag ) {
+        __meroxa_debug "Completing equal sign flag"
+        # Remove the flag part
+        $Flag,$WordToComplete = $WordToComplete.Split("=",2)
+    }
+
+    if ( $WordToComplete -eq "" -And ( -Not $IsEqualFlag )) {
+        # If the last parameter is complete (there is a space following it)
+        # We add an extra empty parameter so we can indicate this to the go method.
+        __meroxa_debug "Adding extra empty parameter"
+        # We need to use `"`" to pass an empty argument a "" or '' does not work!!!
+        $RequestComp="$RequestComp" + ' `"`"' 
+    }
+
+    __meroxa_debug "Calling $RequestComp"
+    #call the command store the output in $out and redirect stderr and stdout to null
+    # $Out is an array contains each line per element
+    Invoke-Expression -OutVariable out "$RequestComp" 2>&1 | Out-Null
+
+
+    # get directive from last line
+    [int]$Directive = $Out[-1].TrimStart(':')
+    if ($Directive -eq "") {
+        # There is no directive specified
+        $Directive = 0
+    }
+    __meroxa_debug "The completion directive is: $Directive"
+
+    # remove directive (last element) from out
+    $Out = $Out | Where-Object { $_ -ne $Out[-1] }
+    __meroxa_debug "The completions are: $Out"
+
+    if (($Directive -band $ShellCompDirectiveError) -ne 0 ) {
+        # Error code.  No completion.
+        __meroxa_debug "Received error from custom completion go code"
+        return
+    }
+
+    $Longest = 0
+    $Values = $Out | ForEach-Object {
+        #Split the output in name and description
+        $Name, $Description = $_.Split("`t",2)
+        __meroxa_debug "Name: $Name Description: $Description"
+
+        # Look for the longest completion so that we can format things nicely
+        if ($Longest -lt $Name.Length) {
+            $Longest = $Name.Length
+        }
+
+        # Set the description to a one space string if there is none set.
+        # This is needed because the CompletionResult does not accept an empty string as argument
+        if (-Not $Description) {
+            $Description = " "
+        }
+        @{Name="$Name";Description="$Description"}
+    }
+
+
+    $Space = " "
+    if (($Directive -band $ShellCompDirectiveNoSpace) -ne 0 ) {
+        # remove the space here
+        __meroxa_debug "ShellCompDirectiveNoSpace is called"
+        $Space = ""
+    }
+
+    if (($Directive -band $ShellCompDirectiveNoFileComp) -ne 0 ) {
+        __meroxa_debug "ShellCompDirectiveNoFileComp is called"
+
+        if ($Values.Length -eq 0) {
+            # Just print an empty string here so the
+            # shell does not start to complete paths.
+            # We cannot use CompletionResult here because
+            # it does not accept an empty string as argument.
+            ""
+            return
+        }
+    }
+
+    if ((($Directive -band $ShellCompDirectiveFilterFileExt) -ne 0 ) -or
+       (($Directive -band $ShellCompDirectiveFilterDirs) -ne 0 ))  {
+        __meroxa_debug "ShellCompDirectiveFilterFileExt ShellCompDirectiveFilterDirs are not supported"
+
+        # return here to prevent the completion of the extensions
+        return
+    }
+
+    $Values = $Values | Where-Object {
+        # filter the result
+        $_.Name -like "$WordToComplete*"
+
+        # Join the flag back if we have a equal sign flag
+        if ( $IsEqualFlag ) {
+            __meroxa_debug "Join the equal sign flag back to the completion value"
+            $_.Name = $Flag + "=" + $_.Name
+        }
+    }
+
+    # Get the current mode
+    $Mode = (Get-PSReadLineKeyHandler | Where-Object {$_.Key -eq "Tab" }).Function
+    __meroxa_debug "Mode: $Mode"
+
+    $Values | ForEach-Object {
+
+        # store temporay because switch will overwrite $_
+        $comp = $_
+
+        # PowerShell supports three different completion modes
+        # - TabCompleteNext (default windows style - on each key press the next option is displayed)
+        # - Complete (works like bash)
+        # - MenuComplete (works like zsh)
+        # You set the mode with Set-PSReadLineKeyHandler -Key Tab -Function <mode>
+
+        # CompletionResult Arguments:
+        # 1) CompletionText text to be used as the auto completion result
+        # 2) ListItemText   text to be displayed in the suggestion list
+        # 3) ResultType     type of completion result
+        # 4) ToolTip        text for the tooltip with details about the object
+
+        switch ($Mode) {
+
+            # bash like
+            "Complete" {
+
+                if ($Values.Length -eq 1) {
+                    __meroxa_debug "Only one completion left"
+
+                    # insert space after value
+                    [System.Management.Automation.CompletionResult]::new($($comp.Name | __meroxa_escapeStringWithSpecialChars) + $Space, "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
+
+                } else {
+                    # Add the proper number of spaces to align the descriptions
+                    while($comp.Name.Length -lt $Longest) {
+                        $comp.Name = $comp.Name + " "
+                    }
+
+                    # Check for empty description and only add parentheses if needed
+                    if ($($comp.Description) -eq " " ) {
+                        $Description = ""
+                    } else {
+                        $Description = "  ($($comp.Description))"
+                    }
+
+                    [System.Management.Automation.CompletionResult]::new("$($comp.Name)$Description", "$($comp.Name)$Description", 'ParameterValue', "$($comp.Description)")
+                }
+             }
+
+            # zsh like
+            "MenuComplete" {
+                # insert space after value
+                # MenuComplete will automatically show the ToolTip of
+                # the highlighted value at the bottom of the suggestions.
+                [System.Management.Automation.CompletionResult]::new($($comp.Name | __meroxa_escapeStringWithSpecialChars) + $Space, "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
+            }
+
+            # TabCompleteNext and in case we get something unknown
+            Default {
+                # Like MenuComplete but we don't want to add a space here because
+                # the user need to press space anyway to get the completion.
+                # Description will not be shown because thats not possible with TabCompleteNext
+                [System.Management.Automation.CompletionResult]::new($($comp.Name | __meroxa_escapeStringWithSpecialChars), "$($comp.Name)", 'ParameterValue', "$($comp.Description)")
+            }
+        }
+
+    }
+}

--- a/etc/completion/meroxa.completion.sh
+++ b/etc/completion/meroxa.completion.sh
@@ -1,0 +1,1783 @@
+# bash completion for meroxa                               -*- shell-script -*-
+
+__meroxa_debug()
+{
+    if [[ -n ${BASH_COMP_DEBUG_FILE} ]]; then
+        echo "$*" >> "${BASH_COMP_DEBUG_FILE}"
+    fi
+}
+
+# Homebrew on Macs have version 1.3 of bash-completion which doesn't include
+# _init_completion. This is a very minimal version of that function.
+__meroxa_init_completion()
+{
+    COMPREPLY=()
+    _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+__meroxa_index_of_word()
+{
+    local w word=$1
+    shift
+    index=0
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+        index=$((index+1))
+    done
+    index=-1
+}
+
+__meroxa_contains_word()
+{
+    local w word=$1; shift
+    for w in "$@"; do
+        [[ $w = "$word" ]] && return
+    done
+    return 1
+}
+
+__meroxa_handle_go_custom_completion()
+{
+    __meroxa_debug "${FUNCNAME[0]}: cur is ${cur}, words[*] is ${words[*]}, #words[@] is ${#words[@]}"
+
+    local shellCompDirectiveError=1
+    local shellCompDirectiveNoSpace=2
+    local shellCompDirectiveNoFileComp=4
+    local shellCompDirectiveFilterFileExt=8
+    local shellCompDirectiveFilterDirs=16
+
+    local out requestComp lastParam lastChar comp directive args
+
+    # Prepare the command to request completions for the program.
+    # Calling ${words[0]} instead of directly meroxa allows to handle aliases
+    args=("${words[@]:1}")
+    requestComp="${words[0]} __completeNoDesc ${args[*]}"
+
+    lastParam=${words[$((${#words[@]}-1))]}
+    lastChar=${lastParam:$((${#lastParam}-1)):1}
+    __meroxa_debug "${FUNCNAME[0]}: lastParam ${lastParam}, lastChar ${lastChar}"
+
+    if [ -z "${cur}" ] && [ "${lastChar}" != "=" ]; then
+        # If the last parameter is complete (there is a space following it)
+        # We add an extra empty parameter so we can indicate this to the go method.
+        __meroxa_debug "${FUNCNAME[0]}: Adding extra empty parameter"
+        requestComp="${requestComp} \"\""
+    fi
+
+    __meroxa_debug "${FUNCNAME[0]}: calling ${requestComp}"
+    # Use eval to handle any environment variables and such
+    out=$(eval "${requestComp}" 2>/dev/null)
+
+    # Extract the directive integer at the very end of the output following a colon (:)
+    directive=${out##*:}
+    # Remove the directive
+    out=${out%:*}
+    if [ "${directive}" = "${out}" ]; then
+        # There is not directive specified
+        directive=0
+    fi
+    __meroxa_debug "${FUNCNAME[0]}: the completion directive is: ${directive}"
+    __meroxa_debug "${FUNCNAME[0]}: the completions are: ${out[*]}"
+
+    if [ $((directive & shellCompDirectiveError)) -ne 0 ]; then
+        # Error code.  No completion.
+        __meroxa_debug "${FUNCNAME[0]}: received error from custom completion go code"
+        return
+    else
+        if [ $((directive & shellCompDirectiveNoSpace)) -ne 0 ]; then
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                __meroxa_debug "${FUNCNAME[0]}: activating no space"
+                compopt -o nospace
+            fi
+        fi
+        if [ $((directive & shellCompDirectiveNoFileComp)) -ne 0 ]; then
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                __meroxa_debug "${FUNCNAME[0]}: activating no file completion"
+                compopt +o default
+            fi
+        fi
+    fi
+
+    if [ $((directive & shellCompDirectiveFilterFileExt)) -ne 0 ]; then
+        # File extension filtering
+        local fullFilter filter filteringCmd
+        # Do not use quotes around the $out variable or else newline
+        # characters will be kept.
+        for filter in ${out[*]}; do
+            fullFilter+="$filter|"
+        done
+
+        filteringCmd="_filedir $fullFilter"
+        __meroxa_debug "File filtering command: $filteringCmd"
+        $filteringCmd
+    elif [ $((directive & shellCompDirectiveFilterDirs)) -ne 0 ]; then
+        # File completion for directories only
+        local subDir
+        # Use printf to strip any trailing newline
+        subdir=$(printf "%s" "${out[0]}")
+        if [ -n "$subdir" ]; then
+            __meroxa_debug "Listing directories in $subdir"
+            __meroxa_handle_subdirs_in_dir_flag "$subdir"
+        else
+            __meroxa_debug "Listing directories in ."
+            _filedir -d
+        fi
+    else
+        while IFS='' read -r comp; do
+            COMPREPLY+=("$comp")
+        done < <(compgen -W "${out[*]}" -- "$cur")
+    fi
+}
+
+__meroxa_handle_reply()
+{
+    __meroxa_debug "${FUNCNAME[0]}"
+    local comp
+    case $cur in
+        -*)
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                compopt -o nospace
+            fi
+            local allflags
+            if [ ${#must_have_one_flag[@]} -ne 0 ]; then
+                allflags=("${must_have_one_flag[@]}")
+            else
+                allflags=("${flags[*]} ${two_word_flags[*]}")
+            fi
+            while IFS='' read -r comp; do
+                COMPREPLY+=("$comp")
+            done < <(compgen -W "${allflags[*]}" -- "$cur")
+            if [[ $(type -t compopt) = "builtin" ]]; then
+                [[ "${COMPREPLY[0]}" == *= ]] || compopt +o nospace
+            fi
+
+            # complete after --flag=abc
+            if [[ $cur == *=* ]]; then
+                if [[ $(type -t compopt) = "builtin" ]]; then
+                    compopt +o nospace
+                fi
+
+                local index flag
+                flag="${cur%=*}"
+                __meroxa_index_of_word "${flag}" "${flags_with_completion[@]}"
+                COMPREPLY=()
+                if [[ ${index} -ge 0 ]]; then
+                    PREFIX=""
+                    cur="${cur#*=}"
+                    ${flags_completion[${index}]}
+                    if [ -n "${ZSH_VERSION}" ]; then
+                        # zsh completion needs --flag= prefix
+                        eval "COMPREPLY=( \"\${COMPREPLY[@]/#/${flag}=}\" )"
+                    fi
+                fi
+            fi
+            return 0;
+            ;;
+    esac
+
+    # check if we are handling a flag with special work handling
+    local index
+    __meroxa_index_of_word "${prev}" "${flags_with_completion[@]}"
+    if [[ ${index} -ge 0 ]]; then
+        ${flags_completion[${index}]}
+        return
+    fi
+
+    # we are parsing a flag and don't have a special handler, no completion
+    if [[ ${cur} != "${words[cword]}" ]]; then
+        return
+    fi
+
+    local completions
+    completions=("${commands[@]}")
+    if [[ ${#must_have_one_noun[@]} -ne 0 ]]; then
+        completions+=("${must_have_one_noun[@]}")
+    elif [[ -n "${has_completion_function}" ]]; then
+        # if a go completion function is provided, defer to that function
+        __meroxa_handle_go_custom_completion
+    fi
+    if [[ ${#must_have_one_flag[@]} -ne 0 ]]; then
+        completions+=("${must_have_one_flag[@]}")
+    fi
+    while IFS='' read -r comp; do
+        COMPREPLY+=("$comp")
+    done < <(compgen -W "${completions[*]}" -- "$cur")
+
+    if [[ ${#COMPREPLY[@]} -eq 0 && ${#noun_aliases[@]} -gt 0 && ${#must_have_one_noun[@]} -ne 0 ]]; then
+        while IFS='' read -r comp; do
+            COMPREPLY+=("$comp")
+        done < <(compgen -W "${noun_aliases[*]}" -- "$cur")
+    fi
+
+    if [[ ${#COMPREPLY[@]} -eq 0 ]]; then
+		if declare -F __meroxa_custom_func >/dev/null; then
+			# try command name qualified custom func
+			__meroxa_custom_func
+		else
+			# otherwise fall back to unqualified for compatibility
+			declare -F __custom_func >/dev/null && __custom_func
+		fi
+    fi
+
+    # available in bash-completion >= 2, not always present on macOS
+    if declare -F __ltrim_colon_completions >/dev/null; then
+        __ltrim_colon_completions "$cur"
+    fi
+
+    # If there is only 1 completion and it is a flag with an = it will be completed
+    # but we don't want a space after the =
+    if [[ "${#COMPREPLY[@]}" -eq "1" ]] && [[ $(type -t compopt) = "builtin" ]] && [[ "${COMPREPLY[0]}" == --*= ]]; then
+       compopt -o nospace
+    fi
+}
+
+# The arguments should be in the form "ext1|ext2|extn"
+__meroxa_handle_filename_extension_flag()
+{
+    local ext="$1"
+    _filedir "@(${ext})"
+}
+
+__meroxa_handle_subdirs_in_dir_flag()
+{
+    local dir="$1"
+    pushd "${dir}" >/dev/null 2>&1 && _filedir -d && popd >/dev/null 2>&1 || return
+}
+
+__meroxa_handle_flag()
+{
+    __meroxa_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+
+    # if a command required a flag, and we found it, unset must_have_one_flag()
+    local flagname=${words[c]}
+    local flagvalue
+    # if the word contained an =
+    if [[ ${words[c]} == *"="* ]]; then
+        flagvalue=${flagname#*=} # take in as flagvalue after the =
+        flagname=${flagname%=*} # strip everything after the =
+        flagname="${flagname}=" # but put the = back
+    fi
+    __meroxa_debug "${FUNCNAME[0]}: looking for ${flagname}"
+    if __meroxa_contains_word "${flagname}" "${must_have_one_flag[@]}"; then
+        must_have_one_flag=()
+    fi
+
+    # if you set a flag which only applies to this command, don't show subcommands
+    if __meroxa_contains_word "${flagname}" "${local_nonpersistent_flags[@]}"; then
+      commands=()
+    fi
+
+    # keep flag value with flagname as flaghash
+    # flaghash variable is an associative array which is only supported in bash > 3.
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        if [ -n "${flagvalue}" ] ; then
+            flaghash[${flagname}]=${flagvalue}
+        elif [ -n "${words[ $((c+1)) ]}" ] ; then
+            flaghash[${flagname}]=${words[ $((c+1)) ]}
+        else
+            flaghash[${flagname}]="true" # pad "true" for bool flag
+        fi
+    fi
+
+    # skip the argument to a two word flag
+    if [[ ${words[c]} != *"="* ]] && __meroxa_contains_word "${words[c]}" "${two_word_flags[@]}"; then
+			  __meroxa_debug "${FUNCNAME[0]}: found a flag ${words[c]}, skip the next argument"
+        c=$((c+1))
+        # if we are looking for a flags value, don't show commands
+        if [[ $c -eq $cword ]]; then
+            commands=()
+        fi
+    fi
+
+    c=$((c+1))
+
+}
+
+__meroxa_handle_noun()
+{
+    __meroxa_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+
+    if __meroxa_contains_word "${words[c]}" "${must_have_one_noun[@]}"; then
+        must_have_one_noun=()
+    elif __meroxa_contains_word "${words[c]}" "${noun_aliases[@]}"; then
+        must_have_one_noun=()
+    fi
+
+    nouns+=("${words[c]}")
+    c=$((c+1))
+}
+
+__meroxa_handle_command()
+{
+    __meroxa_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+
+    local next_command
+    if [[ -n ${last_command} ]]; then
+        next_command="_${last_command}_${words[c]//:/__}"
+    else
+        if [[ $c -eq 0 ]]; then
+            next_command="_meroxa_root_command"
+        else
+            next_command="_${words[c]//:/__}"
+        fi
+    fi
+    c=$((c+1))
+    __meroxa_debug "${FUNCNAME[0]}: looking for ${next_command}"
+    declare -F "$next_command" >/dev/null && $next_command
+}
+
+__meroxa_handle_word()
+{
+    if [[ $c -ge $cword ]]; then
+        __meroxa_handle_reply
+        return
+    fi
+    __meroxa_debug "${FUNCNAME[0]}: c is $c words[c] is ${words[c]}"
+    if [[ "${words[c]}" == -* ]]; then
+        __meroxa_handle_flag
+    elif __meroxa_contains_word "${words[c]}" "${commands[@]}"; then
+        __meroxa_handle_command
+    elif [[ $c -eq 0 ]]; then
+        __meroxa_handle_command
+    elif __meroxa_contains_word "${words[c]}" "${command_aliases[@]}"; then
+        # aliashash variable is an associative array which is only supported in bash > 3.
+        if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+            words[c]=${aliashash[${words[c]}]}
+            __meroxa_handle_command
+        else
+            __meroxa_handle_noun
+        fi
+    else
+        __meroxa_handle_noun
+    fi
+    __meroxa_handle_word
+}
+
+_meroxa_add_help()
+{
+    last_command="meroxa_add_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_add_resource()
+{
+    last_command="meroxa_add_resource"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--credentials=")
+    two_word_flags+=("--credentials")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--metadata=")
+    two_word_flags+=("--metadata")
+    two_word_flags+=("-m")
+    flags+=("--type=")
+    two_word_flags+=("--type")
+    flags+=("--url=")
+    two_word_flags+=("--url")
+    two_word_flags+=("-u")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--type=")
+    must_have_one_flag+=("--url=")
+    must_have_one_flag+=("-u")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_add()
+{
+    last_command="meroxa_add"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("help")
+    commands+=("resource")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_api()
+{
+    last_command="meroxa_api"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_billing()
+{
+    last_command="meroxa_billing"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_completion()
+{
+    last_command="meroxa_completion"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    must_have_one_noun+=("bash")
+    must_have_one_noun+=("fish")
+    must_have_one_noun+=("powershell")
+    must_have_one_noun+=("zsh")
+    noun_aliases=()
+}
+
+_meroxa_connect()
+{
+    last_command="meroxa_connect"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--from=")
+    two_word_flags+=("--from")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--input=")
+    two_word_flags+=("--input")
+    flags+=("--pipeline=")
+    two_word_flags+=("--pipeline")
+    flags+=("--to=")
+    two_word_flags+=("--to")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--from=")
+    must_have_one_flag+=("--to=")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_create_connector()
+{
+    last_command="meroxa_create_connector"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--from=")
+    two_word_flags+=("--from")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--input=")
+    two_word_flags+=("--input")
+    flags+=("--pipeline=")
+    two_word_flags+=("--pipeline")
+    flags+=("--to=")
+    two_word_flags+=("--to")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--input=")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_create_endpoint()
+{
+    last_command="meroxa_create_endpoint"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--protocol=")
+    two_word_flags+=("--protocol")
+    two_word_flags+=("-p")
+    flags+=("--stream=")
+    two_word_flags+=("--stream")
+    two_word_flags+=("-s")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--protocol=")
+    must_have_one_flag+=("-p")
+    must_have_one_flag+=("--stream=")
+    must_have_one_flag+=("-s")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_create_help()
+{
+    last_command="meroxa_create_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_create_pipeline()
+{
+    last_command="meroxa_create_pipeline"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--metadata=")
+    two_word_flags+=("--metadata")
+    two_word_flags+=("-m")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_create()
+{
+    last_command="meroxa_create"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("connector")
+    commands+=("endpoint")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("endpoints")
+        aliashash["endpoints"]="endpoint"
+    fi
+    commands+=("help")
+    commands+=("pipeline")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_describe_connector()
+{
+    last_command="meroxa_describe_connector"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_describe_endpoint()
+{
+    last_command="meroxa_describe_endpoint"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_describe_help()
+{
+    last_command="meroxa_describe_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_describe_resource()
+{
+    last_command="meroxa_describe_resource"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_describe()
+{
+    last_command="meroxa_describe"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("connector")
+    commands+=("endpoint")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("endpoints")
+        aliashash["endpoints"]="endpoint"
+    fi
+    commands+=("help")
+    commands+=("resource")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_help()
+{
+    last_command="meroxa_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_list_connectors()
+{
+    last_command="meroxa_list_connectors"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--pipeline=")
+    two_word_flags+=("--pipeline")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_list_endpoint()
+{
+    last_command="meroxa_list_endpoint"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_list_help()
+{
+    last_command="meroxa_list_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_list_pipelines()
+{
+    last_command="meroxa_list_pipelines"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_list_resource-types()
+{
+    last_command="meroxa_list_resource-types"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_list_resources()
+{
+    last_command="meroxa_list_resources"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_list_transforms()
+{
+    last_command="meroxa_list_transforms"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_list()
+{
+    last_command="meroxa_list"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("connectors")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("connector")
+        aliashash["connector"]="connectors"
+    fi
+    commands+=("endpoint")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("endpoints")
+        aliashash["endpoints"]="endpoint"
+    fi
+    commands+=("help")
+    commands+=("pipelines")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("pipeline")
+        aliashash["pipeline"]="pipelines"
+    fi
+    commands+=("resource-types")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("resource-type")
+        aliashash["resource-type"]="resource-types"
+    fi
+    commands+=("resources")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("resource")
+        aliashash["resource"]="resources"
+    fi
+    commands+=("transforms")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("transform")
+        aliashash["transform"]="transforms"
+    fi
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_login()
+{
+    last_command="meroxa_login"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_logout()
+{
+    last_command="meroxa_logout"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_logs_connector()
+{
+    last_command="meroxa_logs_connector"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_logs_help()
+{
+    last_command="meroxa_logs_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_logs()
+{
+    last_command="meroxa_logs"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("connector")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_open_billing()
+{
+    last_command="meroxa_open_billing"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_open_help()
+{
+    last_command="meroxa_open_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_open()
+{
+    last_command="meroxa_open"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("billing")
+    commands+=("help")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_remove_connector()
+{
+    last_command="meroxa_remove_connector"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--force")
+    flags+=("-f")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_remove_endpoint()
+{
+    last_command="meroxa_remove_endpoint"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--force")
+    flags+=("-f")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_remove_help()
+{
+    last_command="meroxa_remove_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--force")
+    flags+=("-f")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_remove_pipeline()
+{
+    last_command="meroxa_remove_pipeline"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--force")
+    flags+=("-f")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_remove_resource()
+{
+    last_command="meroxa_remove_resource"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--force")
+    flags+=("-f")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_remove()
+{
+    last_command="meroxa_remove"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("connector")
+    commands+=("endpoint")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("endpoints")
+        aliashash["endpoints"]="endpoint"
+    fi
+    commands+=("help")
+    commands+=("pipeline")
+    commands+=("resource")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--force")
+    flags+=("-f")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_update_connector()
+{
+    last_command="meroxa_update_connector"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--state=")
+    two_word_flags+=("--state")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_flag+=("--state=")
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_update_help()
+{
+    last_command="meroxa_update_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_update_pipeline()
+{
+    last_command="meroxa_update_pipeline"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--metadata=")
+    two_word_flags+=("--metadata")
+    two_word_flags+=("-m")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    flags+=("--state=")
+    two_word_flags+=("--state")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_update_resource()
+{
+    last_command="meroxa_update_resource"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--credentials=")
+    two_word_flags+=("--credentials")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--metadata=")
+    two_word_flags+=("--metadata")
+    two_word_flags+=("-m")
+    flags+=("--url=")
+    two_word_flags+=("--url")
+    two_word_flags+=("-u")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_update()
+{
+    last_command="meroxa_update"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("connector")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("connectors")
+        aliashash["connectors"]="connector"
+    fi
+    commands+=("help")
+    commands+=("pipeline")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("pipelines")
+        aliashash["pipelines"]="pipeline"
+    fi
+    commands+=("resource")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("resources")
+        aliashash["resources"]="resource"
+    fi
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_version()
+{
+    last_command="meroxa_version"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_root_command()
+{
+    last_command="meroxa"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("add")
+    commands+=("api")
+    commands+=("billing")
+    commands+=("completion")
+    commands+=("connect")
+    commands+=("create")
+    commands+=("describe")
+    commands+=("help")
+    commands+=("list")
+    commands+=("login")
+    commands+=("logout")
+    commands+=("logs")
+    commands+=("open")
+    commands+=("remove")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("delete")
+        aliashash["delete"]="remove"
+        command_aliases+=("rm")
+        aliashash["rm"]="remove"
+    fi
+    commands+=("update")
+    commands+=("version")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    flags+=("--debug")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--json")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+__start_meroxa()
+{
+    local cur prev words cword
+    declare -A flaghash 2>/dev/null || :
+    declare -A aliashash 2>/dev/null || :
+    if declare -F _init_completion >/dev/null 2>&1; then
+        _init_completion -s || return
+    else
+        __meroxa_init_completion -n "=" || return
+    fi
+
+    local c=0
+    local flags=()
+    local two_word_flags=()
+    local local_nonpersistent_flags=()
+    local flags_with_completion=()
+    local flags_completion=()
+    local commands=("meroxa")
+    local must_have_one_flag=()
+    local must_have_one_noun=()
+    local has_completion_function
+    local last_command
+    local nouns=()
+
+    __meroxa_handle_word
+}
+
+if [[ $(type -t compopt) = "builtin" ]]; then
+    complete -o default -F __start_meroxa meroxa
+else
+    complete -o default -o nospace -F __start_meroxa meroxa
+fi
+
+# ex: ts=4 sw=4 et filetype=sh

--- a/etc/completion/meroxa.completion.zsh
+++ b/etc/completion/meroxa.completion.zsh
@@ -1,0 +1,159 @@
+#compdef _meroxa meroxa
+
+# zsh completion for meroxa                               -*- shell-script -*-
+
+__meroxa_debug()
+{
+    local file="$BASH_COMP_DEBUG_FILE"
+    if [[ -n ${file} ]]; then
+        echo "$*" >> "${file}"
+    fi
+}
+
+_meroxa()
+{
+    local shellCompDirectiveError=1
+    local shellCompDirectiveNoSpace=2
+    local shellCompDirectiveNoFileComp=4
+    local shellCompDirectiveFilterFileExt=8
+    local shellCompDirectiveFilterDirs=16
+
+    local lastParam lastChar flagPrefix requestComp out directive compCount comp lastComp
+    local -a completions
+
+    __meroxa_debug "\n========= starting completion logic =========="
+    __meroxa_debug "CURRENT: ${CURRENT}, words[*]: ${words[*]}"
+
+    # The user could have moved the cursor backwards on the command-line.
+    # We need to trigger completion from the $CURRENT location, so we need
+    # to truncate the command-line ($words) up to the $CURRENT location.
+    # (We cannot use $CURSOR as its value does not work when a command is an alias.)
+    words=("${=words[1,CURRENT]}")
+    __meroxa_debug "Truncated words[*]: ${words[*]},"
+
+    lastParam=${words[-1]}
+    lastChar=${lastParam[-1]}
+    __meroxa_debug "lastParam: ${lastParam}, lastChar: ${lastChar}"
+
+    # For zsh, when completing a flag with an = (e.g., meroxa -n=<TAB>)
+    # completions must be prefixed with the flag
+    setopt local_options BASH_REMATCH
+    if [[ "${lastParam}" =~ '-.*=' ]]; then
+        # We are dealing with a flag with an =
+        flagPrefix="-P ${BASH_REMATCH}"
+    fi
+
+    # Prepare the command to obtain completions
+    requestComp="${words[1]} __complete ${words[2,-1]}"
+    if [ "${lastChar}" = "" ]; then
+        # If the last parameter is complete (there is a space following it)
+        # We add an extra empty parameter so we can indicate this to the go completion code.
+        __meroxa_debug "Adding extra empty parameter"
+        requestComp="${requestComp} \"\""
+    fi
+
+    __meroxa_debug "About to call: eval ${requestComp}"
+
+    # Use eval to handle any environment variables and such
+    out=$(eval ${requestComp} 2>/dev/null)
+    __meroxa_debug "completion output: ${out}"
+
+    # Extract the directive integer following a : from the last line
+    local lastLine
+    while IFS='\n' read -r line; do
+        lastLine=${line}
+    done < <(printf "%s\n" "${out[@]}")
+    __meroxa_debug "last line: ${lastLine}"
+
+    if [ "${lastLine[1]}" = : ]; then
+        directive=${lastLine[2,-1]}
+        # Remove the directive including the : and the newline
+        local suffix
+        (( suffix=${#lastLine}+2))
+        out=${out[1,-$suffix]}
+    else
+        # There is no directive specified.  Leave $out as is.
+        __meroxa_debug "No directive found.  Setting do default"
+        directive=0
+    fi
+
+    __meroxa_debug "directive: ${directive}"
+    __meroxa_debug "completions: ${out}"
+    __meroxa_debug "flagPrefix: ${flagPrefix}"
+
+    if [ $((directive & shellCompDirectiveError)) -ne 0 ]; then
+        __meroxa_debug "Completion received error. Ignoring completions."
+        return
+    fi
+
+    compCount=0
+    while IFS='\n' read -r comp; do
+        if [ -n "$comp" ]; then
+            # If requested, completions are returned with a description.
+            # The description is preceded by a TAB character.
+            # For zsh's _describe, we need to use a : instead of a TAB.
+            # We first need to escape any : as part of the completion itself.
+            comp=${comp//:/\\:}
+
+            local tab=$(printf '\t')
+            comp=${comp//$tab/:}
+
+            ((compCount++))
+            __meroxa_debug "Adding completion: ${comp}"
+            completions+=${comp}
+            lastComp=$comp
+        fi
+    done < <(printf "%s\n" "${out[@]}")
+
+    if [ $((directive & shellCompDirectiveFilterFileExt)) -ne 0 ]; then
+        # File extension filtering
+        local filteringCmd
+        filteringCmd='_files'
+        for filter in ${completions[@]}; do
+            if [ ${filter[1]} != '*' ]; then
+                # zsh requires a glob pattern to do file filtering
+                filter="\*.$filter"
+            fi
+            filteringCmd+=" -g $filter"
+        done
+        filteringCmd+=" ${flagPrefix}"
+
+        __meroxa_debug "File filtering command: $filteringCmd"
+        _arguments '*:filename:'"$filteringCmd"
+    elif [ $((directive & shellCompDirectiveFilterDirs)) -ne 0 ]; then
+        # File completion for directories only
+        local subDir
+        subdir="${completions[1]}"
+        if [ -n "$subdir" ]; then
+            __meroxa_debug "Listing directories in $subdir"
+            pushd "${subdir}" >/dev/null 2>&1
+        else
+            __meroxa_debug "Listing directories in ."
+        fi
+
+        _arguments '*:dirname:_files -/'" ${flagPrefix}"
+        if [ -n "$subdir" ]; then
+            popd >/dev/null 2>&1
+        fi
+    elif [ $((directive & shellCompDirectiveNoSpace)) -ne 0 ] && [ ${compCount} -eq 1 ]; then
+        __meroxa_debug "Activating nospace."
+        # We can use compadd here as there is no description when
+        # there is only one completion.
+        compadd -S '' "${lastComp}"
+    elif [ ${compCount} -eq 0 ]; then
+        if [ $((directive & shellCompDirectiveNoFileComp)) -ne 0 ]; then
+            __meroxa_debug "deactivating file completion"
+        else
+            # Perform file completion
+            __meroxa_debug "activating file completion"
+            _arguments '*:filename:_files'" ${flagPrefix}"
+        fi
+    else
+        _describe "completions" completions $(echo $flagPrefix)
+    fi
+}
+
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_meroxa" ]; then
+	_meroxa
+fi

--- a/etc/man/man1/meroxa-add-resource.1
+++ b/etc/man/man1/meroxa-add-resource.1
@@ -1,0 +1,73 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-add\-resource \- Add a resource to your Meroxa resource catalog
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa add resource [NAME] \-\-type TYPE [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Use the add command to add resources to your Meroxa resource catalog.
+
+
+.SH OPTIONS
+.PP
+\fB\-\-credentials\fP=""
+	resource credentials
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for resource
+
+.PP
+\fB\-m\fP, \fB\-\-metadata\fP=""
+	resource metadata
+
+.PP
+\fB\-\-type\fP=""
+	resource type
+
+.PP
+\fB\-u\fP, \fB\-\-url\fP=""
+	resource url
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+
+meroxa add resource store \-\-type postgres \-u $DATABASE\_URL
+meroxa add resource datalake \-\-type s3 \-u "s3://$AWS\_ACCESS\_KEY\_ID:$AWS\_ACCESS\_KEY\_SECRET@us\-east\-1/meroxa\-demos"
+meroxa add resource warehouse \-\-type redshift \-u $REDSHIFT\_URL
+meroxa add resource slack \-\-type url \-u $WEBHOOK\_URL
+
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-add(1)\fP

--- a/etc/man/man1/meroxa-add.1
+++ b/etc/man/man1/meroxa-add.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-add \- Add a resource to your Meroxa resource catalog
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa add [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Add a resource to your Meroxa resource catalog
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for add
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP, \fBmeroxa\-add\-resource(1)\fP

--- a/etc/man/man1/meroxa-api.1
+++ b/etc/man/man1/meroxa-api.1
@@ -1,0 +1,54 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-api \- Invoke Meroxa API
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa api METHOD PATH [body] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Invoke Meroxa API
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for api
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+
+meroxa api GET /v1/endpoints
+meroxa api POST /v1/endpoints '{"protocol": "HTTP", "stream": "resource\-2\-499379\-public.accounts", "name": "1234"}'
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP

--- a/etc/man/man1/meroxa-billing.1
+++ b/etc/man/man1/meroxa-billing.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-billing \- Open your billing page in a web browser
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa billing [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Open your billing page in a web browser
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for billing
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP

--- a/etc/man/man1/meroxa-completion.1
+++ b/etc/man/man1/meroxa-completion.1
@@ -1,0 +1,77 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-completion \- Generate completion script
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa completion [bash|zsh|fish|powershell]\fP
+
+
+.SH DESCRIPTION
+.PP
+To load completions:
+
+.PP
+.RS
+
+.nf
+Bash:
+
+$ source <(meroxa completion bash)
+
+# To load completions for each session, execute once:
+Linux:
+  $ meroxa completion bash > /etc/bash\_completion.d/meroxa
+MacOS:
+  $ meroxa completion bash > /usr/local/etc/bash\_completion.d/meroxa
+
+Zsh:
+
+# If shell completion is not already enabled in your environment you will need
+# to enable it.  You can execute the following once:
+
+$ echo "autoload \-U compinit; compinit" >> \~/.zshrc
+
+# To load completions for each session, execute once:
+$ meroxa completion zsh > "${fpath[1]}/\_meroxa"
+
+# You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+$ meroxa completion fish | source
+
+# To load completions for each session, execute once:
+$ meroxa completion fish > \~/.config/fish/completions/meroxa.fish
+
+.fi
+.RE
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for completion
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP

--- a/etc/man/man1/meroxa-connect.1
+++ b/etc/man/man1/meroxa-connect.1
@@ -1,0 +1,72 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-connect \- Connect two resources together
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa connect \-\-from RESOURCE\-NAME \-\-to RESOURCE\-NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Use the connect command to automatically configure the connectors required to pull data from one resource
+(source) to another (destination).
+
+.PP
+This command is equivalent to creating two connectors separately, one from the source to Meroxa and another from Meroxa
+to the destination:
+
+.PP
+meroxa connect \-\-from RESOURCE\-NAME \-\-to RESOURCE\-NAME \-\-input SOURCE\-INPUT
+
+.PP
+or
+
+.PP
+meroxa create connector \-\-from postgres \-\-input accounts # Creates source connector
+meroxa create connector \-\-to redshift \-\-input orders # Creates destination connector
+
+
+.SH OPTIONS
+.PP
+\fB\-\-from\fP=""
+	source resource name
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for connect
+
+.PP
+\fB\-\-input\fP=""
+	command delimeted list of input streams
+
+.PP
+\fB\-\-pipeline\fP=""
+	pipeline name to attach connectors to
+
+.PP
+\fB\-\-to\fP=""
+	destination resource name
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP

--- a/etc/man/man1/meroxa-create-connector.1
+++ b/etc/man/man1/meroxa-create-connector.1
@@ -1,0 +1,72 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-create\-connector \- Create a connector
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa create connector [NAME] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Use create connector to create a connector from a source (\-\-from) or to a destination (\-\-to)
+
+
+.SH OPTIONS
+.PP
+\fB\-\-from\fP=""
+	resource name to use as source
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for connector
+
+.PP
+\fB\-\-input\fP=""
+	command delimited list of input streams
+
+.PP
+\fB\-\-pipeline\fP=""
+	pipeline name to attach connector to
+
+.PP
+\fB\-\-to\fP=""
+	resource name to use as destination
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+
+meroxa create connector [NAME] \-\-from pg2kafka \-\-input accounts 
+meroxa create connector [NAME] \-\-to pg2redshift \-\-input orders # \-\-input will be the desired stream 
+meroxa create connector [NAME] \-\-to pg2redshift \-\-input orders \-\-pipeline my\-pipeline
+
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-create(1)\fP

--- a/etc/man/man1/meroxa-create-endpoint.1
+++ b/etc/man/man1/meroxa-create-endpoint.1
@@ -1,0 +1,61 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-create\-endpoint \- Create an endpoint
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa create endpoint [NAME] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Use create endpoint to expose an endpoint to a connector stream
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for endpoint
+
+.PP
+\fB\-p\fP, \fB\-\-protocol\fP=""
+	protocol, value can be http or grpc (required)
+
+.PP
+\fB\-s\fP, \fB\-\-stream\fP=""
+	stream name (required)
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+
+meroxa create endpoint my\-endpoint \-\-protocol http \-\-stream my\-stream
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-create(1)\fP

--- a/etc/man/man1/meroxa-create-pipeline.1
+++ b/etc/man/man1/meroxa-create-pipeline.1
@@ -1,0 +1,45 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-create\-pipeline \- Create a pipeline
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa create pipeline NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Create a pipeline
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for pipeline
+
+.PP
+\fB\-m\fP, \fB\-\-metadata\fP=""
+	pipeline metadata
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-create(1)\fP

--- a/etc/man/man1/meroxa-create.1
+++ b/etc/man/man1/meroxa-create.1
@@ -1,0 +1,42 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-create \- Create Meroxa pipeline components
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa create [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Use the create command to create various Meroxa pipeline components
+including connectors.
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for create
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP, \fBmeroxa\-create\-connector(1)\fP, \fBmeroxa\-create\-endpoint(1)\fP, \fBmeroxa\-create\-pipeline(1)\fP

--- a/etc/man/man1/meroxa-describe-connector.1
+++ b/etc/man/man1/meroxa-describe-connector.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-describe\-connector \- Describe connector
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa describe connector [name] [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Describe connector
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for connector
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-describe(1)\fP

--- a/etc/man/man1/meroxa-describe-endpoint.1
+++ b/etc/man/man1/meroxa-describe-endpoint.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-describe\-endpoint \- Describe endpoint
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa describe endpoint NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Describe endpoint
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for endpoint
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-describe(1)\fP

--- a/etc/man/man1/meroxa-describe-resource.1
+++ b/etc/man/man1/meroxa-describe-resource.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-describe\-resource \- Describe resource
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa describe resource NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Describe resource
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for resource
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-describe(1)\fP

--- a/etc/man/man1/meroxa-describe.1
+++ b/etc/man/man1/meroxa-describe.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-describe \- Describe a component
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa describe [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Describe a component of the Meroxa data platform, including resources and connectors
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for describe
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP, \fBmeroxa\-describe\-connector(1)\fP, \fBmeroxa\-describe\-endpoint(1)\fP, \fBmeroxa\-describe\-resource(1)\fP

--- a/etc/man/man1/meroxa-list-connectors.1
+++ b/etc/man/man1/meroxa-list-connectors.1
@@ -1,0 +1,45 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-list\-connectors \- List connectors
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa list connectors [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+List connectors
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for connectors
+
+.PP
+\fB\-\-pipeline\fP=""
+	filter connectors by pipeline name
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-list(1)\fP

--- a/etc/man/man1/meroxa-list-endpoint.1
+++ b/etc/man/man1/meroxa-list-endpoint.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-list\-endpoint \- List endpoints
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa list endpoint [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+List endpoints
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for endpoint
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-list(1)\fP

--- a/etc/man/man1/meroxa-list-pipelines.1
+++ b/etc/man/man1/meroxa-list-pipelines.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-list\-pipelines \- List pipelines
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa list pipelines [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+List pipelines
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for pipelines
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-list(1)\fP

--- a/etc/man/man1/meroxa-list-resource-types.1
+++ b/etc/man/man1/meroxa-list-resource-types.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-list\-resource\-types \- List resource\-types
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa list resource\-types [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+List resource\-types
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for resource\-types
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-list(1)\fP

--- a/etc/man/man1/meroxa-list-resources.1
+++ b/etc/man/man1/meroxa-list-resources.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-list\-resources \- List resources
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa list resources [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+List resources
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for resources
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-list(1)\fP

--- a/etc/man/man1/meroxa-list-transforms.1
+++ b/etc/man/man1/meroxa-list-transforms.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-list\-transforms \- List transforms
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa list transforms [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+List transforms
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for transforms
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-list(1)\fP

--- a/etc/man/man1/meroxa-list.1
+++ b/etc/man/man1/meroxa-list.1
@@ -1,0 +1,42 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-list \- List components
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa list [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+List the components of the Meroxa platform, including pipelines,
+ resources, connectors, etc... You may also filter by type.
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for list
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP, \fBmeroxa\-list\-connectors(1)\fP, \fBmeroxa\-list\-endpoint(1)\fP, \fBmeroxa\-list\-pipelines(1)\fP, \fBmeroxa\-list\-resource\-types(1)\fP, \fBmeroxa\-list\-resources(1)\fP, \fBmeroxa\-list\-transforms(1)\fP

--- a/etc/man/man1/meroxa-login.1
+++ b/etc/man/man1/meroxa-login.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-login \- login or sign up to the Meroxa platform
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa login [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+login or sign up to the Meroxa platform
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for login
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP

--- a/etc/man/man1/meroxa-logout.1
+++ b/etc/man/man1/meroxa-logout.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-logout \- logout of the Meroxa platform
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa logout [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+logout of the Meroxa platform
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for logout
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP

--- a/etc/man/man1/meroxa-logs-connector.1
+++ b/etc/man/man1/meroxa-logs-connector.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-logs\-connector \- Print logs for a connector
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa logs connector NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Print logs for a connector
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for connector
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-logs(1)\fP

--- a/etc/man/man1/meroxa-logs.1
+++ b/etc/man/man1/meroxa-logs.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-logs \- Print logs for a component
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa logs [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Print logs for a component
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for logs
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP, \fBmeroxa\-logs\-connector(1)\fP

--- a/etc/man/man1/meroxa-open-billing.1
+++ b/etc/man/man1/meroxa-open-billing.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-open\-billing \- Open your billing page in a web browser
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa open billing [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Open your billing page in a web browser
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for billing
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-open(1)\fP

--- a/etc/man/man1/meroxa-open.1
+++ b/etc/man/man1/meroxa-open.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-open \- Open in a web browser
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa open [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Open in a web browser
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for open
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP, \fBmeroxa\-open\-billing(1)\fP

--- a/etc/man/man1/meroxa-remove-connector.1
+++ b/etc/man/man1/meroxa-remove-connector.1
@@ -1,0 +1,45 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-remove\-connector \- Remove connector
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa remove connector NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Remove connector
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for connector
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-f\fP, \fB\-\-force\fP[=false]
+	force delete without confirmation prompt
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-remove(1)\fP

--- a/etc/man/man1/meroxa-remove-endpoint.1
+++ b/etc/man/man1/meroxa-remove-endpoint.1
@@ -1,0 +1,45 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-remove\-endpoint \- Remove endpoint
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa remove endpoint NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Remove endpoint
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for endpoint
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-f\fP, \fB\-\-force\fP[=false]
+	force delete without confirmation prompt
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-remove(1)\fP

--- a/etc/man/man1/meroxa-remove-pipeline.1
+++ b/etc/man/man1/meroxa-remove-pipeline.1
@@ -1,0 +1,45 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-remove\-pipeline \- Remove pipeline
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa remove pipeline NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Remove pipeline
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for pipeline
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-f\fP, \fB\-\-force\fP[=false]
+	force delete without confirmation prompt
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-remove(1)\fP

--- a/etc/man/man1/meroxa-remove-resource.1
+++ b/etc/man/man1/meroxa-remove-resource.1
@@ -1,0 +1,45 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-remove\-resource \- Remove resource
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa remove resource NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Remove resource
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for resource
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-f\fP, \fB\-\-force\fP[=false]
+	force delete without confirmation prompt
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-remove(1)\fP

--- a/etc/man/man1/meroxa-remove.1
+++ b/etc/man/man1/meroxa-remove.1
@@ -1,0 +1,46 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-remove \- Remove a component
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa remove [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Deprovision a component of the Meroxa platform, including pipelines,
+ resources, and connectors
+
+
+.SH OPTIONS
+.PP
+\fB\-f\fP, \fB\-\-force\fP[=false]
+	force delete without confirmation prompt
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for remove
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP, \fBmeroxa\-remove\-connector(1)\fP, \fBmeroxa\-remove\-endpoint(1)\fP, \fBmeroxa\-remove\-pipeline(1)\fP, \fBmeroxa\-remove\-resource(1)\fP

--- a/etc/man/man1/meroxa-update-connector.1
+++ b/etc/man/man1/meroxa-update-connector.1
@@ -1,0 +1,45 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-update\-connector \- Update connector state
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa update connector NAME \-\-state pause | resume | restart [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Update connector state
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for connector
+
+.PP
+\fB\-\-state\fP=""
+	connector state
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-update(1)\fP

--- a/etc/man/man1/meroxa-update-pipeline.1
+++ b/etc/man/man1/meroxa-update-pipeline.1
@@ -1,0 +1,67 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-update\-pipeline \- Update pipeline state
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa update pipeline NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Update pipeline state
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for pipeline
+
+.PP
+\fB\-m\fP, \fB\-\-metadata\fP=""
+	new pipeline metadata
+
+.PP
+\fB\-\-name\fP=""
+	new pipeline name
+
+.PP
+\fB\-\-state\fP=""
+	new pipeline state
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+
+meroxa update pipeline old\-name \-\-name new\-name
+meroxa update pipeline pipeline\-name \-\-state pause
+meroxa update pipeline pipeline\-name \-\-metadata '{"key":"value"}'
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-update(1)\fP

--- a/etc/man/man1/meroxa-update-resource.1
+++ b/etc/man/man1/meroxa-update-resource.1
@@ -1,0 +1,53 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-update\-resource \- Update a resource
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa update resource NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Use the update command to update various Meroxa resources.
+
+
+.SH OPTIONS
+.PP
+\fB\-\-credentials\fP=""
+	resource credentials
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for resource
+
+.PP
+\fB\-m\fP, \fB\-\-metadata\fP=""
+	resource metadata
+
+.PP
+\fB\-u\fP, \fB\-\-url\fP=""
+	resource url
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-update(1)\fP

--- a/etc/man/man1/meroxa-update.1
+++ b/etc/man/man1/meroxa-update.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-update \- Update a component
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa update [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Update a component of the Meroxa platform, including connectors
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for update
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP, \fBmeroxa\-update\-connector(1)\fP, \fBmeroxa\-update\-pipeline(1)\fP, \fBmeroxa\-update\-resource(1)\fP

--- a/etc/man/man1/meroxa-version.1
+++ b/etc/man/man1/meroxa-version.1
@@ -1,0 +1,41 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-version \- Display the Meroxa CLI version
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa version [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Display the Meroxa CLI version
+
+
+.SH OPTIONS
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for version
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa(1)\fP

--- a/etc/man/man1/meroxa.1
+++ b/etc/man/man1/meroxa.1
@@ -1,0 +1,47 @@
+.nh
+.TH "Meroxa" "1" "Apr 2021" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa \- The Meroxa CLI
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+The Meroxa CLI allows quick and easy access to the Meroxa data platform.
+
+.PP
+Using the CLI you are able to create and manage sophisticated data pipelines
+with only a few simple commands. You can get started by listing the supported
+resource types:
+
+.PP
+meroxa list resource\-types
+
+
+.SH OPTIONS
+.PP
+\fB\-\-config\fP=""
+	config file (default is $HOME/meroxa.env)
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for meroxa
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-add(1)\fP, \fBmeroxa\-api(1)\fP, \fBmeroxa\-billing(1)\fP, \fBmeroxa\-completion(1)\fP, \fBmeroxa\-connect(1)\fP, \fBmeroxa\-create(1)\fP, \fBmeroxa\-describe(1)\fP, \fBmeroxa\-list(1)\fP, \fBmeroxa\-login(1)\fP, \fBmeroxa\-logout(1)\fP, \fBmeroxa\-logs(1)\fP, \fBmeroxa\-open(1)\fP, \fBmeroxa\-remove(1)\fP, \fBmeroxa\-update(1)\fP, \fBmeroxa\-version(1)\fP

--- a/gen-docs/main.go
+++ b/gen-docs/main.go
@@ -13,8 +13,53 @@ func main() {
 	// set HOME env var so that default values involve user's home directory do not depend on the running user.
 	os.Setenv("HOME", "/home/user")
 
-	err := doc.GenMarkdownTree(cmd.RootCmd(), "./docs/cmd")
+	rootCmd := cmd.RootCmd()
+
+	// Generating Man Pages
+	header := &doc.GenManHeader{
+		Title:   "Meroxa",
+		Section: "1",
+		Source:  cmd.VersionString(),
+		Manual:  "Meroxa Manual",
+	}
+
+	if err := doc.GenManTree(rootCmd, header, "./etc/man/man1"); err != nil {
+		log.Fatal(err)
+	}
+
+	// Generating Markdown Documents
+	err := doc.GenMarkdownTree(rootCmd, "./docs/cmd")
 	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Generating Bash Completion File
+	if err := rootCmd.GenBashCompletionFile("./etc/completion/meroxa.completion.sh"); err != nil {
+		log.Fatal(err)
+	}
+	if err := rootCmd.GenZshCompletionFile("./etc/completion/meroxa.completion.zsh"); err != nil {
+		log.Fatal(err)
+	}
+
+	// Generating Fish Completion File
+	fishCompletionFile, err := os.Create("./etc/completion/meroxa.completion.fish")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := rootCmd.GenFishCompletion(fishCompletionFile, true); err != nil {
+		log.Fatal(err)
+	}
+
+	// Generating Power Shell File
+	powerShellCompletionFile, err := os.Create("./etc/completion/meroxa.completion.ps1")
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := rootCmd.GenPowerShellCompletion(powerShellCompletionFile); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
# Description of change

- Updates arguments (from <arg> to ARG) to generate man pages correctly, otherwise, a warning such as `WARNING: go-md2man does not handle node type HTMLSpan` will be printed out.
- Updates `docs` build to make sure documentation, scripts are deleted and generated on the following build.
- Adds instructions to the `completion` cmd.

Fixes https://meroxa.atlassian.net/browse/PLATFORM-420

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  In https://github.com/raulb/cli with https://github.com/raulb/homebrew-taps
- [ ]  Deployed to staging

# Additional references

This can be tested by doing:

```
$ brew uninstall meroxa && untap meroxa/taps 
$ brew tap raulb/taps && brew install meroxa
$ man meroxa
```

### Demo

![](https://d.pr/i/C6c7xj.png)
