### PR TITLE
[PLATFORM-662] feat: Add environment command

### DIFF
--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -41,6 +41,12 @@ type CommandWithDocs interface {
 	Docs() Docs
 }
 
+type CommandWithHidden interface {
+	Command
+	// Hidden returns the desired hidden value for the command.
+	Hidden() bool
+}
+
 // Docs will be shown to the user when typing 'help' as well as in generated docs.
 type Docs struct {
 	// Short is the short description shown in the 'help' output.
@@ -130,6 +136,7 @@ func BuildCobraCommand(c Command) *cobra.Command {
 	buildCommandWithClient(cmd, c)
 	buildCommandWithConfirm(cmd, c)
 	buildCommandWithExecute(cmd, c)
+	buildCommandWithHidden(cmd, c)
 	buildCommandWithSubCommands(cmd, c)
 
 	return cmd
@@ -145,6 +152,15 @@ func buildCommandWithDocs(cmd *cobra.Command, c Command) {
 	cmd.Long = docs.Long
 	cmd.Short = docs.Short
 	cmd.Example = docs.Example
+}
+
+func buildCommandWithHidden(cmd *cobra.Command, c Command) {
+	v, ok := c.(CommandWithHidden)
+	if !ok {
+		return
+	}
+
+	cmd.Hidden = v.Hidden()
 }
 
 func buildCommandWithAliases(cmd *cobra.Command, c Command) {

--- a/cmd/meroxa/global/config.go
+++ b/cmd/meroxa/global/config.go
@@ -12,6 +12,8 @@ import (
 const (
 	// The environment variable prefix of all environment variables bound to our command line flags.
 	envPrefix = "MEROXA"
+	envName   = "config"
+	envType   = "env"
 )
 
 func readConfig() (*viper.Viper, error) {
@@ -35,8 +37,8 @@ func readConfig() (*viper.Viper, error) {
 		}
 
 		cfg.AddConfigPath(configDir)
-		cfg.SetConfigName("config")
-		cfg.SetConfigType("env")
+		cfg.SetConfigName(envName)
+		cfg.SetConfigType(envType)
 	}
 
 	// Attempt to read the config file, gracefully ignoring errors

--- a/cmd/meroxa/global/global.go
+++ b/cmd/meroxa/global/global.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	Version string
-	Config  *viper.Viper // TODO remove this global variable, read on demand
+	Config  *viper.Viper
 )
 
 var (

--- a/cmd/meroxa/root/env/env.go
+++ b/cmd/meroxa/root/env/env.go
@@ -1,0 +1,107 @@
+/*
+Copyright © 2021 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impliee.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/meroxa/cli/cmd/meroxa/global"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+)
+
+var (
+	_ builder.CommandWithDocs    = (*Env)(nil)
+	_ builder.CommandWithLogger  = (*Env)(nil)
+	_ builder.CommandWithExecute = (*Env)(nil)
+	_ builder.CommandWithHidden  = (*Env)(nil)
+)
+
+type Env struct {
+	logger log.Logger
+}
+
+func (e *Env) Usage() string {
+	return "env"
+}
+
+func (e *Env) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Show Meroxa CLI environment details",
+	}
+}
+
+func (e *Env) Execute(ctx context.Context) error {
+	path := global.Config.ConfigFileUsed()
+
+	var env struct {
+		Path   string                 `json:"path"`
+		Config map[string]interface{} `json:"config"`
+	}
+
+	env.Path = path
+	env.Config = global.Config.AllSettings()
+
+	cfgSettings := global.Config.AllSettings()
+	cfgKeySettings := global.Config.AllKeys()
+
+	sort.Strings(cfgKeySettings)
+
+	e.logger.Infof(ctx, "Using meroxa config located in %q\n\n", path)
+
+	for _, k := range cfgKeySettings {
+		v := e.obfuscate(k, fmt.Sprintf("%s", cfgSettings[k]))
+		e.logger.Infof(ctx, "%s: %s", k, v)
+	}
+
+	e.logger.JSON(ctx, env)
+	return nil
+}
+
+func (e *Env) Hidden() bool {
+	return true
+}
+
+func (e *Env) Logger(logger log.Logger) {
+	e.logger = logger
+}
+
+func (e *Env) obfuscate(key, value string) string {
+	if !strings.Contains(key, "token") {
+		return value
+	}
+
+	if len(value) < 5 { // nolint:gomnd
+		// hide whole text
+		return strings.Repeat("*", len(value))
+	}
+
+	const (
+		maxVisibleLen = 7
+	)
+
+	visibleLen := (len(value) - 3) / 2
+	if visibleLen > maxVisibleLen {
+		visibleLen = maxVisibleLen
+	}
+
+	return value[:visibleLen] + "..." + value[len(value)-visibleLen:]
+}

--- a/cmd/meroxa/root/env/env_test.go
+++ b/cmd/meroxa/root/env/env_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright © 2021 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or impliee.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/meroxa/cli/cmd/meroxa/global"
+	"github.com/spf13/viper"
+
+	"github.com/meroxa/cli/log"
+)
+
+func TestEnvExecution(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewTestLogger()
+
+	type confEnv struct {
+		Path   string                 `json:"path"`
+		Config map[string]interface{} `json:"config"`
+	}
+
+	var env confEnv
+
+	env.Path = "~/meroxa"
+	env.Config = make(map[string]interface{})
+	env.Config["my-key"] = "my-value"
+	env.Config["my-token"] = "supersecrettokenandverylongaswell"
+
+	cfg := viper.New()
+	cfg.Set("my-key", env.Config["my-key"])
+	cfg.Set("my-token", env.Config["my-token"])
+
+	cfg.SetConfigFile(env.Path)
+	global.Config = cfg
+
+	e := &Env{
+		logger: logger,
+	}
+
+	err := e.Execute(ctx)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	gotLeveledOutput := logger.LeveledOutput()
+	wantLeveledOutput := fmt.Sprintf(`Using meroxa config located in "%s"
+
+my-key: %s
+my-token: superse...gaswell
+`, env.Path, env.Config["my-key"])
+
+	if gotLeveledOutput != wantLeveledOutput {
+		t.Fatalf("expected output:\n%s\ngot:\n%s", wantLeveledOutput, gotLeveledOutput)
+	}
+
+	gotJSONOutput := logger.JSONOutput()
+
+	var gotEnv confEnv
+	err = json.Unmarshal([]byte(gotJSONOutput), &gotEnv)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	if !reflect.DeepEqual(env, gotEnv) {
+		t.Fatalf("expected \"%v\", got \"%v\"", gotEnv, env)
+	}
+}

--- a/cmd/meroxa/root/root.go
+++ b/cmd/meroxa/root/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/meroxa/cli/cmd/meroxa/root/billing"
 	"github.com/meroxa/cli/cmd/meroxa/root/connectors"
 	"github.com/meroxa/cli/cmd/meroxa/root/endpoints"
+	"github.com/meroxa/cli/cmd/meroxa/root/env"
 	"github.com/meroxa/cli/cmd/meroxa/root/open"
 	"github.com/meroxa/cli/cmd/meroxa/root/pipelines"
 	"github.com/meroxa/cli/cmd/meroxa/root/resources"
@@ -85,6 +86,7 @@ meroxa resources list --types
 	cmd.AddCommand(builder.BuildCobraCommand(&connectors.Connect{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&connectors.Connectors{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&endpoints.Endpoints{}))
+	cmd.AddCommand(builder.BuildCobraCommand(&env.Env{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&open.Open{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&pipelines.Pipelines{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&resources.Resources{}))


### PR DESCRIPTION
# Description of change

Occasionally, I wonder where my configuration lives or its content. This command  will help with that.

It's hidden for now, but it'll be available in case we ask customers to run it for us.

This pull-request also adds the option to build hidden commands via builder.

Fixes https://meroxa.atlassian.net/browse/PLATFORM-662

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

**nonexistent command**

```
❯ meroxa env
The Meroxa CLI allows quick and easy access to the Meroxa Data Platform.

Using the CLI you are able to create and manage sophisticated data pipelines
with only a few simple commands. You can get started by listing the supported
resource types:

meroxa resources list --types

Usage:
  meroxa [command]

Available Commands:
  api         Invoke Meroxa API
  auth        Authentication commands for Meroxa
  billing     Open your billing page in a web browser
  completion  Generate completion script
  connect     Connect two resources together
  connectors  Manage connectors on Meroxa
  endpoints   Manage endpoints on Meroxa
  help        Help about any command
  open        Open in a web browser
  pipelines   Manage pipelines on Meroxa
  resources   Manage resources on Meroxa
  transforms  Manage transforms on Meroxa
  version     Display the Meroxa CLI version

Flags:
      --config string      config file
      --debug              display any debugging information
  -h, --help               help for meroxa
      --json               output json
      --timeout duration   set the client timeout (default 10s)

Use "meroxa [command] --help" for more information about a command.
```

**After this pull-request**

Command does not show up in the help / not documented:

```
❯ .m help
The Meroxa CLI allows quick and easy access to the Meroxa Data Platform.

Using the CLI you are able to create and manage sophisticated data pipelines
with only a few simple commands. You can get started by listing the supported
resource types:

meroxa resources list --types

Usage:
  meroxa [command]

Available Commands:
  api         Invoke Meroxa API
  auth        Authentication commands for Meroxa
  billing     Open your billing page in a web browser
  completion  Generate completion script
  connect     Connect two resources together
  connectors  Manage connectors on Meroxa
  endpoints   Manage endpoints on Meroxa
  help        Help about any command
  open        Open in a web browser
  pipelines   Manage pipelines on Meroxa
  resources   Manage resources on Meroxa
  transforms  Manage transforms on Meroxa
  version     Display the Meroxa CLI version

Flags:
      --config string      config file
      --debug              display any debugging information
  -h, --help               help for meroxa
      --json               output json
      --timeout duration   set the client timeout (default 10s)

Use "meroxa [command] --help" for more information about a command.
```

Without `--json`, obfuscate tokens:

```
❯ .m env
Using meroxa config located in "/Users/rb/Library/Application Support/meroxa/config.env"

access_token: eyJhbGc...2xJlQAQ
latest_version: 0.4
refresh_token: psmshcy...oNdCYc3
```

With `--json` , it does not obfuscate it

```
❯ .m env --json
{
	"path": "/Users/rb/Library/Application Support/meroxa/config.env",
	"config": {
		"access_token": "supersecrettokenandverylongaswell",
		"latest_version": "0.4",
		"refresh_token": "supersecrettokenandverylongaswell"
	}
}
```