### PR TITLE
[PLATFORM-676] feat: Set actor on whoami

### DIFF
--- a/cmd/meroxa/root/auth/logout.go
+++ b/cmd/meroxa/root/auth/logout.go
@@ -19,20 +19,22 @@ package auth
 import (
 	"context"
 
+	"github.com/meroxa/cli/config"
 	"github.com/meroxa/cli/log"
 
 	"github.com/meroxa/cli/cmd/meroxa/builder"
-	"github.com/meroxa/cli/cmd/meroxa/global"
 )
 
 var (
 	_ builder.CommandWithDocs    = (*Logout)(nil)
 	_ builder.CommandWithExecute = (*Logout)(nil)
 	_ builder.CommandWithLogger  = (*Logout)(nil)
+	_ builder.CommandWithConfig  = (*Logout)(nil)
 )
 
 type Logout struct {
 	logger log.Logger
+	config config.Config
 }
 
 func (l *Logout) Usage() string {
@@ -49,13 +51,16 @@ func (l *Logout) Logger(logger log.Logger) {
 	l.logger = logger
 }
 
+func (l *Logout) Config(cfg config.Config) {
+	l.config = cfg
+}
+
 func (l *Logout) Execute(ctx context.Context) error {
-	global.Config.Set("ACCESS_TOKEN", "")
-	global.Config.Set("REFRESH_TOKEN", "")
-	err := global.Config.WriteConfig()
-	if err != nil {
-		return err
-	}
+	l.config.Set("ACCESS_TOKEN", "")
+	l.config.Set("REFRESH_TOKEN", "")
+	l.config.Set("ACTOR", "")
+	l.config.Set("ACTOR_UUID", "")
+
 	l.logger.Infof(ctx, "Successfully logged out.")
 	return nil
 }

--- a/cmd/meroxa/root/auth/whoami_test.go
+++ b/cmd/meroxa/root/auth/whoami_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/meroxa/meroxa-go"
-
+	"github.com/meroxa/cli/config"
 	"github.com/meroxa/cli/log"
+	"github.com/meroxa/meroxa-go"
 
 	"github.com/golang/mock/gomock"
 	mock "github.com/meroxa/cli/mock-cmd"
@@ -21,9 +21,12 @@ func TestWhoAmIExecution(t *testing.T) {
 	client := mock.NewMockGetUserClient(ctrl)
 	logger := log.NewTestLogger()
 
+	cfg := config.NewInMemoryConfig()
+
 	w := WhoAmI{
 		logger: logger,
 		client: client,
+		config: cfg,
 	}
 
 	u := meroxa.User{
@@ -64,5 +67,13 @@ func TestWhoAmIExecution(t *testing.T) {
 
 	if !reflect.DeepEqual(gotUser, u) {
 		t.Fatalf("expected \"%v\", got \"%v\"", u, gotUser)
+	}
+
+	if w.config.GetString("ACTOR") != u.Email {
+		t.Fatalf("expected ACTOR key to be %q", u.Email)
+	}
+
+	if w.config.GetString("ACTOR_UUID") != u.UUID {
+		t.Fatalf("expected ACTOR_UUID key to be %q", u.UUID)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,22 @@
+/*
+Copyright © 2021 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+type Config interface {
+	Set(key string, value interface{})
+	GetString(key string) string
+}

--- a/config/in_memory.go
+++ b/config/in_memory.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2021 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+type InMemoryConfig struct {
+	values map[string]interface{}
+}
+
+// NewInMemoryConfig is the constructor for InMemoryConfig.
+func NewInMemoryConfig() *InMemoryConfig {
+	return &InMemoryConfig{
+		values: make(map[string]interface{}),
+	}
+}
+
+func (m *InMemoryConfig) Set(key string, value interface{}) {
+	m.values[key] = value
+}
+
+func (m *InMemoryConfig) GetString(key string) string {
+	return m.values[key].(string)
+}


### PR DESCRIPTION
# Description of change

Fixes https://meroxa.atlassian.net/browse/PLATFORM-676

Starts writing on file / memory (for tests mainly) `ACTOR` and `ACTOR_UUID` towards using this information for emitting metrics on commands usage.

- It also implements config on builder automatically writing on file

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
❯ .m env
Using meroxa config located in "/Users/rb/Library/Application Support/meroxa/config.env"

access_token: eyJhbGc...JRuUKjQ
latest_version: 0.4
refresh_token: ab_c6CD...n54qWoS
```

**After this pull-request**

```
❯ .m whoami
raul@meroxa.io

❯ .m env
Using meroxa config located in "/Users/rb/Library/Application Support/meroxa/config.env"

access_token: eyJhbGc...JRuUKjQ
actor: raul@meroxa.io
actor_uuid: my-uuid
latest_version: 0.4
refresh_token: ab_c6CD...n54qWoS
```
