### PR TITLE
[PLATFORM-439] fix(cli): Let handle values as bool

### DIFF
--- a/cmd/add_resource.go
+++ b/cmd/add_resource.go
@@ -72,7 +72,7 @@ func (ar *AddResource) execute(ctx context.Context, c AddResourceClient, res mer
 	}
 
 	if ar.metadata != "" {
-		var metadata map[string]string
+		var metadata map[string]interface{}
 		err = json.Unmarshal([]byte(ar.metadata), &metadata)
 		if err != nil {
 			return nil, err
@@ -100,7 +100,7 @@ func (ar *AddResource) command() *cobra.Command {
 		Short: "Add a resource to your Meroxa resource catalog",
 		Long:  `Use the add command to add resources to your Meroxa resource catalog.`,
 		Example: "\n" +
-			"meroxa add resource store --type postgres -u $DATABASE_URL\n" +
+			"meroxa add resource store --type postgres -u $DATABASE_URL --metadata '{\"logical_replication\":true}'\n" +
 			"meroxa add resource datalake --type s3 -u \"s3://$AWS_ACCESS_KEY_ID:$AWS_ACCESS_KEY_SECRET@us-east-1/meroxa-demos\"\n" +
 			"meroxa add resource warehouse --type redshift -u $REDSHIFT_URL\n" +
 			"meroxa add resource slack --type url -u $WEBHOOK_URL\n",

--- a/cmd/create_connector.go
+++ b/cmd/create_connector.go
@@ -63,8 +63,8 @@ func (cc *CreateConnector) setFlags(cmd *cobra.Command) {
 	cmd.Flags().MarkHidden("metadata")
 }
 
-func (cc *CreateConnector) parseJSONMap(str string) (out map[string]string, err error) {
-	out = make(map[string]string)
+func (cc *CreateConnector) parseJSONMap(str string) (out map[string]interface{}, err error) {
+	out = make(map[string]interface{})
 	if str != "" {
 		err = json.Unmarshal([]byte(str), &out)
 	}

--- a/cmd/create_connector_test.go
+++ b/cmd/create_connector_test.go
@@ -106,11 +106,11 @@ func TestCreateConnectorExecution(t *testing.T) {
 				Name:         "connector-name",
 				ResourceID:   123,
 				PipelineName: "my-pipeline",
-				Configuration: map[string]string{
+				Configuration: map[string]interface{}{
 					"key":   "value",
 					"input": "foo",
 				},
-				Metadata: map[string]string{
+				Metadata: map[string]interface{}{
 					"metakey":          "metavalue",
 					"mx:connectorType": "source",
 				},

--- a/cmd/create_pipeline.go
+++ b/cmd/create_pipeline.go
@@ -55,7 +55,7 @@ func CreatePipelineCmd() *cobra.Command {
 				return err
 			}
 			if metadataString != "" {
-				var metadata map[string]string
+				var metadata map[string]interface{}
 				err = json.Unmarshal([]byte(metadataString), &metadata)
 				if err != nil {
 					return err

--- a/cmd/update_pipeline.go
+++ b/cmd/update_pipeline.go
@@ -85,7 +85,7 @@ func (up *UpdatePipeline) execute(ctx context.Context, c UpdatePipelineClient) (
 		}
 
 		if up.metadata != "" {
-			metadata := map[string]string{}
+			metadata := map[string]interface{}{}
 
 			err := json.Unmarshal([]byte(up.metadata), &metadata)
 			if err != nil {

--- a/cmd/update_pipeline_test.go
+++ b/cmd/update_pipeline_test.go
@@ -186,7 +186,7 @@ func TestUpdatePipelineExecutionWithNewMetadata(t *testing.T) {
 	p := utils.GeneratePipeline()
 	var pi meroxa.UpdatePipelineInput
 
-	pi.Metadata = map[string]string{"key": "value"}
+	pi.Metadata = map[string]interface{}{"key": "value"}
 
 	client.
 		EXPECT().

--- a/cmd/update_resource.go
+++ b/cmd/update_resource.go
@@ -86,7 +86,7 @@ func (ur *UpdateResource) execute(ctx context.Context, c UpdateResourceClient) (
 
 	// If metadata was provided, update it
 	if ur.metadata != "" {
-		var metadata map[string]string
+		var metadata map[string]interface{}
 		err := json.Unmarshal([]byte(ur.metadata), &metadata)
 		if err != nil {
 			return nil, fmt.Errorf("can't parse metadata: %w", err)

--- a/cmd/update_resource_test.go
+++ b/cmd/update_resource_test.go
@@ -129,7 +129,7 @@ func TestUpdateResourceExecutionWithNewMetadata(t *testing.T) {
 		metadata: `{"metakey":"metavalue"}`,
 	}
 
-	var metadata map[string]string
+	var metadata map[string]interface{}
 
 	json.Unmarshal([]byte(ur.metadata), &metadata)
 	nr := meroxa.UpdateResourceInput{

--- a/docs/cmd/meroxa_add_resource.md
+++ b/docs/cmd/meroxa_add_resource.md
@@ -14,7 +14,7 @@ meroxa add resource [NAME] --type TYPE [flags]
 
 ```
 
-meroxa add resource store --type postgres -u $DATABASE_URL
+meroxa add resource store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":true}'
 meroxa add resource datalake --type s3 -u "s3://$AWS_ACCESS_KEY_ID:$AWS_ACCESS_KEY_SECRET@us-east-1/meroxa-demos"
 meroxa add resource warehouse --type redshift -u $REDSHIFT_URL
 meroxa add resource slack --type url -u $WEBHOOK_URL

--- a/etc/man/man1/meroxa-add-resource.1
+++ b/etc/man/man1/meroxa-add-resource.1
@@ -58,7 +58,7 @@ Use the add command to add resources to your Meroxa resource catalog.
 
 .nf
 
-meroxa add resource store \-\-type postgres \-u $DATABASE\_URL
+meroxa add resource store \-\-type postgres \-u $DATABASE\_URL \-\-metadata '{"logical\_replication":true}'
 meroxa add resource datalake \-\-type s3 \-u "s3://$AWS\_ACCESS\_KEY\_ID:$AWS\_ACCESS\_KEY\_SECRET@us\-east\-1/meroxa\-demos"
 meroxa add resource warehouse \-\-type redshift \-u $REDSHIFT\_URL
 meroxa add resource slack \-\-type url \-u $WEBHOOK\_URL

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20210412135021-30d283ae0dad
+	github.com/meroxa/meroxa-go v0.0.0-20210413105822-b2f2f2377003
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/meroxa/meroxa-go v0.0.0-20210408105927-6a0c076e8b0d h1:Os8tHcnls70ZRu
 github.com/meroxa/meroxa-go v0.0.0-20210408105927-6a0c076e8b0d/go.mod h1:KtaTXPP6L2fv+omflnuihnc8pj7w44jC13M46Wv7T9Q=
 github.com/meroxa/meroxa-go v0.0.0-20210412135021-30d283ae0dad h1:fv+3u+g64Q78nH1UUSDEpVsWgCoipTNIzvv9RMT/lJA=
 github.com/meroxa/meroxa-go v0.0.0-20210412135021-30d283ae0dad/go.mod h1:KtaTXPP6L2fv+omflnuihnc8pj7w44jC13M46Wv7T9Q=
+github.com/meroxa/meroxa-go v0.0.0-20210413105822-b2f2f2377003 h1:ml5995aW7X6ZmpRSRIQFDDHEIDIHz+RVTlvj4XbJFbE=
+github.com/meroxa/meroxa-go v0.0.0-20210413105822-b2f2f2377003/go.mod h1:KtaTXPP6L2fv+omflnuihnc8pj7w44jC13M46Wv7T9Q=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/vendor/github.com/meroxa/meroxa-go/connector.go
+++ b/vendor/github.com/meroxa/meroxa-go/connector.go
@@ -13,8 +13,8 @@ type Connector struct {
 	ID            int                    `json:"id"`
 	Type          string                 `json:"type"`
 	Name          string                 `json:"name"`
-	Configuration map[string]string      `json:"config"`
-	Metadata      map[string]string      `json:"metadata"`
+	Configuration map[string]interface{} `json:"config"`
+	Metadata      map[string]interface{} `json:"metadata"`
 	Streams       map[string]interface{} `json:"streams"`
 	State         string                 `json:"state"`
 	Trace         string                 `json:"trace,omitempty"`
@@ -23,12 +23,12 @@ type Connector struct {
 }
 
 type CreateConnectorInput struct {
-	Name          string            `json:"name,omitempty"`
-	ResourceID    int               `json:"resource_id"`
-	PipelineID    int               `json:"pipeline_id,omitempty"`
-	PipelineName  string            `json:"pipeline_name,omitempty"`
-	Configuration map[string]string `json:"config,omitempty"`
-	Metadata      map[string]string `json:"metadata,omitempty"`
+	Name          string                 `json:"name,omitempty"`
+	ResourceID    int                    `json:"resource_id"`
+	PipelineID    int                    `json:"pipeline_id,omitempty"`
+	PipelineName  string                 `json:"pipeline_name,omitempty"`
+	Configuration map[string]interface{} `json:"config,omitempty"`
+	Metadata      map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // CreateConnector provisions a connector between the Resource and the Meroxa

--- a/vendor/github.com/meroxa/meroxa-go/pipeline.go
+++ b/vendor/github.com/meroxa/meroxa-go/pipeline.go
@@ -12,16 +12,16 @@ const pipelinesBasePath = "/v1/pipelines"
 
 // Pipeline represents the Meroxa Pipeline type within the Meroxa API
 type Pipeline struct {
-	ID       int               `json:"id"`
-	Name     string            `json:"name"`
-	Metadata map[string]string `json:"metadata,omitempty"`
-	State    string            `json:"state"`
+	ID       int                    `json:"id"`
+	Name     string                 `json:"name"`
+	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	State    string                 `json:"state"`
 }
 
 type UpdatePipelineInput struct {
-	Name     string            `json:"name"`
-	Metadata map[string]string `json:"metadata"`
-	State    string            `json:"state"`
+	Name     string                 `json:"name"`
+	Metadata map[string]interface{} `json:"metadata"`
+	State    string                 `json:"state"`
 }
 
 // ComponentKind enum for Component "kinds" within Pipeline stages

--- a/vendor/github.com/meroxa/meroxa-go/resource.go
+++ b/vendor/github.com/meroxa/meroxa-go/resource.go
@@ -27,30 +27,30 @@ type Credentials struct {
 
 // CreateResourceInput represents the input for a Meroxa Resource type we're creating within the Meroxa API
 type CreateResourceInput struct {
-	ID          int               `json:"id"`
-	Type        string            `json:"type"`
-	Name        string            `json:"name,omitempty"`
-	URL         string            `json:"url"`
-	Credentials *Credentials      `json:"credentials,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	ID          int                    `json:"id"`
+	Type        string                 `json:"type"`
+	Name        string                 `json:"name,omitempty"`
+	URL         string                 `json:"url"`
+	Credentials *Credentials           `json:"credentials,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // Resource represents the Meroxa Resource type within the Meroxa API
 type Resource struct {
-	ID          int               `json:"id"`
-	Type        string            `json:"type"`
-	Name        string            `json:"name"`
-	URL         string            `json:"url"`
-	Credentials *Credentials      `json:"credentials,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	ID          int                    `json:"id"`
+	Type        string                 `json:"type"`
+	Name        string                 `json:"name"`
+	URL         string                 `json:"url"`
+	Credentials *Credentials           `json:"credentials,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // UpdateResourceInput represents the Meroxa Resource we're updating in the Meroxa API
 type UpdateResourceInput struct {
-	Name        string            `json:"name,omitempty"` // TODO: Update this via CLI
-	URL         string            `json:"url,omitempty"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
-	Credentials *Credentials      `json:"credentials,omitempty"`
+	Name        string                 `json:"name,omitempty"` // TODO: Update this via CLI
+	URL         string                 `json:"url,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	Credentials *Credentials           `json:"credentials,omitempty"`
 }
 
 // CreateResource provisions a new Resource from the given CreateResourceInput struct

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -42,7 +42,7 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 ## explicit
 github.com/mattn/go-runewidth
-# github.com/meroxa/meroxa-go v0.0.0-20210412135021-30d283ae0dad
+# github.com/meroxa/meroxa-go v0.0.0-20210413105822-b2f2f2377003
 ## explicit
 github.com/meroxa/meroxa-go
 # github.com/mitchellh/go-homedir v1.1.0


### PR DESCRIPTION
# Description of change

Fixes https://meroxa.atlassian.net/browse/PLATFORM-439

The UI is sending certain attributes that are legitimate booleans, and both meroxa-go and CLI have been treating them as strings causing an unmarshal error such as:

`Error: json: cannot unmarshal bool into Go struct field Resource.metadata of type string`.

# Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
$ meroxa list resources
Error: json: cannot unmarshal bool into Go struct field Resource.metadata of type string
```

**After this pull-request**

```
$ meroxa list resources
 ID         NAME           TYPE                                           URL
===== ================= ========== =================================================================================
 420   my-resource       postgres   postgres://meroxa-demo.cwyhi7jl0lln.us-east-2.rds.amazonaws.com:5432/dboP24ThrN
 506   resource-729906   mongodb    mongodb+srv://cluster0.toy9e.mongodb.net/meroxa
 474   resource-902992   postgres   postgres://meroxa-demo.cwyhi7jl0lln.us-east-2.rds.amazonaws.com:5432/dboP24ThrN
 509   resource-942792   postgres   postgres://meroxa-demo.cwyhi7jl0lln.us-east-2.rds.amazonaws.com:5432/dboP24ThrN
 507   resource-984998   mongodb    mongodb+srv://cluster0.toy9e.mongodb.net/meroxa
 510   Testing           postgres   postgres://meroxa-demo.cwyhi7jl0lln.us-east-2.rds.amazonaws.com:5432/dboP24ThrN
```
