### PR TITLE
fix: Show help text on base commands

### DIFF
--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -215,8 +215,8 @@ func buildCommandWithClient(cmd *cobra.Command, c Command) {
 		return
 	}
 
-	old := cmd.RunE
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+	old := cmd.PreRunE
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if old != nil {
 			err := old(cmd, args)
 			if err != nil {
@@ -367,13 +367,12 @@ func buildCommandEvent(cmd *cobra.Command, c Command) {
 		return
 	}
 
-	oldRunE := cmd.RunE
-	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		if oldRunE != nil {
+	if cmd.RunE != nil {
+		oldRunE := cmd.RunE
+		cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			err := oldRunE(cmd, args)
 			return withEventRunE(cmd, args, c, err)
 		}
-		return nil
 	}
 }
 

--- a/docs/cmd/md/meroxa_auth.md
+++ b/docs/cmd/md/meroxa_auth.md
@@ -2,10 +2,6 @@
 
 Authentication commands for Meroxa
 
-```
-meroxa auth [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/md/meroxa_connectors.md
+++ b/docs/cmd/md/meroxa_connectors.md
@@ -2,10 +2,6 @@
 
 Manage connectors on Meroxa
 
-```
-meroxa connectors [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/md/meroxa_endpoints.md
+++ b/docs/cmd/md/meroxa_endpoints.md
@@ -2,10 +2,6 @@
 
 Manage endpoints on Meroxa
 
-```
-meroxa endpoints [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/md/meroxa_open.md
+++ b/docs/cmd/md/meroxa_open.md
@@ -2,10 +2,6 @@
 
 Open in a web browser
 
-```
-meroxa open [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/md/meroxa_pipelines.md
+++ b/docs/cmd/md/meroxa_pipelines.md
@@ -2,10 +2,6 @@
 
 Manage pipelines on Meroxa
 
-```
-meroxa pipelines [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/md/meroxa_resources.md
+++ b/docs/cmd/md/meroxa_resources.md
@@ -2,10 +2,6 @@
 
 Manage resources on Meroxa
 
-```
-meroxa resources [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/md/meroxa_transforms.md
+++ b/docs/cmd/md/meroxa_transforms.md
@@ -2,10 +2,6 @@
 
 Manage transforms on Meroxa
 
-```
-meroxa transforms [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/www/meroxa-auth.md
+++ b/docs/cmd/www/meroxa-auth.md
@@ -9,10 +9,6 @@ url: /cli/meroxa-auth/
 
 Authentication commands for Meroxa
 
-```
-meroxa auth [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/www/meroxa-connectors.md
+++ b/docs/cmd/www/meroxa-connectors.md
@@ -9,10 +9,6 @@ url: /cli/meroxa-connectors/
 
 Manage connectors on Meroxa
 
-```
-meroxa connectors [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/www/meroxa-endpoints.md
+++ b/docs/cmd/www/meroxa-endpoints.md
@@ -9,10 +9,6 @@ url: /cli/meroxa-endpoints/
 
 Manage endpoints on Meroxa
 
-```
-meroxa endpoints [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/www/meroxa-open.md
+++ b/docs/cmd/www/meroxa-open.md
@@ -9,10 +9,6 @@ url: /cli/meroxa-open/
 
 Open in a web browser
 
-```
-meroxa open [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/www/meroxa-pipelines.md
+++ b/docs/cmd/www/meroxa-pipelines.md
@@ -9,10 +9,6 @@ url: /cli/meroxa-pipelines/
 
 Manage pipelines on Meroxa
 
-```
-meroxa pipelines [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/www/meroxa-resources.md
+++ b/docs/cmd/www/meroxa-resources.md
@@ -9,10 +9,6 @@ url: /cli/meroxa-resources/
 
 Manage resources on Meroxa
 
-```
-meroxa resources [flags]
-```
-
 ### Options
 
 ```

--- a/docs/cmd/www/meroxa-transforms.md
+++ b/docs/cmd/www/meroxa-transforms.md
@@ -9,10 +9,6 @@ url: /cli/meroxa-transforms/
 
 Manage transforms on Meroxa
 
-```
-meroxa transforms [flags]
-```
-
 ### Options
 
 ```


### PR DESCRIPTION
# Description of change

Fixes https://github.com/meroxa/cli/issues/162
Fixes https://github.com/meroxa/product/issues/63

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [x]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
❯ .m resources

```

**After this pull-request**

```
❯ .m resources
Usage:
  meroxa resources [flags]
  meroxa resources [command]

Aliases:
  resources, resource

Available Commands:
  create            Add a resource to your Meroxa resource catalog
  describe          Describe resource
  list              List resources and resource types
  remove            Remove resource
  rotate-tunnel-key Rotate the tunnel key for a resource
  update            Update a resource
  validate          Validate a resource

Flags:
  -h, --help   help for resources

Global Flags:
      --config string      config file
      --debug              display any debugging information
      --json               output json
      --timeout duration   set the client timeout (default 10s)

Use "meroxa resources [command] --help" for more information about a command.
```
