### PR TITLE
[PLATFORM-547] chore: Remove generated timestamp for web docs

### DIFF
--- a/docs/cmd/www/meroxa-add-resource.md
+++ b/docs/cmd/www/meroxa-add-resource.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa add resource"
 slug: meroxa-add-resource
 url: /cli/meroxa-add-resource/

--- a/docs/cmd/www/meroxa-add.md
+++ b/docs/cmd/www/meroxa-add.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa add"
 slug: meroxa-add
 url: /cli/meroxa-add/

--- a/docs/cmd/www/meroxa-api.md
+++ b/docs/cmd/www/meroxa-api.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa api"
 slug: meroxa-api
 url: /cli/meroxa-api/

--- a/docs/cmd/www/meroxa-billing.md
+++ b/docs/cmd/www/meroxa-billing.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa billing"
 slug: meroxa-billing
 url: /cli/meroxa-billing/

--- a/docs/cmd/www/meroxa-completion.md
+++ b/docs/cmd/www/meroxa-completion.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa completion"
 slug: meroxa-completion
 url: /cli/meroxa-completion/

--- a/docs/cmd/www/meroxa-connect.md
+++ b/docs/cmd/www/meroxa-connect.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa connect"
 slug: meroxa-connect
 url: /cli/meroxa-connect/

--- a/docs/cmd/www/meroxa-create-connector.md
+++ b/docs/cmd/www/meroxa-create-connector.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa create connector"
 slug: meroxa-create-connector
 url: /cli/meroxa-create-connector/

--- a/docs/cmd/www/meroxa-create-endpoint.md
+++ b/docs/cmd/www/meroxa-create-endpoint.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa create endpoint"
 slug: meroxa-create-endpoint
 url: /cli/meroxa-create-endpoint/

--- a/docs/cmd/www/meroxa-create-pipeline.md
+++ b/docs/cmd/www/meroxa-create-pipeline.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa create pipeline"
 slug: meroxa-create-pipeline
 url: /cli/meroxa-create-pipeline/

--- a/docs/cmd/www/meroxa-create.md
+++ b/docs/cmd/www/meroxa-create.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa create"
 slug: meroxa-create
 url: /cli/meroxa-create/

--- a/docs/cmd/www/meroxa-describe-connector.md
+++ b/docs/cmd/www/meroxa-describe-connector.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa describe connector"
 slug: meroxa-describe-connector
 url: /cli/meroxa-describe-connector/

--- a/docs/cmd/www/meroxa-describe-endpoint.md
+++ b/docs/cmd/www/meroxa-describe-endpoint.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa describe endpoint"
 slug: meroxa-describe-endpoint
 url: /cli/meroxa-describe-endpoint/

--- a/docs/cmd/www/meroxa-describe-resource.md
+++ b/docs/cmd/www/meroxa-describe-resource.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa describe resource"
 slug: meroxa-describe-resource
 url: /cli/meroxa-describe-resource/

--- a/docs/cmd/www/meroxa-describe.md
+++ b/docs/cmd/www/meroxa-describe.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa describe"
 slug: meroxa-describe
 url: /cli/meroxa-describe/

--- a/docs/cmd/www/meroxa-list-connectors.md
+++ b/docs/cmd/www/meroxa-list-connectors.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa list connectors"
 slug: meroxa-list-connectors
 url: /cli/meroxa-list-connectors/

--- a/docs/cmd/www/meroxa-list-endpoint.md
+++ b/docs/cmd/www/meroxa-list-endpoint.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa list endpoint"
 slug: meroxa-list-endpoint
 url: /cli/meroxa-list-endpoint/

--- a/docs/cmd/www/meroxa-list-pipelines.md
+++ b/docs/cmd/www/meroxa-list-pipelines.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa list pipelines"
 slug: meroxa-list-pipelines
 url: /cli/meroxa-list-pipelines/

--- a/docs/cmd/www/meroxa-list-resource-types.md
+++ b/docs/cmd/www/meroxa-list-resource-types.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa list resource-types"
 slug: meroxa-list-resource-types
 url: /cli/meroxa-list-resource-types/

--- a/docs/cmd/www/meroxa-list-resources.md
+++ b/docs/cmd/www/meroxa-list-resources.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa list resources"
 slug: meroxa-list-resources
 url: /cli/meroxa-list-resources/

--- a/docs/cmd/www/meroxa-list-transforms.md
+++ b/docs/cmd/www/meroxa-list-transforms.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa list transforms"
 slug: meroxa-list-transforms
 url: /cli/meroxa-list-transforms/

--- a/docs/cmd/www/meroxa-list.md
+++ b/docs/cmd/www/meroxa-list.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa list"
 slug: meroxa-list
 url: /cli/meroxa-list/

--- a/docs/cmd/www/meroxa-login.md
+++ b/docs/cmd/www/meroxa-login.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa login"
 slug: meroxa-login
 url: /cli/meroxa-login/

--- a/docs/cmd/www/meroxa-logout.md
+++ b/docs/cmd/www/meroxa-logout.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa logout"
 slug: meroxa-logout
 url: /cli/meroxa-logout/

--- a/docs/cmd/www/meroxa-logs-connector.md
+++ b/docs/cmd/www/meroxa-logs-connector.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa logs connector"
 slug: meroxa-logs-connector
 url: /cli/meroxa-logs-connector/

