### PR TITLE
Bump context timeout to 10 seconds

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ const (
 
 	// The environment variable prefix of all environment variables bound to our command line flags.
 	envPrefix     = "MEROXA"
-	clientTimeOut = 5 * time.Second
+	clientTimeOut = 10 * time.Second
 )
 
 var (


### PR DESCRIPTION
# Description of change

Platform-api master is currently failing on `context deadline exceeded`. We need to bump up the `clientTimeOut` time to help unblock release process while we look into the performance issue. 


# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

_Include how it looked before_

**After this pull-request**

_Include how it looks now_

# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

- [ ] Suggested an edit to the appropiate CLI version. To see the list of edits (e.g. v1.0): https://dash.readme.com/project/meroxa/v1.0/suggested

*Provide link:*
