### PR TITLE
Fix linter warnings 🥼

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,11 +1,5 @@
 name: golangci-lint
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-      - main
   pull_request:
 jobs:
   golangci:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,20 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+      - main
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.39.0
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 linters-settings:
-  dupl:
-    threshold: 100
   funlen:
     lines: 100
     statements: 50

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,12 @@
 linters-settings:
-  depguard:
-    list-type: blacklist
-    packages:
-      # logging is allowed only by logutils.Log, logrus
-      # is allowed to use only in logutils package
-      - github.com/sirupsen/logrus
-    packages-with-error-message:
-      - github.com/sirupsen/logrus: "logging is allowed only by logutils.Log"
   dupl:
     threshold: 100
   funlen:
     lines: 100
     statements: 50
-  gci:
-    local-prefixes: github.com/golangci/golangci-lint
   goconst:
-    min-len: 2
-    min-occurrences: 2
+    min-len: 3
+    min-occurrences: 3
   gocritic:
     enabled-tags:
       - diagnostic
@@ -30,17 +20,16 @@ linters-settings:
       - octalLiteral
       - whyNoLint
       - wrapperFunc
+      - hugeParam
   gocyclo:
     min-complexity: 15
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
   golint:
     min-confidence: 0
   gomnd:
     settings:
       mnd:
         # don't include the "operation" and "assign"
-        checks: argument,case,condition,return
+        checks: [argument,case,condition,return]
   govet:
     check-shadowing: true
     settings:
@@ -71,14 +60,15 @@ linters:
     - deadcode
     - depguard
     - dogsled
-    - dupl
     - errcheck
     - exhaustive
+    - exportloopref
     - funlen
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
+    - godot
     - gofmt
     - goimports
     - golint
@@ -88,14 +78,12 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - misspell
     - nakedret
     - noctx
     - nolintlint
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck
@@ -108,9 +96,9 @@ linters:
 
   # don't enable:
   # - asciicheck
+  # - dupl
   # - gochecknoglobals
   # - gocognit
-  # - godot
   # - godox
   # - goerr113
   # - maligned
@@ -125,29 +113,11 @@ issues:
     - path: _test\.go
       linters:
         - gomnd
+        - goconst
+        - gosec
 
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-
-    # TODO temporary rule, must be removed
-    # seems related to v0.34.1, but I was not able to reproduce locally,
-    # I was also not able to reproduce in the CI of a fork,
-    # only the golangci-lint CI seems to be affected by this invalid analysis.
-    - path: pkg/golinters/scopelint.go
-      text: 'directive `//nolint:interfacer` is unused for linter interfacer'
-
-run:
-  skip-dirs:
-    - test/testdata_etc
-    - internal/cache
-    - internal/renameio
-    - internal/robustio
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.23.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"
+    - path: utils/tests.go
+      linters:
+        - gomnd
+        - goconst
+        - gosec

--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -154,6 +154,7 @@ func buildCommandWithAliases(cmd *cobra.Command, c Command) {
 	cmd.Aliases = v.Aliases()
 }
 
