### PR TITLE
Use auth0 secrets with environment context

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Build and Run
         working-directory: ./acceptance
         env:
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_ACCEPTANCE_CLIENT_ID }}
-          AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_ACCEPTANCE_STAGING_CLIENT_ID }}
+          AUTH0_DOMAIN: ${{ secrets.AUTH0_STAGING_DOMAIN }}
           AUTH0_AUDIENCE: ${{ secrets.AUTH0_STAGING_AUDIENCE }}
-          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_ACCEPTANCE_CLIENT_SECRET }}
+          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_ACCEPTANCE_STAGING_CLIENT_SECRET }}
           AUTH0_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
           AUTH0_USERNAME: ${{ secrets.AUTH0_USERNAME }}
           PG_URL: ${{ secrets.TEST_DB_URL }}


### PR DESCRIPTION
# Description of change

staging acceptance tests are failing `Error: HTTP/2.0 401 Unauthorized` because cli uses production auth0 tenant while api uses staging tenant

Fixes https://github.com/meroxa/acceptance/issues/41


# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

_Include how it looked before_

**After this pull-request**

_Include how it looks now_

# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
