### PR TITLE
feat: Update user info every 24h and adds command with feature flag

### DIFF
--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -630,7 +630,8 @@ func buildCommandWithFeatureFlag(cmd *cobra.Command, c Command) {
 		userFeatureFlags := global.Config.GetStringSlice(global.UserFeatureFlagsEnv)
 
 		if !hasFeatureFlag(userFeatureFlags, flagRequired) {
-			return fmt.Errorf("feature flag %q required. reach out to support@meroxa.com for more information", flagRequired)
+			return fmt.Errorf("your account does not have access to the %q feature."+
+				"Reach out to support@meroxa.com for more information", flagRequired)
 		}
 
 		return nil

--- a/cmd/meroxa/global/client.go
+++ b/cmd/meroxa/global/client.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
@@ -45,8 +46,9 @@ func GetCLIUserInfo() (actor, actorUUID string, err error) {
 	// fetch actor account.
 	actor = Config.GetString("ACTOR")
 	actorUUID = Config.GetString("ACTOR_UUID")
+	featureFlags := Config.GetString("FEATURE_FLAGS")
 
-	if actor == "" || actorUUID == "" {
+	if actor == "" || actorUUID == "" || featureFlags == "" {
 		// call api to fetch
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // nolint:gomnd
 		defer cancel()
@@ -66,8 +68,12 @@ func GetCLIUserInfo() (actor, actorUUID string, err error) {
 		actor = account.Email
 		actorUUID = account.UUID
 
+		// write user information in config file
 		Config.Set("ACTOR", actor)
 		Config.Set("ACTOR_UUID", actorUUID)
+
+		// write existing feature flags enabled
+		Config.Set("FEATURE_FLAGS", strings.Join(account.Features, ","))
 
 		err = Config.WriteConfig()
 

--- a/cmd/meroxa/global/client.go
+++ b/cmd/meroxa/global/client.go
@@ -87,7 +87,7 @@ func GetCLIUserInfo() (actor, actorUUID string, err error) {
 		Config.Set(ActorUUIDEnv, actorUUID)
 
 		// write existing feature flags enabled
-		Config.Set(UserFeatureFlagsEnv, strings.Join(account.Features, ","))
+		Config.Set(UserFeatureFlagsEnv, strings.Join(account.Features, " "))
 
 		// write when was the last time we updated user info
 		Config.Set(UserInfoUpdatedAtEnv, time.Now().UTC())

--- a/cmd/meroxa/global/global.go
+++ b/cmd/meroxa/global/global.go
@@ -38,9 +38,17 @@ var (
 	flagJSON    bool
 )
 
-func DeprecateV1Commands() bool {
-	return true
-}
+const (
+	AccessTokenEnv       = "ACCESS_TOKEN"
+	ActorEnv             = "ACTOR"
+	ActorUUIDEnv         = "ACTOR_UUID"
+	CasedDebugEnv        = "CASED_DEBUG"
+	CasedPublishKeyEnv   = "CASED_PUBLISH_KEY"
+	PublishMetricsEnv    = "PUBLISH_METRICS"
+	RefreshTokenEnv      = "REFRESH_TOKEN"
+	UserFeatureFlagsEnv  = "USER_FEATURE_FLAGS"
+	UserInfoUpdatedAtEnv = "USER_INFO_UPDATED_AT"
+)
 
 func RegisterGlobalFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&flagJSON, "json", false, "output json")

--- a/cmd/meroxa/global/metrics.go
+++ b/cmd/meroxa/global/metrics.go
@@ -31,7 +31,7 @@ import (
 func NewPublisher() cased.Publisher {
 	var options []cased.PublisherOption
 
-	casedAPIKey := Config.GetString("CASED_PUBLISH_KEY")
+	casedAPIKey := Config.GetString(CasedPublishKeyEnv)
 
 	if casedAPIKey != "" {
 		options = append(options, cased.WithPublishKey(casedAPIKey))
@@ -39,11 +39,11 @@ func NewPublisher() cased.Publisher {
 		options = append(options, cased.WithPublishURL(fmt.Sprintf("%s/telemetry", GetMeroxaAPIURL())))
 	}
 
-	if v := Config.GetString("PUBLISH_METRICS"); v == "false" {
+	if v := Config.GetString(PublishMetricsEnv); v == "false" {
 		options = append(options, cased.WithSilence(true))
 	}
 
-	if v := Config.GetBool("CASED_DEBUG"); v {
+	if v := Config.GetBool(CasedDebugEnv); v {
 		options = append(options, cased.WithDebug(v))
 	}
 
@@ -166,7 +166,7 @@ var (
 // PublishEvent will take care of publishing the event to Cased.
 func publishEvent(event cased.AuditEvent) {
 	// Only prints out to console
-	if v := Config.GetString("PUBLISH_METRICS"); v == "stdout" {
+	if v := Config.GetString(PublishMetricsEnv); v == "stdout" {
 		e, _ := json.Marshal(event)
 		fmt.Printf("\n\nEvent: %v\n\n", string(e))
 		return
@@ -178,7 +178,7 @@ func publishEvent(event cased.AuditEvent) {
 	err := cased.Publish(event)
 	if err != nil {
 		// cased.Publish could return an error, but we only show it when debugging
-		if Config.GetBool("CASED_DEBUG") {
+		if Config.GetBool(CasedDebugEnv) {
 			fmt.Println("error: %w", err)
 		}
 		return

--- a/cmd/meroxa/global/metrics_test.go
+++ b/cmd/meroxa/global/metrics_test.go
@@ -185,7 +185,7 @@ func TestNewPublisherWithCasedAPIKey(t *testing.T) {
 	defer clearConfiguration()
 
 	apiKey := "8c32e3b7-d0e7-4650-a82b-e85e6a8d56fa"
-	Config.Set("CASED_PUBLISH_KEY", apiKey)
+	Config.Set(CasedPublishKeyEnv, apiKey)
 
 	got := NewPublisher()
 
@@ -214,14 +214,14 @@ func TestNewPublisherPublishing(t *testing.T) {
 	Config = viper.New()
 	defer clearConfiguration()
 
-	Config.Set("PUBLISH_METRICS", "false")
+	Config.Set(PublishMetricsEnv, "false")
 	got := NewPublisher()
 
 	if !got.Options().Silence {
 		t.Fatalf("expected publisher silence option to be %v", true)
 	}
 
-	Config.Set("PUBLISH_METRICS", "any-other-value")
+	Config.Set(PublishMetricsEnv, "any-other-value")
 	got = NewPublisher()
 
 	if got.Options().Silence {
@@ -233,7 +233,7 @@ func TestNewPublisherWithDebug(t *testing.T) {
 	Config = viper.New()
 	defer clearConfiguration()
 
-	Config.Set("CASED_DEBUG", true)
+	Config.Set(CasedDebugEnv, true)
 	got := NewPublisher()
 
 	if !got.Options().Debug {
@@ -249,7 +249,7 @@ func TestPublishEventOnStdout(t *testing.T) {
 	Config = viper.New()
 	defer clearConfiguration()
 
-	Config.Set("PUBLISH_METRICS", "stdout")
+	Config.Set(PublishMetricsEnv, "stdout")
 
 	event := cased.AuditEvent{
 		"key": "event",
@@ -302,22 +302,25 @@ func TestAddUserInfo(t *testing.T) {
 	meroxaUserUUID := "ff45a74a-4fc1-49a5-8fa5-f1762703b7e8"
 
 	// Makes sure user is logged in
-	Config.Set("ACCESS_TOKEN", "access-token")
-	Config.Set("REFRESH_TOKEN", "refresh-token")
+	Config.Set(AccessTokenEnv, "access-token")
+	Config.Set(RefreshTokenEnv, "refresh-token")
 
-	Config.Set("ACTOR", meroxaUser)
-	Config.Set("ACTOR_UUID", meroxaUserUUID)
+	Config.Set(ActorEnv, meroxaUser)
+	Config.Set(ActorUUIDEnv, meroxaUserUUID)
+
+	// Makes sure there's no need to fetch for user info
+	Config.Set(UserInfoUpdatedAtEnv, time.Now().UTC())
 
 	event := cased.AuditEvent{}
 	addUserInfo(event)
 
 	want := meroxaUser
 	if v := event["actor"]; v != want {
-		t.Fatalf("expected event action to be %q, got %q", want, v)
+		t.Fatalf("expected event \"actor\" to be %q, got %q", want, v)
 	}
 
 	want = meroxaUserUUID
 	if v := event["actor_uuid"]; v != want {
-		t.Fatalf("expected event action to be %q, got %q", want, v)
+		t.Fatalf("expected event \"actor_uuid\" to be %q, got %q", want, v)
 	}
 }

--- a/cmd/meroxa/root/auth/login.go
+++ b/cmd/meroxa/root/auth/login.go
@@ -129,8 +129,8 @@ func (l *Login) authorizeUser(ctx context.Context, clientID, authDomain, audienc
 			return
 		}
 
-		l.config.Set("ACCESS_TOKEN", accessToken)
-		l.config.Set("REFRESH_TOKEN", refreshToken)
+		l.config.Set(global.AccessTokenEnv, accessToken)
+		l.config.Set(global.RefreshTokenEnv, refreshToken)
 
 		// return an indication of success to the caller
 		_, _ = io.WriteString(w, `

--- a/cmd/meroxa/root/auth/logout.go
+++ b/cmd/meroxa/root/auth/logout.go
@@ -19,10 +19,10 @@ package auth
 import (
 	"context"
 
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/global"
 	"github.com/meroxa/cli/config"
 	"github.com/meroxa/cli/log"
-
-	"github.com/meroxa/cli/cmd/meroxa/builder"
 )
 
 var (
@@ -56,8 +56,8 @@ func (l *Logout) Config(cfg config.Config) {
 }
 
 func (l *Logout) Execute(ctx context.Context) error {
-	l.config.Set("ACCESS_TOKEN", "")
-	l.config.Set("REFRESH_TOKEN", "")
+	l.config.Set(global.AccessTokenEnv, "")
+	l.config.Set(global.RefreshTokenEnv, "")
 
 	l.logger.Infof(ctx, "Successfully logged out.")
 	return nil

--- a/cmd/meroxa/root/auth/whoami.go
+++ b/cmd/meroxa/root/auth/whoami.go
@@ -81,10 +81,9 @@ func (w *WhoAmI) Execute(ctx context.Context) error {
 	w.logger.JSON(ctx, user)
 
 	// Updates config file with actor information.
-
 	w.config.Set(global.ActorEnv, user.Email)
 	w.config.Set(global.ActorUUIDEnv, user.UUID)
-	w.config.Set(global.UserFeatureFlagsEnv, strings.Join(user.Features, ","))
+	w.config.Set(global.UserFeatureFlagsEnv, strings.Join(user.Features, " "))
 	w.config.Set(global.UserInfoUpdatedAtEnv, time.Now().UTC())
 
 	if err != nil {

--- a/cmd/meroxa/root/auth/whoami.go
+++ b/cmd/meroxa/root/auth/whoami.go
@@ -18,6 +18,10 @@ package auth
 
 import (
 	"context"
+	"strings"
+	"time"
+
+	"github.com/meroxa/cli/cmd/meroxa/global"
 
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 	"github.com/meroxa/cli/config"
@@ -77,8 +81,11 @@ func (w *WhoAmI) Execute(ctx context.Context) error {
 	w.logger.JSON(ctx, user)
 
 	// Updates config file with actor information.
-	w.config.Set("ACTOR", user.Email)
-	w.config.Set("ACTOR_UUID", user.UUID)
+
+	w.config.Set(global.ActorEnv, user.Email)
+	w.config.Set(global.ActorUUIDEnv, user.UUID)
+	w.config.Set(global.UserFeatureFlagsEnv, strings.Join(user.Features, ","))
+	w.config.Set(global.UserInfoUpdatedAtEnv, time.Now().UTC())
 
 	if err != nil {
 		return err

--- a/cmd/meroxa/root/auth/whoami_test.go
+++ b/cmd/meroxa/root/auth/whoami_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/meroxa/cli/cmd/meroxa/global"
+
 	"github.com/meroxa/cli/config"
 	"github.com/meroxa/cli/log"
 	"github.com/meroxa/meroxa-go"
@@ -69,11 +71,11 @@ func TestWhoAmIExecution(t *testing.T) {
 		t.Fatalf("expected \"%v\", got \"%v\"", u, gotUser)
 	}
 
-	if w.config.GetString("ACTOR") != u.Email {
-		t.Fatalf("expected ACTOR key to be %q", u.Email)
+	if w.config.GetString(global.ActorEnv) != u.Email {
+		t.Fatalf("expected %q key to be %q", global.ActorEnv, u.Email)
 	}
 
-	if w.config.GetString("ACTOR_UUID") != u.UUID {
-		t.Fatalf("expected ACTOR_UUID key to be %q", u.UUID)
+	if w.config.GetString(global.ActorUUIDEnv) != u.UUID {
+		t.Fatalf("expected %q key to be %q", global.ActorUUIDEnv, u.UUID)
 	}
 }

--- a/cmd/meroxa/root/environments/environments.go
+++ b/cmd/meroxa/root/environments/environments.go
@@ -1,0 +1,63 @@
+/*
+Copyright © 2021 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package environments
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+)
+
+type Environments struct {
+	logger log.Logger
+}
+
+var (
+	_ builder.CommandWithAliases     = (*Environments)(nil)
+	_ builder.CommandWithDocs        = (*Environments)(nil)
+	_ builder.CommandWithExecute     = (*Environments)(nil)
+	_ builder.CommandWithFeatureFlag = (*Environments)(nil)
+)
+
+func (*Environments) Usage() string {
+	return "environments"
+}
+
+func (*Environments) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Manage environments on Meroxa",
+	}
+}
+
+func (*Environments) Aliases() []string {
+	return []string{"env", "environment"}
+}
+
+func (*Environments) FeatureFlag() string {
+	return "environments"
+}
+
+func (e *Environments) Logger(logger log.Logger) {
+	e.logger = logger
+}
+
+func (e *Environments) Execute(ctx context.Context) error {
+	fmt.Println("Welcome to a new world")
+	return nil
+}

--- a/cmd/meroxa/root/root.go
+++ b/cmd/meroxa/root/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/meroxa/cli/cmd/meroxa/root/config"
 	"github.com/meroxa/cli/cmd/meroxa/root/connectors"
 	"github.com/meroxa/cli/cmd/meroxa/root/endpoints"
+	"github.com/meroxa/cli/cmd/meroxa/root/environments"
 	"github.com/meroxa/cli/cmd/meroxa/root/login"
 	"github.com/meroxa/cli/cmd/meroxa/root/logout"
 	"github.com/meroxa/cli/cmd/meroxa/root/open"
@@ -79,10 +80,11 @@ meroxa resources list --types
 	cmd.AddCommand(builder.BuildCobraCommand(&api.API{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&auth.Auth{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&billing.Billing{}))
+	cmd.AddCommand(builder.BuildCobraCommand(&config.Config{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&connectors.Connect{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&connectors.Connectors{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&endpoints.Endpoints{}))
-	cmd.AddCommand(builder.BuildCobraCommand(&config.Config{}))
+	cmd.AddCommand(builder.BuildCobraCommand(&environments.Environments{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&login.Login{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&logout.Logout{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&open.Open{}))

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20210903151302-d7ef8814cfca
+	github.com/meroxa/meroxa-go v0.0.0-20210928081857-bcbce33ea9f4
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect
@@ -50,5 +50,3 @@ require (
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ require (
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.sum
+++ b/go.sum
@@ -210,8 +210,6 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/meroxa/meroxa-go v0.0.0-20210903151302-d7ef8814cfca h1:Umrqcmy0Xp78Oel9zBmHyk5hEcB0UmVaNOJ8lh71FE4=
-github.com/meroxa/meroxa-go v0.0.0-20210903151302-d7ef8814cfca/go.mod h1:gGKULnbPeFk//HW3XRxkZwZ3jgMuoMB+43EiGZ7QoGU=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -210,6 +210,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/meroxa/meroxa-go v0.0.0-20210928081857-bcbce33ea9f4 h1:7jpUh3WZ9r3vZ0mYdCENg1/F15wkWi/AqkXmZYLsAPk=
+github.com/meroxa/meroxa-go v0.0.0-20210928081857-bcbce33ea9f4/go.mod h1:gGKULnbPeFk//HW3XRxkZwZ3jgMuoMB+43EiGZ7QoGU=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/vendor/github.com/meroxa/meroxa-go/user.go
+++ b/vendor/github.com/meroxa/meroxa-go/user.go
@@ -18,6 +18,7 @@ type User struct {
 	FamilyName string    `json:"family_name,omitempty"`
 	Verified   bool      `json:"email_verified,omitempty"`
 	LastLogin  time.Time `json:"last_login,omitempty"`
+	Features   []string  `json:"features,omitempty"`
 }
 
 // GetUser returns a User with

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,7 +66,7 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 ## explicit; go 1.9
 github.com/mattn/go-runewidth
-# github.com/meroxa/meroxa-go v0.0.0-20210903151302-d7ef8814cfca
+# github.com/meroxa/meroxa-go v0.0.0-20210903151302-d7ef8814cfca => ../meroxa-go
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go
 # github.com/mitchellh/mapstructure v1.4.1
@@ -181,3 +181,4 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
+# github.com/meroxa/meroxa-go => ../meroxa-go

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -66,7 +66,7 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 ## explicit; go 1.9
 github.com/mattn/go-runewidth
-# github.com/meroxa/meroxa-go v0.0.0-20210903151302-d7ef8814cfca => ../meroxa-go
+# github.com/meroxa/meroxa-go v0.0.0-20210928081857-bcbce33ea9f4
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go
 # github.com/mitchellh/mapstructure v1.4.1
@@ -181,4 +181,3 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
-# github.com/meroxa/meroxa-go => ../meroxa-go


### PR DESCRIPTION
# Description of change

This pull-request adds the ability to create a CLI command that depends on a Meroxa User Feature Flag. These are returned by the API endpoint `/v1/users/me` and when that API endpoint is used in `meroxa whoami` we also make sure we update this information.

To make sure user information is not stale, we'll start fetching this information every 24hours since last time was updated.

To demo the usage of feature flags, this pull-request also adds the `environment` command which could aliased as `env` or `environment`.

Fixes https://github.com/meroxa/product/issues/113

~Depends on https://github.com/meroxa/meroxa-go/pull/53~.

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

# Demo

## Before this pull-request

- We didn't check for feature flags.

## After this pull-request

**Without feature flag enabled**

```bash
$ meroxa env
Error: feature flag "environments" required. reach out to support@meroxa.com for more information
```

**With feature flag enabled**

```bash
$ meroxa env
Welcome to a new world
```