### PR TITLE
Make connector input not a required field

### DIFF
--- a/cmd/meroxa/root/connectors/create.go
+++ b/cmd/meroxa/root/connectors/create.go
@@ -50,7 +50,7 @@ type Create struct {
 	}
 
 	flags struct {
-		Input       string `long:"input"      short:""  usage:"command delimited list of input streams" required:"true"`
+		Input       string `long:"input"      short:""  usage:"command delimited list of input streams"`
 		Config      string `long:"config"      short:"c"  usage:"connector configuration"`
 		Metadata    string `long:"metadata"    short:"m" usage:"connector metadata" hidden:"true"`
 		Source      string `long:"from"    short:"" usage:"resource name to use as source"`
@@ -94,7 +94,9 @@ func (c *Create) CreateConnector(ctx context.Context) (*meroxa.Connector, error)
 	}
 
 	// merge in input
-	config["input"] = c.flags.Input
+	if c.flags.Input != "" {
+		config["input"] = c.flags.Input
+	}
 
 	// merge in connector type
 	var resourceName string

--- a/cmd/meroxa/root/connectors/create_test.go
+++ b/cmd/meroxa/root/connectors/create_test.go
@@ -64,7 +64,7 @@ func TestCreateConnectorFlags(t *testing.T) {
 		shorthand string
 		hidden    bool
 	}{
-		{name: "input", required: true, shorthand: "", hidden: false},
+		{name: "input", required: false, shorthand: "", hidden: false},
 		{name: "config", required: false, shorthand: "c", hidden: false},
 		{name: "from", required: false, shorthand: "", hidden: false},
 		{name: "to", required: false, shorthand: "", hidden: false},

--- a/etc/completion/meroxa.completion.sh
+++ b/etc/completion/meroxa.completion.sh
@@ -654,7 +654,6 @@ _meroxa_connectors_create()
     two_word_flags+=("--timeout")
 
     must_have_one_flag=()
-    must_have_one_flag+=("--input=")
     must_have_one_noun=()
     noun_aliases=()
 }


### PR DESCRIPTION
# Description of change

For a JDBC connector, query and input are mutually exclusive. So to allow customers to set query config, we need to stop making input flag required 

Fixes https://github.com/meroxa/product/issues/87

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

<img width="904" alt="Screen Shot 2021-08-06 at 10 02 19 AM" src="https://user-images.githubusercontent.com/31331000/128523770-b096de53-b512-4929-b7e1-5d67958200b6.png">


**After this pull-request**

<img width="564" alt="Screen Shot 2021-08-06 at 10 09 44 AM" src="https://user-images.githubusercontent.com/31331000/128523791-8219540b-194b-42c8-805f-bab9b2225d5e.png">


# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
