### PR TITLE
[PLATFORM-446] fix(add): send credentials when adding resources

### DIFF
--- a/cmd/add_resource.go
+++ b/cmd/add_resource.go
@@ -59,17 +59,16 @@ func (ar *AddResource) execute(ctx context.Context, c AddResourceClient, res mer
 
 	var err error
 
-	// TODO: Figure out best way to handle creds and metadata
 	// Get credentials (expect a JSON string)
+	var creds meroxa.Credentials
 	if ar.credentials != "" {
-		var creds meroxa.Credentials
 		err = json.Unmarshal([]byte(ar.credentials), &creds)
 		if err != nil {
 			return nil, err
 		}
 
-		res.Credentials = &creds
 	}
+	res.Credentials = &creds
 
 	if ar.metadata != "" {
 		var metadata map[string]interface{}
@@ -119,10 +118,9 @@ func (ar *AddResource) command() *cobra.Command {
 			}
 
 			ri := meroxa.CreateResourceInput{
-				Type:     ar.rType,
-				Name:     ar.name,
-				URL:      ar.url,
-				Metadata: nil,
+				Type: ar.rType,
+				Name: ar.name,
+				URL:  ar.url,
 			}
 
 			res, err := ar.execute(ctx, c, ri)

--- a/cmd/add_resource_test.go
+++ b/cmd/add_resource_test.go
@@ -75,12 +75,13 @@ func TestAddResourceExecution(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	client := mock.NewMockAddResourceClient(ctrl)
 
+	var emptyCreds meroxa.Credentials
+
 	r := meroxa.CreateResourceInput{
 		Type:        "postgres",
 		Name:        "",
 		URL:         "https://foo.url",
-		Credentials: nil,
-		Metadata:    nil,
+		Credentials: &emptyCreds,
 	}
 
 	cr := utils.GenerateResource()


### PR DESCRIPTION
# Description of change


Fixes https://meroxa.atlassian.net/browse/PLATFORM-446

# Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
❯ .m add resource webhook --type url -u https://webhook.site/77d8104b-2dca-40d4-a8c6-cf349f2f7363
Adding url resource...
Error: resource improperly configured
details:
	"credentials": ["must be provided"]
```

**After this pull-request**

```
❯ .m add resource webhook --type url -u https://webhook.site/77d8104b-2dca-40d4-a8c6-cf349f2f7363
Adding url resource...
url resource with name webhook successfully added!
```
