### PR TITLE
Use env vars for auth configs

### DIFF
--- a/cmd/meroxa/global/client.go
+++ b/cmd/meroxa/global/client.go
@@ -29,19 +29,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const (
-	clientID         = "2VC9z0ZxtzTcQLDNygeEELV3lYFRZwpb"
-	meroxaBaseAPIURL = "https://api.meroxa.io"
-)
-
-func GetMeroxaAPIURL() string {
-	if v := Config.GetString("API_URL"); v != "" {
-		return v
-	}
-
-	return meroxaBaseAPIURL
-}
-
 func GetCLIUserInfo() (actor, actorUUID string, err error) {
 	// Require login
 	_, _, err = GetUserToken()
@@ -133,8 +120,8 @@ func NewClient() (*meroxa.Client, error) {
 	// to catch requests to auth0
 	options = append(options, meroxa.WithAuthentication(
 		&oauth2.Config{
-			ClientID: clientID,
-			Endpoint: meroxa.OAuth2Endpoint,
+			ClientID: GetMeroxaClientID(),
+			Endpoint: oauthEndpoint(GetMeroxaDomain()),
 		},
 		accessToken,
 		refreshToken,
@@ -142,6 +129,13 @@ func NewClient() (*meroxa.Client, error) {
 	))
 
 	return meroxa.New(options...)
+}
+
+func oauthEndpoint(domain string) oauth2.Endpoint {
+	return oauth2.Endpoint{
+		AuthURL:  fmt.Sprintf("https://%s/authorize", domain),
+		TokenURL: fmt.Sprintf("https://%s/oauth/token", domain),
+	}
 }
 
 // onTokenRefreshed tries to save the new token in the config.

--- a/cmd/meroxa/global/config.go
+++ b/cmd/meroxa/global/config.go
@@ -32,6 +32,26 @@ const (
 	envType   = "env"
 )
 
+func GetMeroxaAPIURL() string {
+	return getEnv("MEROXA_API_URL", "https://api.meroxa.io")
+}
+func GetMeroxaAudience() string {
+	return getEnv("MEROXA_AUDIENCE", "https://api.meroxa.io/v1")
+}
+func GetMeroxaDomain() string {
+	return getEnv("MEROXA_DOMAIN", "auth.meroxa.io")
+}
+func GetMeroxaClientID() string {
+	return getEnv("MEROXA_CLIENT_ID", "2VC9z0ZxtzTcQLDNygeEELV3lYFRZwpb")
+}
+
+func getEnv(key, defaultVal string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		return val
+	}
+	return defaultVal
+}
+
 func readConfig() (*viper.Viper, error) {
 	cfg := viper.New()
 

--- a/cmd/meroxa/global/metrics_test.go
+++ b/cmd/meroxa/global/metrics_test.go
@@ -198,7 +198,7 @@ func TestNewPublisherWithoutCasedAPIKey(t *testing.T) {
 	Config = viper.New()
 	defer clearConfiguration()
 
-	apiURL := fmt.Sprintf("%s/telemetry", meroxaBaseAPIURL)
+	apiURL := fmt.Sprintf("%s/telemetry", GetMeroxaAPIURL())
 	got := NewPublisher()
 
 	if got.Options().PublishKey != "" {


### PR DESCRIPTION
# Description of change

Currently CLI has auth config vars hardcoded. We want to change this to allow new values depending on environment

Fixes https://github.com/meroxa/product/issues/81

# Type of change 

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
