### PR TITLE
feat: Sign commits with GPG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,18 @@ jobs:
         with:
           go-version: 1.16.x
       -
+        name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3.1.0
+        with:
+          gpg-private-key: ${{ secrets.MEROXA_MACHINE_GPG_KEY }}
+          passphrase: ${{ secrets.MEROXA_MACHINE_GPG_PASSPHRASE }}
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
           args: release --rm-dist
         env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.MEROXA_MACHINE }}


### PR DESCRIPTION
# Description of change

As suggested by @terrancej yesterday's at stand up, a good practice would be to start signing our releases with our GPG key generated.

Both secrets were enabled to this repository as well.

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation
