### PR TITLE
Allow output JSON only for `meroxa api`

### DIFF
--- a/cmd/meroxa/root/api/api.go
+++ b/cmd/meroxa/root/api/api.go
@@ -116,16 +116,5 @@ func (a *API) Execute(ctx context.Context) error {
 
 	a.logger.Info(ctx, prettyJSON.String())
 
-	var bodyJSON map[string]interface{}
-
-	err = json.Unmarshal(prettyJSON.Bytes(), &bodyJSON)
-
-	if err != nil {
-		a.logger.Errorf(ctx, "could not unmarshal: %w", err)
-		return err
-	}
-
-	a.logger.JSON(ctx, bodyJSON)
-
 	return nil
 }

--- a/cmd/meroxa/root/api/api.go
+++ b/cmd/meroxa/root/api/api.go
@@ -53,6 +53,10 @@ type API struct {
 		Path   string
 		Body   string
 	}
+
+	flags struct {
+		JSON bool `long:"json" short:"" usage:"output json"`
+	}
 }
 
 func (a *API) Usage() string {
@@ -108,13 +112,20 @@ func (a *API) Execute(ctx context.Context) error {
 		prettyJSON.Write(b)
 	}
 
-	a.logger.Infof(ctx, "> %s %s", a.args.Method, a.args.Path)
-	a.logger.Infof(ctx, "< %s %s", resp.Status, resp.Proto)
-	for k, v := range resp.Header {
-		a.logger.Infof(ctx, "< %s %s", k, strings.Join(v, " "))
+	// Print headers unless JSON only
+	if !a.flags.JSON {
+		a.logger.Infof(ctx, "> %s %s", a.args.Method, a.args.Path)
+		a.logger.Infof(ctx, "< %s %s", resp.Status, resp.Proto)
+		for k, v := range resp.Header {
+			a.logger.Infof(ctx, "< %s %s", k, strings.Join(v, " "))
+		}
 	}
 
 	a.logger.Info(ctx, prettyJSON.String())
 
 	return nil
+}
+
+func (a *API) Flags() []builder.Flag {
+	return builder.BuildFlags(&a.flags)
 }


### PR DESCRIPTION
# Description of change

Allow output JSON only for `meroxa api`. Previously, it outputs the headers & JSON body, and can run into JSON parsing issues.

# Type of change

- [x]  Bug fix

# Demo

**Before this pull-request**

```
m api GET /v1/connectors
> GET /v1/connectors
< 200 OK HTTP/2.0
< Date Wed, 28 Jul 2021 19:47:35 GMT
< Content-Type application/json; charset=utf-8
< Content-Length 330
< Meroxa-Request-Id 76c95e19-3030-46f5-884b-8118810add42
< Vary Origin
[
        {
                "id": 580,
                "name": "hello",
                "type": "jdbc-source",
                "config": {},
                "state": "running",
                "resource_id": 275,
                "pipeline_id": 3,
                "pipeline_name": "default",
                "streams": {
                        "output": [
                                "resource-275-984998-tt"
                        ],
                        "dynamic": false
                },
                "metadata": {
                        "mx:connectorType": "source"
                },
                "created_at": "2021-04-28T22:47:31.867391Z",
                "updated_at": "2021-07-28T19:47:28.940729Z"
        }
]
could not unmarshal: %!w(*json.UnmarshalTypeError=&{array 0x1500000 1  })
Error: json: cannot unmarshal array into Go value of type map[string]interface {}
```

**After this pull-request**

```
m api GET /v1/connectors
> GET /v1/connectors
< 200 OK HTTP/2.0
< Date Wed, 28 Jul 2021 19:50:10 GMT
< Content-Type application/json; charset=utf-8
< Content-Length 330
< Meroxa-Request-Id 8b283f74-9107-4deb-a8a6-fb04c1af2333
< Vary Origin
[
        {
                "id": 580,
                "name": "hello",
                "type": "jdbc-source",
                "config": {},
                "state": "running",
                "resource_id": 275,
                "pipeline_id": 3,
                "pipeline_name": "default",
                "streams": {
                        "output": [
                                "resource-275-984998-tt"
                        ],
                        "dynamic": false
                },
                "metadata": {
                        "mx:connectorType": "source"
                },
                "created_at": "2021-04-28T22:47:31.867391Z",
                "updated_at": "2021-07-28T19:49:58.839427Z"
        }
]

m api GET /v1/connectors --json
[
        {
                "id": 580,
                "name": "hello",
                "type": "jdbc-source",
                "config": {},
                "state": "running",
                "resource_id": 275,
                "pipeline_id": 3,
                "pipeline_name": "default",
                "streams": {
                        "output": [
                                "resource-275-984998-tt"
                        ],
                        "dynamic": false
                },
                "metadata": {
                        "mx:connectorType": "source"
                },
                "created_at": "2021-04-28T22:47:31.867391Z",
                "updated_at": "2021-07-28T19:50:14.052773Z"
        }
]
```