### PR TITLE
[PLATFORM-675] fix: reference to old docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,6 +34,8 @@ _Include how it looks now_
 
 *Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*
 
-- [ ] Suggested an edit to the appropiate CLI version. To see the list of edits (e.g. v1.0): https://dash.readme.com/project/meroxa/v1.0/suggested
+You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.
 
-*Provide link:*
+✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨
+
+*Provide PR link:* 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ We believe that anyone should be empowered to leverage real-time data. Using the
 
 [Website](https://meroxa.io) |
 [Documentation](https://docs.meroxa.com/) |
-[Installation Guide](https://docs.meroxa.com/docs/installation-guide) |
+[Installation Guide](https://docs.meroxa.com/cli/installation-guide) |
 [Contribution Guide](CONTRIBUTING.md) |
 [Twitter](https://twitter.com/meroxadata)
 
 ## Documentation
 
-Meroxa is documented publicly in https://docs.meroxa.com/docs, but on each build we also generate Markdown files for each command, exposing the available commands and help for each one. Check it out at [docs/commands/meroxa](docs/commands/meroxa.md).
+Meroxa is documented publicly in https://docs.meroxa.com/, but on each build we also generate Markdown files for each command, exposing the available commands and help for each one. Check it out at [docs/cmd/md/meroxa](docs/cmd/md/meroxa.md).
 
 ## Contributing
 


### PR DESCRIPTION
# Description of change

Updates our CLI repository with some broken links to the docs.

Fixes https://meroxa.atlassian.net/browse/PLATFORM-675

# Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [x]  Documentation