--- a/docs/cmd/www/meroxa-logs.md
+++ b/docs/cmd/www/meroxa-logs.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa logs"
 slug: meroxa-logs
 url: /cli/meroxa-logs/

--- a/docs/cmd/www/meroxa-open-billing.md
+++ b/docs/cmd/www/meroxa-open-billing.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa open billing"
 slug: meroxa-open-billing
 url: /cli/meroxa-open-billing/

--- a/docs/cmd/www/meroxa-open.md
+++ b/docs/cmd/www/meroxa-open.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa open"
 slug: meroxa-open
 url: /cli/meroxa-open/

--- a/docs/cmd/www/meroxa-remove-connector.md
+++ b/docs/cmd/www/meroxa-remove-connector.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa remove connector"
 slug: meroxa-remove-connector
 url: /cli/meroxa-remove-connector/

--- a/docs/cmd/www/meroxa-remove-endpoint.md
+++ b/docs/cmd/www/meroxa-remove-endpoint.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa remove endpoint"
 slug: meroxa-remove-endpoint
 url: /cli/meroxa-remove-endpoint/

--- a/docs/cmd/www/meroxa-remove-pipeline.md
+++ b/docs/cmd/www/meroxa-remove-pipeline.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa remove pipeline"
 slug: meroxa-remove-pipeline
 url: /cli/meroxa-remove-pipeline/

--- a/docs/cmd/www/meroxa-remove-resource.md
+++ b/docs/cmd/www/meroxa-remove-resource.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa remove resource"
 slug: meroxa-remove-resource
 url: /cli/meroxa-remove-resource/

--- a/docs/cmd/www/meroxa-remove.md
+++ b/docs/cmd/www/meroxa-remove.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa remove"
 slug: meroxa-remove
 url: /cli/meroxa-remove/

--- a/docs/cmd/www/meroxa-update-connector.md
+++ b/docs/cmd/www/meroxa-update-connector.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa update connector"
 slug: meroxa-update-connector
 url: /cli/meroxa-update-connector/

--- a/docs/cmd/www/meroxa-update-pipeline.md
+++ b/docs/cmd/www/meroxa-update-pipeline.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa update pipeline"
 slug: meroxa-update-pipeline
 url: /cli/meroxa-update-pipeline/

--- a/docs/cmd/www/meroxa-update-resource.md
+++ b/docs/cmd/www/meroxa-update-resource.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa update resource"
 slug: meroxa-update-resource
 url: /cli/meroxa-update-resource/

--- a/docs/cmd/www/meroxa-update.md
+++ b/docs/cmd/www/meroxa-update.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa update"
 slug: meroxa-update
 url: /cli/meroxa-update/

--- a/docs/cmd/www/meroxa-version.md
+++ b/docs/cmd/www/meroxa-version.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa version"
 slug: meroxa-version
 url: /cli/meroxa-version/

--- a/docs/cmd/www/meroxa-whoami.md
+++ b/docs/cmd/www/meroxa-whoami.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa whoami"
 slug: meroxa-whoami
 url: /cli/meroxa-whoami/

--- a/docs/cmd/www/meroxa.md
+++ b/docs/cmd/www/meroxa.md
@@ -1,6 +1,6 @@
 ---
-createdAt: 2021-04-21T15:46:44+02:00
-updatedAt: 2021-04-21T15:46:44+02:00
+createdAt: 
+updatedAt: 
 title: "meroxa"
 slug: meroxa
 url: /cli/meroxa/

--- a/gen-docs/main.go
+++ b/gen-docs/main.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/meroxa/cli/cmd/meroxa/root"
 	"github.com/spf13/cobra"
@@ -62,12 +61,11 @@ func generateMarkdownPages(rootCmd *cobra.Command) error {
 
 func generateDocsDotComPages(rootCmd *cobra.Command) error {
 	filePrepender := func(filename string) string {
-		createdAt := time.Now().Format(time.RFC3339)
 		name := filepath.Base(filename)
 		base := strings.TrimSuffix(name, path.Ext(name))
 		slug := strings.Replace(base, "_", "-", -1)
 		url := "/cli/" + strings.ToLower(slug) + "/"
-		return fmt.Sprintf(fmTemplate, createdAt, createdAt, strings.Replace(base, "_", " ", -1), slug, url)
+		return fmt.Sprintf(fmTemplate, "", "", strings.Replace(base, "_", " ", -1), slug, url)
 	}
 
 	linkHandler := func(name string) string {


### PR DESCRIPTION
# Description of change

Fixes https://meroxa.atlassian.net/browse/PLATFORM-547

Since we started generating documentation for the web (https://github.com/meroxa/cli/pull/122), we're updating the .md documents every time we compile based on this line https://github.com/meroxa/cli/blob/master/gen-docs/main.go#L66.

This makes working with git diffs very difficult since even if you compile a second later, the documents would be different. This makes working with the CLI very difficult as a developer.

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

![image](https://user-images.githubusercontent.com/306015/116233577-c2620b80-a75b-11eb-841b-50c8af2bb5fb.png)

**After this pull-request**

Nothing would see as changed unless it's actually changed.

# Additional references

Per @anaptfox , we don't care as much as their values bur rather than those two fields are part of the template.