+// nolint:funlen,gocyclo // this function has a big switch statement, can't get around that
 func buildCommandWithFlags(cmd *cobra.Command, c Command) {
 	v, ok := c.(CommandWithFlags)
 	if !ok {

--- a/cmd/meroxa/builder/builder_test.go
+++ b/cmd/meroxa/builder/builder_test.go
@@ -263,7 +263,7 @@ func TestBuildCommandWithFlags(t *testing.T) {
 
 	for i := 1; i <= 17; i++ {
 		if i%2 == 1 {
-			want.MarkFlagRequired(fmt.Sprintf("flag%d", i))
+			_ = want.MarkFlagRequired(fmt.Sprintf("flag%d", i))
 		}
 	}
 

--- a/cmd/meroxa/global/client.go
+++ b/cmd/meroxa/global/client.go
@@ -47,8 +47,8 @@ func NewClient() (*meroxa.Client, error) {
 	if flagTimeout != 0 {
 		options = append(options, meroxa.WithClientTimeout(flagTimeout))
 	}
-	if flagApiUrl != "" {
-		options = append(options, meroxa.WithBaseURL(flagApiUrl))
+	if flagAPIURL != "" {
+		options = append(options, meroxa.WithBaseURL(flagAPIURL))
 	}
 
 	// WithAuthentication needs to be added after WithDumpTransport

--- a/cmd/meroxa/global/config.go
+++ b/cmd/meroxa/global/config.go
@@ -56,8 +56,8 @@ func readConfig() (*viper.Viper, error) {
 	}
 
 	// TODO remove this code once we migrate acceptance tests to use new env variable
-	if apiUrl, ok := os.LookupEnv("API_URL"); ok {
-		os.Setenv("MEROXA_API_URL", apiUrl)
+	if apiURL, ok := os.LookupEnv("API_URL"); ok {
+		os.Setenv("MEROXA_API_URL", apiURL)
 	}
 
 	// When we bind flags to environment variables expect that the
@@ -87,7 +87,7 @@ func setupCompatibility(cfg *viper.Viper) error {
 	cfg.SetConfigName("meroxa")
 	cfg.SetConfigType("env")
 
-	if err := cfg.ReadInConfig(); err != nil {
+	if err = cfg.ReadInConfig(); err != nil {
 		// It's okay if there isn't a config file
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
 			return fmt.Errorf("could not read config: %w", err)

--- a/cmd/meroxa/global/global.go
+++ b/cmd/meroxa/global/global.go
@@ -16,7 +16,7 @@ var (
 
 var (
 	flagConfig  string
-	flagApiUrl  string
+	flagAPIURL  string
 	flagDebug   bool
 	flagTimeout time.Duration
 	FlagJSON    bool // TODO make this private! do not use this variable from other packages
@@ -25,9 +25,9 @@ var (
 func RegisterGlobalFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&FlagJSON, "json", false, "output json")
 	cmd.PersistentFlags().StringVar(&flagConfig, "config", "", "config file")
-	cmd.PersistentFlags().StringVar(&flagApiUrl, "api-url", "", "API url")
+	cmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "API url")
 	cmd.PersistentFlags().BoolVar(&flagDebug, "debug", false, "display any debugging information")
-	cmd.PersistentFlags().DurationVar(&flagTimeout, "timeout", time.Second*10, "set the client timeout")
+	cmd.PersistentFlags().DurationVar(&flagTimeout, "timeout", time.Second*10, "set the client timeout") // nolint:gomnd
 
 	if err := cmd.PersistentFlags().MarkHidden("api-url"); err != nil {
 		panic(fmt.Sprintf("could not mark flag as hidden: %v", err))
@@ -49,7 +49,7 @@ func PersistentPreRunE(cmd *cobra.Command) error {
 	return nil
 }
 
-// Bind each cobra flag to its associated viper configuration (config file and environment variable)
+// Bind each cobra flag to its associated viper configuration (config file and environment variable).
 func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	var err error
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {

--- a/cmd/meroxa/root/add/add_resource.go
+++ b/cmd/meroxa/root/add/add_resource.go
@@ -29,6 +29,7 @@ type addResourceClient interface {
 	CreateResource(ctx context.Context, resource *meroxa.CreateResourceInput) (*meroxa.Resource, error)
 }
 
+// nolint:golint // add.AddResource is stuttering, it should be fixed when reorganizing commands
 type AddResource struct {
 	client addResourceClient
 	logger log.Logger
@@ -39,7 +40,7 @@ type AddResource struct {
 
 	flags struct {
 		Type     string `long:"type"        short:""  usage:"resource type"        required:"true"`
-		Url      string `long:"url"         short:"u" usage:"resource url"         required:"true"`
+		URL      string `long:"url"         short:"u" usage:"resource url"         required:"true"`
 		Metadata string `long:"metadata"    short:"m" usage:"resource metadata"`
 
 		// credentials
@@ -101,7 +102,7 @@ func (ar *AddResource) Execute(ctx context.Context) error {
 	input := meroxa.CreateResourceInput{
 		Type:     ar.flags.Type,
 		Name:     ar.args.Name,
-		URL:      ar.flags.Url,
+		URL:      ar.flags.URL,
 		Metadata: nil,
 	}
 

--- a/cmd/meroxa/root/add/add_resource_test.go
+++ b/cmd/meroxa/root/add/add_resource_test.go
@@ -103,7 +103,7 @@ func TestAddResourceExecution(t *testing.T) {
 	}
 	ar.args.Name = r.Name
 	ar.flags.Type = r.Type
-	ar.flags.Url = r.URL
+	ar.flags.URL = r.URL
 
 	err := ar.Execute(ctx)
 	if err != nil {

--- a/cmd/meroxa/root/add/add_test.go
+++ b/cmd/meroxa/root/add/add_test.go
@@ -32,7 +32,6 @@ func TestAddCmd(t *testing.T) {
 	}
 
 	out, err := ioutil.ReadAll(b)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/meroxa/root/old/api.go
+++ b/cmd/meroxa/root/old/api.go
@@ -2,7 +2,6 @@ package old
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -12,12 +11,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ApiCmd represents the `meroxa api` command
-func ApiCmd() *cobra.Command {
+// APICmd represents the `meroxa api` command.
+func APICmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "api METHOD PATH [body]",
 		Short: "Invoke Meroxa API",
-		Args:  cobra.MinimumNArgs(2),
+		Args:  cobra.MinimumNArgs(2), // nolint:gomnd
 		Example: `
 meroxa api GET /v1/endpoints
 meroxa api POST /v1/endpoints '{"protocol": "HTTP", "stream": "resource-2-499379-public.accounts", "name": "1234"}'`,
@@ -33,14 +32,15 @@ meroxa api POST /v1/endpoints '{"protocol": "HTTP", "stream": "resource-2-499379
 				body   string
 			)
 
-			if len(args) > 2 {
+			if len(args) > 2 { // nolint:gomnd
 				body = args[2]
 			}
 
-			resp, err := c.MakeRequest(context.Background(), method, path, body, nil)
+			resp, err := c.MakeRequest(cmd.Context(), method, path, body, nil)
 			if err != nil {
 				return err
 			}
+			defer resp.Body.Close()
 
 			b, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
@@ -56,7 +56,7 @@ meroxa api POST /v1/endpoints '{"protocol": "HTTP", "stream": "resource-2-499379
 			for k, v := range resp.Header {
 				fmt.Printf("< %s %s\n", k, strings.Join(v, " "))
 			}
-			fmt.Printf(prettyJSON.String())
+			fmt.Print(prettyJSON.String())
 
 			return nil
 		},

--- a/cmd/meroxa/root/old/billing.go
+++ b/cmd/meroxa/root/old/billing.go
@@ -24,7 +24,7 @@ import (
 
 // TODO: Check how to disable parent flags (e.g.: --json)
 
-// BillingCmd represents the `meroxa billing` command
+// BillingCmd represents the `meroxa billing` command.
 func BillingCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "billing",

--- a/cmd/meroxa/root/old/completion.go
+++ b/cmd/meroxa/root/old/completion.go
@@ -1,12 +1,13 @@
 package old
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 )
 
-// CompletionCmd represents the completion command
+// CompletionCmd represents the completion command.
 func CompletionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "completion [bash|zsh|fish|powershell]",
@@ -45,16 +46,18 @@ func CompletionCmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.ExactValidArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
 			case "bash":
-				cmd.Root().GenBashCompletion(os.Stdout)
+				return cmd.Root().GenBashCompletion(os.Stdout)
 			case "zsh":
-				cmd.Root().GenZshCompletion(os.Stdout)
+				return cmd.Root().GenZshCompletion(os.Stdout)
 			case "fish":
-				cmd.Root().GenFishCompletion(os.Stdout, true)
+				return cmd.Root().GenFishCompletion(os.Stdout, true)
 			case "powershell":
-				cmd.Root().GenPowerShellCompletion(os.Stdout)
+				return cmd.Root().GenPowerShellCompletion(os.Stdout)
+			default:
+				return fmt.Errorf("unexpected argument %q", args[0])
 			}
 		},
 	}

--- a/cmd/meroxa/root/old/connect_test.go
+++ b/cmd/meroxa/root/old/connect_test.go
@@ -35,7 +35,7 @@ func TestConnectCmd(t *testing.T) {
 		rootCmd.SetOut(b)
 		rootCmd.SetErr(b)
 		rootCmd.SetArgs(tt.args)
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 		output, err := ioutil.ReadAll(b)
 
 		if err != nil {

--- a/cmd/meroxa/root/old/create.go
+++ b/cmd/meroxa/root/old/create.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CreateCmd represents the `meroxa create` command
+// CreateCmd represents the `meroxa create` command.
 func CreateCmd() *cobra.Command {
 	createCmd := &cobra.Command{
 		Use:   "create",

--- a/cmd/meroxa/root/old/create_connector.go
+++ b/cmd/meroxa/root/old/create_connector.go
@@ -52,7 +52,7 @@ func (cc *CreateConnector) setArgs(args []string) error {
 
 func (cc *CreateConnector) setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&cc.input, "input", "", "", "command delimited list of input streams")
-	cmd.MarkFlagRequired("input")
+	_ = cmd.MarkFlagRequired("input")
 
 	cmd.Flags().StringVarP(&cc.config, "config", "c", "", "connector configuration")
 	cmd.Flags().StringVarP(&cc.metadata, "metadata", "m", "", "connector metadata")
@@ -61,7 +61,7 @@ func (cc *CreateConnector) setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&cc.pipelineName, "pipeline", "", "", "pipeline name to attach connector to")
 
 	// Hide metadata flag for now. This could probably go away
-	cmd.Flags().MarkHidden("metadata")
+	_ = cmd.Flags().MarkHidden("metadata")
 }
 
 func (cc *CreateConnector) parseJSONMap(str string) (out map[string]interface{}, err error) {
@@ -130,7 +130,7 @@ func (cc *CreateConnector) output(con *meroxa.Connector) {
 	}
 }
 
-// command returns the cobra Command for `create connector`
+// command returns the cobra Command for `create connector`.
 func (cc *CreateConnector) command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connector [NAME] [flags]",
@@ -145,13 +145,11 @@ func (cc *CreateConnector) command() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := global.NewClient()
-
 			if err != nil {
 				return err
 			}
 
 			res, err := cc.execute(cmd.Context(), c)
-
 			if err != nil {
 				return err
 			}

--- a/cmd/meroxa/root/old/create_connector_test.go
+++ b/cmd/meroxa/root/old/create_connector_test.go
@@ -162,7 +162,7 @@ func TestCreateConnectorJSONOutput(t *testing.T) {
 	})
 
 	var parsedOutput meroxa.Connector
-	json.Unmarshal([]byte(output), &parsedOutput)
+	_ = json.Unmarshal([]byte(output), &parsedOutput)
 
 	if !reflect.DeepEqual(c, parsedOutput) {
 		t.Fatalf("not expected output, got \"%s\"", output)

--- a/cmd/meroxa/root/old/create_endpoint.go
+++ b/cmd/meroxa/root/old/create_endpoint.go
@@ -43,8 +43,8 @@ func (ce *CreateEndpoint) setArgs(args []string) error {
 func (ce *CreateEndpoint) setFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&ce.protocol, "protocol", "p", "", "protocol, value can be http or grpc (required)")
 	cmd.Flags().StringVarP(&ce.stream, "stream", "s", "", "stream name (required)")
-	cmd.MarkFlagRequired("protocol")
-	cmd.MarkFlagRequired("stream")
+	_ = cmd.MarkFlagRequired("protocol")
+	_ = cmd.MarkFlagRequired("stream")
 }
 
 func (ce *CreateEndpoint) output() {
@@ -56,7 +56,7 @@ func (ce *CreateEndpoint) execute(ctx context.Context, c CreateEndpointClient) e
 	return c.CreateEndpoint(ctx, ce.name, ce.protocol, ce.stream)
 }
 
-// CreateEndpointCmd represents the `meroxa create endpoint` command
+// CreateEndpointCmd represents the `meroxa create endpoint` command.
 func (ce *CreateEndpoint) command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "endpoint [NAME] [flags]",

--- a/cmd/meroxa/root/old/create_endpoint_test.go
+++ b/cmd/meroxa/root/old/create_endpoint_test.go
@@ -2,7 +2,6 @@ package old
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -89,7 +88,7 @@ func TestCreateEndpointExecution(t *testing.T) {
 		}
 	})
 
-	expected := fmt.Sprintf("Creating endpoint...")
+	expected := "Creating endpoint..."
 
 	if !strings.Contains(output, expected) {
 		t.Fatalf("expected output \"%s\" got \"%s\"", expected, output)
@@ -104,7 +103,7 @@ func TestCreateEndpointOutput(t *testing.T) {
 		ce.output()
 	})
 
-	expected := fmt.Sprintf("Endpoint successfully created!")
+	expected := "Endpoint successfully created!"
 
 	if !strings.Contains(output, expected) {
 		t.Fatalf("expected output \"%s\" got \"%s\"", expected, output)

--- a/cmd/meroxa/root/old/create_pipeline.go
+++ b/cmd/meroxa/root/old/create_pipeline.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// CreatePipelineCmd represents the `meroxa create pipeline` command
+// CreatePipelineCmd represents the `meroxa create pipeline` command.
 func CreatePipelineCmd() *cobra.Command {
 	createPipelineCmd := &cobra.Command{
 		Use:   "pipeline NAME",

--- a/cmd/meroxa/root/old/create_pipeline_test.go
+++ b/cmd/meroxa/root/old/create_pipeline_test.go
@@ -27,7 +27,7 @@ func TestCreatePipelineCmd(t *testing.T) {
 		rootCmd.SetOut(b)
 		rootCmd.SetErr(b)
 		rootCmd.SetArgs(tt.args)
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 		output, err := ioutil.ReadAll(b)
 
 		if err != nil {

--- a/cmd/meroxa/root/old/create_test.go
+++ b/cmd/meroxa/root/old/create_test.go
@@ -27,7 +27,7 @@ func TestCreateCmd(t *testing.T) {
 	b := bytes.NewBufferString("")
 	rootCmd.SetOut(b)
 	rootCmd.SetArgs([]string{"create"})
-	rootCmd.Execute()
+	_ = rootCmd.Execute()
 
 	out, err := ioutil.ReadAll(b)
 

--- a/cmd/meroxa/root/old/deprecated.go
+++ b/cmd/meroxa/root/old/deprecated.go
@@ -17,6 +17,7 @@ limitations under the License.
 package old
 
 var (
-	// Deprecated: use log.Logger instead, it knows about the flag
+	// FlagRootOutputJSON is true if we should output a JSON result.
+	// Deprecated: use log.Logger instead, it knows about the flag.
 	FlagRootOutputJSON bool
 )

--- a/cmd/meroxa/root/old/describe.go
+++ b/cmd/meroxa/root/old/describe.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DescribeCmd represents the `meroxa describe` command
+// DescribeCmd represents the `meroxa describe` command.
 func DescribeCmd() *cobra.Command {
 	describeCmd := &cobra.Command{
 		Use:   "describe",

--- a/cmd/meroxa/root/old/describe_connector.go
+++ b/cmd/meroxa/root/old/describe_connector.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DescribeConnectorCmd represents the `meroxa describe connector` command
+// DescribeConnectorCmd represents the `meroxa describe connector` command.
 func DescribeConnectorCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "connector [name]",

--- a/cmd/meroxa/root/old/describe_connector_test.go
+++ b/cmd/meroxa/root/old/describe_connector_test.go
@@ -27,7 +27,7 @@ func TestDescribeConnectorCmd(t *testing.T) {
 		rootCmd.SetOut(b)
 		rootCmd.SetErr(b)
 		rootCmd.SetArgs(tt.args)
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 		output, err := ioutil.ReadAll(b)
 
 		if err != nil {

--- a/cmd/meroxa/root/old/describe_endpoint.go
+++ b/cmd/meroxa/root/old/describe_endpoint.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DescribeEndpointCmd represents the `meroxa describe endpoint` command
+// DescribeEndpointCmd represents the `meroxa describe endpoint` command.
 func DescribeEndpointCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "endpoint NAME",
@@ -53,7 +53,6 @@ func DescribeEndpointCmd() *cobra.Command {
 				utils.PrintEndpointsTable([]meroxa.Endpoint{*end})
 			}
 			return nil
-
 		},
 	}
 }

--- a/cmd/meroxa/root/old/describe_endpoint_test.go
+++ b/cmd/meroxa/root/old/describe_endpoint_test.go
@@ -27,7 +27,7 @@ func TestDescribeEndpointCmd(t *testing.T) {
 		rootCmd.SetOut(b)
 		rootCmd.SetErr(b)
 		rootCmd.SetArgs(tt.args)
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 		output, err := ioutil.ReadAll(b)
 
 		if err != nil {

--- a/cmd/meroxa/root/old/describe_resource.go
+++ b/cmd/meroxa/root/old/describe_resource.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// DescribeResourceCmd represents the `meroxa describe resource` command
+// DescribeResourceCmd represents the `meroxa describe resource` command.
 func DescribeResourceCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "resource NAME",

--- a/cmd/meroxa/root/old/describe_resource_test.go
+++ b/cmd/meroxa/root/old/describe_resource_test.go
@@ -27,7 +27,7 @@ func TestDescribeResourceCmd(t *testing.T) {
 		rootCmd.SetOut(b)
 		rootCmd.SetErr(b)
 		rootCmd.SetArgs(tt.args)
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 		output, err := ioutil.ReadAll(b)
 
 		if err != nil {

--- a/cmd/meroxa/root/old/describe_test.go
+++ b/cmd/meroxa/root/old/describe_test.go
@@ -28,7 +28,7 @@ func TestDescribeCmd(t *testing.T) {
 	b := bytes.NewBufferString("")
 	rootCmd.SetOut(b)
 	rootCmd.SetArgs([]string{"describe"})
-	rootCmd.Execute()
+	_ = rootCmd.Execute()
 
 	out, err := ioutil.ReadAll(b)
 

--- a/cmd/meroxa/root/old/list.go
+++ b/cmd/meroxa/root/old/list.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListCmd represents the `meroxa list` command
+// ListCmd represents the `meroxa list` command.
 func ListCmd() *cobra.Command {
 	listCmd := &cobra.Command{
 		Use:   "list",

--- a/cmd/meroxa/root/old/list_connectors.go
+++ b/cmd/meroxa/root/old/list_connectors.go
@@ -61,7 +61,7 @@ func (lc *ListConnectors) output(connectors []*meroxa.Connector) {
 	}
 }
 
-// ListConnectorsCmd represents the `meroxa list connectors` command
+// ListConnectorsCmd represents the `meroxa list connectors` command.
 func (lc *ListConnectors) command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "connectors",

--- a/cmd/meroxa/root/old/list_connectors_test.go
+++ b/cmd/meroxa/root/old/list_connectors_test.go
@@ -147,7 +147,7 @@ func TestListConnectorsJSONOutput(t *testing.T) {
 	})
 
 	var parsedOutput []*meroxa.Connector
-	json.Unmarshal([]byte(output), &parsedOutput)
+	_ = json.Unmarshal([]byte(output), &parsedOutput)
 
 	if !reflect.DeepEqual(connectors, parsedOutput) {
 		t.Fatalf("not expected output, got \"%s\"", output)

--- a/cmd/meroxa/root/old/list_endpoints.go
+++ b/cmd/meroxa/root/old/list_endpoints.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListEndpointsCmd represents the `meroxa list endpoints` command
+// ListEndpointsCmd represents the `meroxa list endpoints` command.
 func ListEndpointsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "endpoint",

--- a/cmd/meroxa/root/old/list_pipelines.go
+++ b/cmd/meroxa/root/old/list_pipelines.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListPipelinesCmd represents the `meroxa list pipelines` command
+// ListPipelinesCmd represents the `meroxa list pipelines` command.
 func ListPipelinesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "pipelines",

--- a/cmd/meroxa/root/old/list_resource_types.go
+++ b/cmd/meroxa/root/old/list_resource_types.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListResourceTypesCmd represents the `meroxa list resource-types` command
+// ListResourceTypesCmd represents the `meroxa list resource-types` command.
 func ListResourceTypesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "resource-types",

--- a/cmd/meroxa/root/old/list_resources.go
+++ b/cmd/meroxa/root/old/list_resources.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListResourcesCmd represents the `meroxa list resources` command
+// ListResourcesCmd represents the `meroxa list resources` command.
 func ListResourcesCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "resources",

--- a/cmd/meroxa/root/old/list_test.go
+++ b/cmd/meroxa/root/old/list_test.go
@@ -30,7 +30,7 @@ func TestListCmd(t *testing.T) {
 	b := bytes.NewBufferString("")
 	rootCmd.SetOut(b)
 	rootCmd.SetArgs([]string{"list"})
-	rootCmd.Execute()
+	_ = rootCmd.Execute()
 
 	out, err := ioutil.ReadAll(b)
 

--- a/cmd/meroxa/root/old/list_transforms.go
+++ b/cmd/meroxa/root/old/list_transforms.go
@@ -22,7 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ListTransformsCmd represents the `meroxa list transforms` command
+// ListTransformsCmd represents the `meroxa list transforms` command.
 func ListTransformsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "transforms",

--- a/cmd/meroxa/root/old/logout.go
+++ b/cmd/meroxa/root/old/logout.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// LogoutCmd represents the `meroxa logout` command
+// LogoutCmd represents the `meroxa logout` command.
 func LogoutCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "logout",

--- a/cmd/meroxa/root/old/logs.go
+++ b/cmd/meroxa/root/old/logs.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// LogsCmd represents the `meroxa logs` command
+// LogsCmd represents the `meroxa logs` command.
 func LogsCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:   "logs",

--- a/cmd/meroxa/root/old/logs_connector.go
+++ b/cmd/meroxa/root/old/logs_connector.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// LogsConnectorCmd represents the `meroxa logs connector` command
+// LogsConnectorCmd represents the `meroxa logs connector` command.
 func LogsConnectorCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "connector NAME",
@@ -45,6 +45,7 @@ func LogsConnectorCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			defer resp.Body.Close()
 
 			_, err = io.Copy(os.Stdout, resp.Body)
 			if err != nil {

--- a/cmd/meroxa/root/old/logs_connector_test.go
+++ b/cmd/meroxa/root/old/logs_connector_test.go
@@ -27,7 +27,7 @@ func TestLogsConnectorCmd(t *testing.T) {
 		rootCmd.SetOut(b)
 		rootCmd.SetErr(b)
 		rootCmd.SetArgs(tt.args)
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 		output, err := ioutil.ReadAll(b)
 
 		if err != nil {

--- a/cmd/meroxa/root/old/logs_test.go
+++ b/cmd/meroxa/root/old/logs_test.go
@@ -24,7 +24,7 @@ func TestLogsCmd(t *testing.T) {
 	b := bytes.NewBufferString("")
 	rootCmd.SetOut(b)
 	rootCmd.SetArgs([]string{"logs"})
-	rootCmd.Execute()
+	_ = rootCmd.Execute()
 
 	out, err := ioutil.ReadAll(b)
 

--- a/cmd/meroxa/root/old/open.go
+++ b/cmd/meroxa/root/old/open.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// OpenCmd represents the `meroxa open` command
+// OpenCmd represents the `meroxa open` command.
 func OpenCmd() *cobra.Command {
 	openCmd := &cobra.Command{
 		Use:   "open",

--- a/cmd/meroxa/root/old/open_billing.go
+++ b/cmd/meroxa/root/old/open_billing.go
@@ -38,20 +38,13 @@ func getBillingURL() string {
 	return fmt.Sprintf("%s/settings/billing", platformURL)
 }
 
-// OpenBillingCmd represents the `meroxa open billing` command
+// OpenBillingCmd represents the `meroxa open billing` command.
 func OpenBillingCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "billing",
 		Short: "Open your billing page in a web browser",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			err := browser.OpenURL(getBillingURL())
-
-			if err != nil {
-				return err
-			}
-
-			return nil
+			return browser.OpenURL(getBillingURL())
 		},
 	}
 }

--- a/cmd/meroxa/root/old/open_test.go
+++ b/cmd/meroxa/root/old/open_test.go
@@ -26,7 +26,7 @@ func TestOpenCmd(t *testing.T) {
 	b := bytes.NewBufferString("")
 	rootCmd.SetOut(b)
 	rootCmd.SetArgs([]string{"open"})
-	rootCmd.Execute()
+	_ = rootCmd.Execute()
 
 	out, err := ioutil.ReadAll(b)
 

--- a/cmd/meroxa/root/old/remove.go
+++ b/cmd/meroxa/root/old/remove.go
@@ -32,7 +32,7 @@ type Remove struct {
 	force, yolo                    bool
 }
 
-// confirmRemove will prompt for confirmation
+// confirmRemove will prompt for confirmation.
 func (r *Remove) confirmRemove(stdin io.Reader, val string) error {
 	reader := bufio.NewReader(stdin)
 	fmt.Printf("To proceed, type %q or re-run this command with --force\n▸ ", val)
@@ -40,10 +40,9 @@ func (r *Remove) confirmRemove(stdin io.Reader, val string) error {
 
 	if val != strings.TrimSuffix(input, "\n") {
 		if r.componentType != "" {
-			return errors.New(fmt.Sprintf("removing %s not confirmed", r.componentType))
-		} else {
-			return errors.New("removing value not confirmed")
+			return fmt.Errorf("removing %s not confirmed", r.componentType)
 		}
+		return errors.New("removing value not confirmed")
 	}
 	return nil
 }
@@ -51,10 +50,10 @@ func (r *Remove) confirmRemove(stdin io.Reader, val string) error {
 func (r *Remove) setFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVarP(&r.force, "force", "f", false, "force delete without confirmation prompt")
 	cmd.PersistentFlags().BoolVarP(&r.yolo, "yolo", "", false, "alias to --force")
-	cmd.PersistentFlags().MarkHidden("yolo")
+	_ = cmd.PersistentFlags().MarkHidden("yolo")
 }
 
-// Command represents the `meroxa remove` command
+// Command represents the `meroxa remove` command.
 func (r *Remove) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove",

--- a/cmd/meroxa/root/old/remove_connector.go
+++ b/cmd/meroxa/root/old/remove_connector.go
@@ -27,13 +27,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RemoveConnectorCmd represents the `meroxa remove connector` command
+// RemoveConnector represents the `meroxa remove connector` command.
 type RemoveConnector struct {
 	name      string
 	removeCmd *Remove
 }
 
-// RemoveConnectorClient represents the interface for meroxa client
+// RemoveConnectorClient represents the interface for meroxa client.
 type RemoveConnectorClient interface {
 	GetConnectorByName(ctx context.Context, name string) (*meroxa.Connector, error)
 	DeleteConnector(ctx context.Context, id int) error
@@ -69,7 +69,7 @@ func (rc *RemoveConnector) output(c *meroxa.Connector) {
 	}
 }
 
-// command represents the `meroxa remove connector` command
+// command represents the `meroxa remove connector` command.
 func (rc *RemoveConnector) command() *cobra.Command {
 	return &cobra.Command{
 		Use:   "connector NAME",

--- a/cmd/meroxa/root/old/remove_connector_test.go
+++ b/cmd/meroxa/root/old/remove_connector_test.go
@@ -113,7 +113,7 @@ func TestRemoveConnectorJSONOutput(t *testing.T) {
 	})
 
 	var parsedOutput meroxa.Connector
-	json.Unmarshal([]byte(output), &parsedOutput)
+	_ = json.Unmarshal([]byte(output), &parsedOutput)
 
 	if !reflect.DeepEqual(c, parsedOutput) {
 		t.Fatalf("not expected output, got \"%s\"", output)

--- a/cmd/meroxa/root/old/remove_endpoint.go
+++ b/cmd/meroxa/root/old/remove_endpoint.go
@@ -30,7 +30,7 @@ type RemoveEndpoint struct {
 	removeCmd *Remove
 }
 
-// RemoveEndpointClient represents the interface for meroxa client
+// RemoveEndpointClient represents the interface for meroxa client.
 type RemoveEndpointClient interface {
 	DeleteEndpoint(ctx context.Context, name string) error
 }
@@ -56,7 +56,7 @@ func (re *RemoveEndpoint) output() {
 	fmt.Printf("endpoint %s successfully removed\n", re.name)
 }
 
-// command represents the `meroxa remove endpoint` command
+// command represents the `meroxa remove endpoint` command.
 func (re *RemoveEndpoint) command() *cobra.Command {
 	return &cobra.Command{
 		Use:     "endpoint NAME",

--- a/cmd/meroxa/root/old/remove_pipeline.go
+++ b/cmd/meroxa/root/old/remove_pipeline.go
@@ -32,7 +32,7 @@ type RemovePipeline struct {
 	removeCmd *Remove
 }
 
-// RemovePipelineClient represents the interface for meroxa client
+// RemovePipelineClient represents the interface for meroxa client.
 type RemovePipelineClient interface {
 	GetPipelineByName(ctx context.Context, name string) (*meroxa.Pipeline, error)
 	DeletePipeline(ctx context.Context, id int) error
@@ -68,7 +68,7 @@ func (rp *RemovePipeline) output(p *meroxa.Pipeline) {
 	}
 }
 
-// command represents the `meroxa remove pipeline` command
+// command represents the `meroxa remove pipeline` command.
 func (rp *RemovePipeline) command() *cobra.Command {
 	return &cobra.Command{
 		Use:   "pipeline NAME",
@@ -83,6 +83,9 @@ func (rp *RemovePipeline) command() *cobra.Command {
 			}
 
 			p, err := rp.execute(cmd.Context(), c)
+			if err != nil {
+				return err
+			}
 
 			rp.output(p)
 

--- a/cmd/meroxa/root/old/remove_pipeline_test.go
+++ b/cmd/meroxa/root/old/remove_pipeline_test.go
@@ -111,7 +111,7 @@ func TestRemovePipelineJSONOutput(t *testing.T) {
 	})
 
 	var parsedOutput meroxa.Pipeline
-	json.Unmarshal([]byte(output), &parsedOutput)
+	_ = json.Unmarshal([]byte(output), &parsedOutput)
 
 	if !reflect.DeepEqual(r, parsedOutput) {
 		t.Fatalf("not expected output, got \"%s\"", output)

--- a/cmd/meroxa/root/old/remove_resource.go
+++ b/cmd/meroxa/root/old/remove_resource.go
@@ -32,7 +32,7 @@ type RemoveResource struct {
 	removeCmd *Remove
 }
 
-// RemoveResourceClient represents the interface for meroxa client
+// RemoveResourceClient represents the interface for meroxa client.
 type RemoveResourceClient interface {
 	GetResourceByName(ctx context.Context, name string) (*meroxa.Resource, error)
 	DeleteResource(ctx context.Context, id int) error
@@ -67,7 +67,7 @@ func (rr *RemoveResource) output(r *meroxa.Resource) {
 	}
 }
 
-// command represents the `meroxa remove resource` command
+// command represents the `meroxa remove resource` command.
 func (rr *RemoveResource) command() *cobra.Command {
 	return &cobra.Command{
 		Use:   "resource NAME",
@@ -77,13 +77,11 @@ func (rr *RemoveResource) command() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := global.NewClient()
-
 			if err != nil {
 				return err
 			}
 
 			r, err := rr.execute(cmd.Context(), c)
-
 			if err != nil {
 				return err
 			}

--- a/cmd/meroxa/root/old/remove_resource_test.go
+++ b/cmd/meroxa/root/old/remove_resource_test.go
@@ -111,7 +111,7 @@ func TestRemoveResourceJSONOutput(t *testing.T) {
 	})
 
 	var parsedOutput meroxa.Resource
-	json.Unmarshal([]byte(output), &parsedOutput)
+	_ = json.Unmarshal([]byte(output), &parsedOutput)
 
 	if !reflect.DeepEqual(r, parsedOutput) {
 		t.Fatalf("not expected output, got \"%s\"", output)

--- a/cmd/meroxa/root/old/update.go
+++ b/cmd/meroxa/root/old/update.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// UpdateCmd represents the `meroxa update` command
+// UpdateCmd represents the `meroxa update` command.
 func UpdateCmd() *cobra.Command {
 	updateCmd := &cobra.Command{
 		Use:   "update",

--- a/cmd/meroxa/root/old/update_connector.go
+++ b/cmd/meroxa/root/old/update_connector.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// UpdateConnectorCmd represents the `meroxa update connector` command
+// UpdateConnectorCmd represents the `meroxa update connector` command.
 func UpdateConnectorCmd() *cobra.Command {
 	var state string
 
@@ -71,7 +71,7 @@ func UpdateConnectorCmd() *cobra.Command {
 
 	// TODO: Validate state has to be either of pause|resume|restart
 	updateConnectorCmd.Flags().StringVarP(&state, "state", "", "", "connector state")
-	updateConnectorCmd.MarkFlagRequired("state")
+	_ = updateConnectorCmd.MarkFlagRequired("state")
 
 	return updateConnectorCmd
 }

--- a/cmd/meroxa/root/old/update_connector_test.go
+++ b/cmd/meroxa/root/old/update_connector_test.go
@@ -31,7 +31,7 @@ func TestUpdateConnectorCmd(t *testing.T) {
 		rootCmd.SetOut(b)
 		rootCmd.SetErr(b)
 		rootCmd.SetArgs(tt.args)
-		rootCmd.Execute()
+		_ = rootCmd.Execute()
 		output, err := ioutil.ReadAll(b)
 
 		if err != nil {

--- a/cmd/meroxa/root/old/update_pipeline.go
+++ b/cmd/meroxa/root/old/update_pipeline.go
@@ -89,7 +89,7 @@ func (up *UpdatePipeline) execute(ctx context.Context, c UpdatePipelineClient) (
 		if up.metadata != "" {
 			metadata := map[string]interface{}{}
 
-			err := json.Unmarshal([]byte(up.metadata), &metadata)
+			err = json.Unmarshal([]byte(up.metadata), &metadata)
 			if err != nil {
 				return p, err
 			}
@@ -114,7 +114,7 @@ func (up *UpdatePipeline) output(p *meroxa.Pipeline) {
 	}
 }
 
-// command represents the `meroxa update pipeline` command
+// command represents the `meroxa update pipeline` command.
 func (up *UpdatePipeline) command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pipeline NAME",

--- a/cmd/meroxa/root/old/update_pipeline_test.go
+++ b/cmd/meroxa/root/old/update_pipeline_test.go
@@ -250,7 +250,7 @@ func TestUpdatePipelineJSONOutput(t *testing.T) {
 	})
 
 	var parsedOutput meroxa.Pipeline
-	json.Unmarshal([]byte(output), &parsedOutput)
+	_ = json.Unmarshal([]byte(output), &parsedOutput)
 
 	if !reflect.DeepEqual(r, parsedOutput) {
 		t.Fatalf("not expected output, got \"%s\"", output)

--- a/cmd/meroxa/root/old/update_resource.go
+++ b/cmd/meroxa/root/old/update_resource.go
@@ -108,7 +108,7 @@ func (ur *UpdateResource) output(res *meroxa.Resource) {
 	}
 }
 
-// UpdateResourceCmd represents the `meroxa update resource` command
+// UpdateResourceCmd represents the `meroxa update resource` command.
 func (ur *UpdateResource) command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "resource NAME",

--- a/cmd/meroxa/root/old/update_resource_test.go
+++ b/cmd/meroxa/root/old/update_resource_test.go
@@ -106,7 +106,6 @@ func TestUpdateResourceExecutionWithNewName(t *testing.T) {
 		if !reflect.DeepEqual(got, &r) {
 			t.Fatalf("expected \"%v\", got \"%v\"", &r, got)
 		}
-
 	})
 
 	expected := fmt.Sprintf("Updating %s resource...", r.Name)
@@ -132,7 +131,7 @@ func TestUpdateResourceExecutionWithNewMetadata(t *testing.T) {
 
 	var metadata map[string]interface{}
 
-	json.Unmarshal([]byte(ur.metadata), &metadata)
+	_ = json.Unmarshal([]byte(ur.metadata), &metadata)
 	nr := meroxa.UpdateResourceInput{
 		Metadata: metadata,
 	}
@@ -287,7 +286,7 @@ func TestUpdateResourceJSONOutput(t *testing.T) {
 	})
 
 	var parsedOutput meroxa.Resource
-	json.Unmarshal([]byte(output), &parsedOutput)
+	_ = json.Unmarshal([]byte(output), &parsedOutput)
 
 	if !reflect.DeepEqual(r, parsedOutput) {
 		t.Fatalf("not expected output, got \"%s\"", output)

--- a/cmd/meroxa/root/old/update_test.go
+++ b/cmd/meroxa/root/old/update_test.go
@@ -28,7 +28,7 @@ func TestUpdateCmd(t *testing.T) {
 	b := bytes.NewBufferString("")
 	rootCmd.SetOut(b)
 	rootCmd.SetArgs([]string{"update"})
-	rootCmd.Execute()
+	_ = rootCmd.Execute()
 
 	out, err := ioutil.ReadAll(b)
 

--- a/cmd/meroxa/root/old/version.go
+++ b/cmd/meroxa/root/old/version.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// VersionCmd represents the `meroxa version` command
+// VersionCmd represents the `meroxa version` command.
 func VersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",

--- a/cmd/meroxa/root/old/whoami.go
+++ b/cmd/meroxa/root/old/whoami.go
@@ -52,7 +52,7 @@ func (gu *GetUser) output(user *meroxa.User) {
 	}
 }
 
-// Command represents the `meroxa whoami` command
+// Command represents the `meroxa whoami` command.
 func (gu *GetUser) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "whoami",

--- a/cmd/meroxa/root/old/whoami_test.go
+++ b/cmd/meroxa/root/old/whoami_test.go
@@ -3,7 +3,6 @@ package old
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -49,7 +48,7 @@ func TestWhoAmIOutput(t *testing.T) {
 		gu.output(&u)
 	})
 
-	expected := fmt.Sprintf("%s", u.Email)
+	expected := u.Email
 
 	if !strings.Contains(output, expected) {
 		t.Fatalf("expected output \"%s\" got \"%s\"", expected, output)
@@ -66,7 +65,7 @@ func TestWhoAmIOutputJSONOutput(t *testing.T) {
 	})
 
 	var parsedOutput meroxa.User
-	json.Unmarshal([]byte(output), &parsedOutput)
+	_ = json.Unmarshal([]byte(output), &parsedOutput)
 
 	if !reflect.DeepEqual(u, parsedOutput) {
 		t.Fatalf("not expected output, got \"%s\"", output)

--- a/cmd/meroxa/root/root.go
+++ b/cmd/meroxa/root/root.go
@@ -61,7 +61,7 @@ meroxa list resource-types`,
 
 	// Subcommands
 	cmd.AddCommand(builder.BuildCobraCommand(&add.Add{}))
-	cmd.AddCommand(old.ApiCmd())
+	cmd.AddCommand(old.APICmd())
 	cmd.AddCommand(old.BillingCmd())
 	cmd.AddCommand(old.CompletionCmd())
 	cmd.AddCommand((&old.Connect{}).Command())

--- a/cmd/meroxa/root/root_test.go
+++ b/cmd/meroxa/root/root_test.go
@@ -47,9 +47,12 @@ func TestCmd(t *testing.T) {
 	cmd := Cmd()
 	var b bytes.Buffer
 	cmd.SetOut(&b)
-	cmd.Execute()
-	out, err := ioutil.ReadAll(&b)
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
 
+	out, err := ioutil.ReadAll(&b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/magiconair/properties v1.8.4 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20210426102830-ca17779c22ac
+	github.com/meroxa/meroxa-go v0.0.0-20210426150351-91d304d1dc66
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pelletier/go-toml v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/meroxa/meroxa-go v0.0.0-20210426102830-ca17779c22ac h1:LHSAiAS/buwI++WBLmWKH3lxuRqruoR+FBaKK2gtA1o=
-github.com/meroxa/meroxa-go v0.0.0-20210426102830-ca17779c22ac/go.mod h1:kU+28Y6AfKRPbZ8kt1zYtpTXzpuTqFZg2PjyO7c+cHU=
+github.com/meroxa/meroxa-go v0.0.0-20210426150351-91d304d1dc66 h1:V7FhfUt78WHaToA7l6Z2X1bt/CDuwlamdwOhzt8qPeI=
+github.com/meroxa/meroxa-go v0.0.0-20210426150351-91d304d1dc66/go.mod h1:kU+28Y6AfKRPbZ8kt1zYtpTXzpuTqFZg2PjyO7c+cHU=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/mock-server/main.go
+++ b/mock-server/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -12,7 +13,6 @@ import (
 var memDB map[string]map[string]interface{}
 
 func main() {
-
 	// Init in-memory database
 	memDB = make(map[string]map[string]interface{})
 
@@ -24,7 +24,10 @@ func main() {
 	r.HandleFunc("/{object}/{id}", describeHandler).Methods("GET")
 
 	// Run Server
-	http.ListenAndServe(":8080", r)
+	err := http.ListenAndServe(":8080", r)
+	if err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
 }
 
 func listHandler(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +40,7 @@ func listHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, string(responseJSON))
+	_, _ = w.Write(responseJSON)
 }
 
 func createHandler(w http.ResponseWriter, r *http.Request) {
@@ -59,7 +62,7 @@ func createHandler(w http.ResponseWriter, r *http.Request) {
 	nextID := strconv.Itoa(len(memDB[object]) + 1)
 	memDB[object][nextID] = o
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, "%s created", object)
+	_, _ = fmt.Fprintf(w, "%s created", object)
 }
 
 func describeHandler(w http.ResponseWriter, r *http.Request) {
@@ -74,5 +77,5 @@ func describeHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 	w.WriteHeader(http.StatusOK)
-	fmt.Fprintf(w, string(responseJSON))
+	_, _ = w.Write(responseJSON)
 }

--- a/utils/display.go
+++ b/utils/display.go
@@ -168,7 +168,7 @@ func PrintConnectorsTable(connectors []*meroxa.Connector) {
 				{Text: conn.Type},
 				{Text: streamStr},
 				{Text: conn.State},
-				{Text: fmt.Sprintf("%s", conn.PipelineName)},
+				{Text: conn.PipelineName},
 			}
 
 			table.Body.Cells = append(table.Body.Cells, r)

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -3,10 +3,11 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/meroxa/meroxa-go"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/meroxa/meroxa-go"
 )
 
 func TestResourcesTable(t *testing.T) {
@@ -210,5 +211,5 @@ func TestPipelinesTable(t *testing.T) {
 
 func deepCopy(a, b interface{}) {
 	byt, _ := json.Marshal(a)
-	json.Unmarshal(byt, b)
+	_ = json.Unmarshal(byt, b)
 }

--- a/utils/tests.go
+++ b/utils/tests.go
@@ -2,11 +2,12 @@ package utils
 
 import (
 	"bytes"
-	"github.com/meroxa/meroxa-go"
-	"github.com/spf13/pflag"
 	"io"
 	"math/rand"
 	"os"
+
+	"github.com/meroxa/meroxa-go"
+	"github.com/spf13/pflag"
 )
 
 func GeneratePipeline() meroxa.Pipeline {
@@ -52,7 +53,7 @@ func IsFlagRequired(flag *pflag.Flag) bool {
 	return false
 }
 
-// CaptureOutput is used to capture stdout to be compared on tests
+// CaptureOutput is used to capture stdout to be compared on tests.
 func CaptureOutput(f func()) string {
 	old := os.Stdout // keep backup of the real stdout
 	r, w, _ := os.Pipe()
@@ -64,13 +65,13 @@ func CaptureOutput(f func()) string {
 	// copy the output in a separate goroutine so printing can't block indefinitely
 	go func() {
 		var buf bytes.Buffer
-		io.Copy(&buf, r)
+		_, _ = io.Copy(&buf, r)
 		outC <- buf.String()
 	}()
 	f()
 
 	// back to normal state
-	w.Close()
+	_ = w.Close()
 	os.Stdout = old // restoring the real stdout
 	out := <-outC
 	return out

--- a/vendor/github.com/meroxa/meroxa-go/dump.go
+++ b/vendor/github.com/meroxa/meroxa-go/dump.go
@@ -75,20 +75,19 @@ func (d *dumpTransport) dumpResponse(resp *http.Response) error {
 }
 
 func (d *dumpTransport) obfuscate(text string) string {
+	if len(text) < 5 {
+		// hide whole text
+		return strings.Repeat("*", len(text))
+	}
+
 	const (
-		visibleSuffixLen = 4
-		minStarsLen      = 4
-		star             = "*"
+		maxVisibleLen = 7
 	)
 
-	if len(text) < minStarsLen {
-		// hide whole text
-		return strings.Repeat(star, len(text))
-	} else if len(text) < minStarsLen+visibleSuffixLen {
-		// hide only minStarsLen
-		return strings.Repeat(star, minStarsLen) + text[minStarsLen:]
-	} else {
-		// hide everything except visibleSuffixLen
-		return strings.Repeat(star, minStarsLen) + text[len(text)-visibleSuffixLen:]
+	visibleLen := (len(text) - 3) / 2
+	if visibleLen > maxVisibleLen {
+		visibleLen = maxVisibleLen
 	}
+
+	return text[:visibleLen] + "..." + text[len(text)-visibleLen:]
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -43,7 +43,7 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 ## explicit
 github.com/mattn/go-runewidth
-# github.com/meroxa/meroxa-go v0.0.0-20210426102830-ca17779c22ac
+# github.com/meroxa/meroxa-go v0.0.0-20210426150351-91d304d1dc66
 ## explicit
 github.com/meroxa/meroxa-go
 # github.com/mitchellh/mapstructure v1.4.1


### PR DESCRIPTION
# Description of change

Fixes all linter warnings and adds a Github Action which executes the golangci-lint workflow.

Note that this branch is based on https://github.com/meroxa/cli/pull/130, diff will look nicer once that branch is merged.

# Type of change

- [X]  New feature
- [X]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [X]  Unit Tests
- [ ]  Tested in staging