### PR TITLE
refactor: Rename auth env vars

### DIFF
--- a/cmd/meroxa/global/client.go
+++ b/cmd/meroxa/global/client.go
@@ -120,8 +120,8 @@ func NewClient() (*meroxa.Client, error) {
 	// to catch requests to auth0
 	options = append(options, meroxa.WithAuthentication(
 		&oauth2.Config{
-			ClientID: GetMeroxaClientID(),
-			Endpoint: oauthEndpoint(GetMeroxaDomain()),
+			ClientID: GetMeroxaAuthClientID(),
+			Endpoint: oauthEndpoint(GetMeroxaAuthDomain()),
 		},
 		accessToken,
 		refreshToken,

--- a/cmd/meroxa/global/config.go
+++ b/cmd/meroxa/global/config.go
@@ -33,21 +33,24 @@ const (
 )
 
 func GetMeroxaAPIURL() string {
-	return getEnv("MEROXA_API_URL", "https://api.meroxa.io")
+	return getEnvVal([]string{"MEROXA_API_URL"}, "https://api.meroxa.io")
 }
-func GetMeroxaAudience() string {
-	return getEnv("MEROXA_AUDIENCE", "https://api.meroxa.io/v1")
+func GetMeroxaAuthAudience() string {
+	return getEnvVal([]string{"MEROXA_AUTH_AUDIENCE", "MEROXA_AUDIENCE"}, "https://api.meroxa.io/v1")
 }
-func GetMeroxaDomain() string {
-	return getEnv("MEROXA_DOMAIN", "auth.meroxa.io")
+func GetMeroxaAuthDomain() string {
+	return getEnvVal([]string{"MEROXA_AUTH_DOMAIN", "MEROXA_DOMAIN"}, "auth.meroxa.io")
 }
-func GetMeroxaClientID() string {
-	return getEnv("MEROXA_CLIENT_ID", "2VC9z0ZxtzTcQLDNygeEELV3lYFRZwpb")
+func GetMeroxaAuthClientID() string {
+	return getEnvVal([]string{"MEROXA_AUTH_CLIENT_ID", "MEROXA_CLIENT_ID"}, "2VC9z0ZxtzTcQLDNygeEELV3lYFRZwpb")
 }
 
-func getEnv(key, defaultVal string) string {
-	if val, ok := os.LookupEnv(key); ok {
-		return val
+// getEnvVal returns the value of either the first existing key specified in keys, or defaultVal if none were present.
+func getEnvVal(keys []string, defaultVal string) string {
+	for _, key := range keys {
+		if val, ok := os.LookupEnv(key); ok {
+			return val
+		}
 	}
 	return defaultVal
 }

--- a/cmd/meroxa/root/auth/login.go
+++ b/cmd/meroxa/root/auth/login.go
@@ -186,9 +186,9 @@ func (l *Login) login(ctx context.Context) error {
 	l.logger.Infof(ctx, color.CyanString("You will now be taken to your browser for authentication or open the url below in a browser."))
 	l.authorizeUser(
 		ctx,
-		global.GetMeroxaClientID(),
-		global.GetMeroxaDomain(),
-		global.GetMeroxaAudience(),
+		global.GetMeroxaAuthClientID(),
+		global.GetMeroxaAuthDomain(),
+		global.GetMeroxaAuthAudience(),
 		callbackURL,
 	)
 	return nil
@@ -208,7 +208,7 @@ func (l *Login) getAccessTokenAuth(
 ) (accessToken, refreshToken string, err error) {
 	// set the url and form-encoded data for the POST to the access token endpoint
 	// this URL should actually be taken from meroxa.OAuth2Endpoint
-	tokenURL := fmt.Sprintf("https://%s/oauth/token", global.GetMeroxaDomain())
+	tokenURL := fmt.Sprintf("https://%s/oauth/token", global.GetMeroxaAuthDomain())
 	data := fmt.Sprintf(
 		"grant_type=authorization_code&client_id=%s"+
 			"&code_verifier=%s"+


### PR DESCRIPTION
# Description of change

When running into these environment variables, I think we could benefit from a bit of clarity. For instance, seeing `MEROXA_DOMAIN` is not clear enough what it's related to. By adding `AUTH` as part of it, I believe we accomplish that. For consistency, I'm adding `AUTH` to the other environment variables that are also related to authentication.

This pull request adds backwards compatibility to the previous keys so it doesn't break current behaviour, but maybe we could remove those overtime. For starters, instructions in our [platform-dev-setup](https://github.com/meroxa/platform-dev-setup#point-clients-to-in-cluster-meroxa-api).

Once this ships, we could merge this other pull-request: https://github.com/meroxa/platform-dev-setup/pull/34.
 

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation
