### PR TITLE
add MEROXA_ prefix

### DIFF
--- a/cmd/meroxa/global/client.go
+++ b/cmd/meroxa/global/client.go
@@ -98,8 +98,8 @@ func GetCLIUserInfo() (actor, actorUUID string, err error) {
 }
 
 func GetUserToken() (accessToken, refreshToken string, err error) {
-	accessToken = Config.GetString("ACCESS_TOKEN")
-	refreshToken = Config.GetString("REFRESH_TOKEN")
+	accessToken = Config.GetString("MEROXA_ACCESS_TOKEN")
+	refreshToken = Config.GetString("MEROXA_REFRESH_TOKEN")
 	if accessToken == "" && refreshToken == "" {
 		// we need at least one token for creating an authenticated client
 		return "", "", errors.New("please login or signup by running 'meroxa login'")
@@ -146,7 +146,7 @@ func NewClient() (*meroxa.Client, error) {
 
 // onTokenRefreshed tries to save the new token in the config.
 func onTokenRefreshed(token *oauth2.Token) {
-	Config.Set("ACCESS_TOKEN", token.AccessToken)
-	Config.Set("REFRESH_TOKEN", token.RefreshToken)
+	Config.Set("MEROXA_ACCESS_TOKEN", token.AccessToken)
+	Config.Set("MEROXA_REFRESH_TOKEN", token.RefreshToken)
 	_ = Config.WriteConfig() // ignore error, it's a best effort
 }

--- a/cmd/meroxa/global/metrics_test.go
+++ b/cmd/meroxa/global/metrics_test.go
@@ -302,8 +302,8 @@ func TestAddUserInfo(t *testing.T) {
 	meroxaUserUUID := "ff45a74a-4fc1-49a5-8fa5-f1762703b7e8"
 
 	// Makes sure user is logged in
-	Config.Set("ACCESS_TOKEN", "access-token")
-	Config.Set("REFRESH_TOKEN", "refresh-token")
+	Config.Set("MEROXA_ACCESS_TOKEN", "access-token")
+	Config.Set("MEROXA_REFRESH_TOKEN", "refresh-token")
 
 	Config.Set("ACTOR", meroxaUser)
 	Config.Set("ACTOR_UUID", meroxaUserUUID)

--- a/cmd/meroxa/root/auth/login.go
+++ b/cmd/meroxa/root/auth/login.go
@@ -133,8 +133,8 @@ func (l *Login) authorizeUser(ctx context.Context, clientID, authDomain, redirec
 			return
 		}
 
-		l.config.Set("ACCESS_TOKEN", accessToken)
-		l.config.Set("REFRESH_TOKEN", refreshToken)
+		l.config.Set("MEROXA_ACCESS_TOKEN", accessToken)
+		l.config.Set("MEROXA_REFRESH_TOKEN", refreshToken)
 
 		// return an indication of success to the caller
 		_, _ = io.WriteString(w, `

--- a/cmd/meroxa/root/auth/logout.go
+++ b/cmd/meroxa/root/auth/logout.go
@@ -56,8 +56,8 @@ func (l *Logout) Config(cfg config.Config) {
 }
 
 func (l *Logout) Execute(ctx context.Context) error {
-	l.config.Set("ACCESS_TOKEN", "")
-	l.config.Set("REFRESH_TOKEN", "")
+	l.config.Set("MEROXA_ACCESS_TOKEN", "")
+	l.config.Set("MEROXA_REFRESH_TOKEN", "")
 
 	l.logger.Infof(ctx, "Successfully logged out.")
 	return nil


### PR DESCRIPTION
# Description of change

*Add `MEROXA_` prefix to access token and refresh token. My particular use case enables a better experience with the terraform provider. However, others may benefit in the future by not overloading the two environment variables. *

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [X]  Refactor
- [ ]  Documentation

# How was this tested?

- [X]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

_Include how it looked before_

**After this pull-request**

_Include how it looks now_

# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
