### PR TITLE
fix: Unmarshal error on meroxa api --json

### DIFF
--- a/cmd/meroxa/root/api/api.go
+++ b/cmd/meroxa/root/api/api.go
@@ -115,17 +115,7 @@ func (a *API) Execute(ctx context.Context) error {
 	}
 
 	a.logger.Info(ctx, prettyJSON.String())
-
-	var bodyJSON map[string]interface{}
-
-	err = json.Unmarshal(prettyJSON.Bytes(), &bodyJSON)
-
-	if err != nil {
-		a.logger.Errorf(ctx, "could not unmarshal: %w", err)
-		return err
-	}
-
-	a.logger.JSON(ctx, bodyJSON)
+	a.logger.JSON(ctx, prettyJSON.String())
 
 	return nil
 }

--- a/log/json.go
+++ b/log/json.go
@@ -20,6 +20,11 @@ type jsonLogger struct {
 }
 
 func (l *jsonLogger) JSON(ctx context.Context, data interface{}) {
+	if raw, ok := data.(string); ok {
+		l.l.Print(raw)
+		return
+	}
+
 	p, err := json.MarshalIndent(data, "", "\t")
 	if err != nil {
 		l.l.Printf("could not marshal JSON: %s", err.Error())


### PR DESCRIPTION
Reverts meroxa/cli#169

----

`--json` already worked and only showing the body content as expected however #169 did caught an issue with arrays, which is what this pull-request is addressing.

**before**

```
❯ .m api get /v1/connectors --json
could not unmarshal: %!w(*json.UnmarshalTypeError=&{array 0x1500580 1  })
Error: json: cannot unmarshal array into Go value of type map[string]interface {}
```

**now**

```
❯ .m api get /v1/connectors --json
[
	{
		"id": 583,
		"name": "my-resource-149-954565",
		"type": "jdbc-source",
		"config": {},
		"state": "failed",
		"trace": "trace",
		"resource_id": 149,
		"pipeline_id": 11,
		"pipeline_name": "default",
		"streams": {
			"output": [
				"resource-149-942792-public.User"
			],
			"dynamic": false
		},
		"metadata": {
			"mx:connectorType": "source"
		},
		"created_at": "2021-04-29T13:34:32.66516Z",
		"updated_at": "2021-08-02T14:35:58.671148Z"
	}
]
```
