### PR TITLE
chore: Rename env name for metrics key

### DIFF
--- a/cmd/meroxa/global/metrics.go
+++ b/cmd/meroxa/global/metrics.go
@@ -31,7 +31,7 @@ import (
 func NewPublisher() cased.Publisher {
 	var options []cased.PublisherOption
 
-	casedAPIKey := Config.GetString("CASED_API_KEY")
+	casedAPIKey := Config.GetString("CASED_PUBLISH_KEY")
 
 	if casedAPIKey != "" {
 		options = append(options, cased.WithPublishKey(casedAPIKey))

--- a/cmd/meroxa/global/metrics_test.go
+++ b/cmd/meroxa/global/metrics_test.go
@@ -185,7 +185,7 @@ func TestNewPublisherWithCasedAPIKey(t *testing.T) {
 	defer clearConfiguration()
 
 	apiKey := "8c32e3b7-d0e7-4650-a82b-e85e6a8d56fa"
-	Config.Set("CASED_API_KEY", apiKey)
+	Config.Set("CASED_PUBLISH_KEY", apiKey)
 
 	got := NewPublisher()
 


### PR DESCRIPTION
# Description of change

Uses the same one as in [API](https://github.com/meroxa/platform-api/blob/9590cb367ce10a82c9d609c4a07dff299b5e9980/cmd/api/config/config.go#L52) so it's consistent.

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging