### PR TITLE
feat(connector): Include connector trace in `connector describe`

### DIFF
--- a/cmd/meroxa/root/connectors/describe.go
+++ b/cmd/meroxa/root/connectors/describe.go
@@ -64,7 +64,7 @@ func (d *Describe) Execute(ctx context.Context) error {
 		return err
 	}
 
-	d.logger.Info(ctx, utils.ConnectorsTable([]*meroxa.Connector{connector}, false))
+	d.logger.Info(ctx, utils.ConnectorTable(connector))
 	d.logger.JSON(ctx, connector)
 
 	return nil

--- a/cmd/meroxa/root/connectors/describe_test.go
+++ b/cmd/meroxa/root/connectors/describe_test.go
@@ -65,6 +65,8 @@ func TestDescribeConnectorExecution(t *testing.T) {
 	connectorName := "my-connector"
 
 	c := utils.GenerateConnector(0, connectorName)
+	c.State = "failed"
+	c.Trace = "exception goes here"
 	client.
 		EXPECT().
 		GetConnectorByName(
@@ -85,7 +87,7 @@ func TestDescribeConnectorExecution(t *testing.T) {
 	}
 
 	gotLeveledOutput := logger.LeveledOutput()
-	wantLeveledOutput := utils.ConnectorsTable([]*meroxa.Connector{&c}, false)
+	wantLeveledOutput := utils.ConnectorTable(&c)
 
 	if !strings.Contains(gotLeveledOutput, wantLeveledOutput) {
 		t.Fatalf("expected output:\n%s\ngot:\n%s", wantLeveledOutput, gotLeveledOutput)

--- a/utils/display.go
+++ b/utils/display.go
@@ -190,6 +190,46 @@ func TransformsTable(transforms []*meroxa.Transform, hideHeaders bool) string {
 	return ""
 }
 
+func ConnectorTable(connector *meroxa.Connector) string {
+	mainTable := simpletable.New()
+	mainTable.Body.Cells = [][]*simpletable.Cell{
+		{
+			{Align: simpletable.AlignRight, Text: "ID:"},
+			{Text: fmt.Sprintf("%d", connector.ID)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Name:"},
+			{Text: connector.Name},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Type:"},
+			{Text: connector.Type},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Streams:"},
+			{Text: formatStreams(connector.Streams)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "State:"},
+			{Text: connector.State},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Pipeline:"},
+			{Text: strings.Title(connector.PipelineName)},
+		},
+	}
+
+	if connector.Trace != "" {
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "Trace:"},
+			{Text: strings.Title(connector.Trace)},
+		})
+	}
+	mainTable.SetStyle(simpletable.StyleCompact)
+
+	return mainTable.String()
+}
+
 func ConnectorsTable(connectors []*meroxa.Connector, hideHeaders bool) string {
 	if len(connectors) != 0 {
 		table := simpletable.New()
@@ -208,33 +248,7 @@ func ConnectorsTable(connectors []*meroxa.Connector, hideHeaders bool) string {
 		}
 
 		for _, conn := range connectors {
-			var streamStr string
-
-			if streamInput, ok := conn.Streams["input"]; ok {
-				streamStr += "(input) "
-
-				streamInterface := streamInput.([]interface{})
-				for i, v := range streamInterface {
-					streamStr += fmt.Sprintf("%v", v)
-
-					if i < len(streamInterface)-1 {
-						streamStr += ", "
-					}
-				}
-			}
-
-			if streamOutput, ok := conn.Streams["output"]; ok {
-				streamStr += "(output) "
-
-				streamInterface := streamOutput.([]interface{})
-				for i, v := range streamInterface {
-					streamStr += fmt.Sprintf("%v", v)
-
-					if i < len(streamInterface)-1 {
-						streamStr += ", "
-					}
-				}
-			}
+			streamStr := formatStreams(conn.Streams)
 			r := []*simpletable.Cell{
 				{Align: simpletable.AlignRight, Text: fmt.Sprintf("%d", conn.ID)},
 				{Text: conn.Name},
@@ -251,6 +265,37 @@ func ConnectorsTable(connectors []*meroxa.Connector, hideHeaders bool) string {
 	}
 
 	return ""
+}
+
+func formatStreams(ss map[string]interface{}) string {
+	var streamStr string
+
+	if streamInput, ok := ss["input"]; ok {
+		streamStr += "(input) "
+
+		streamInterface := streamInput.([]interface{})
+		for i, v := range streamInterface {
+			streamStr += fmt.Sprintf("%v", v)
+
+			if i < len(streamInterface)-1 {
+				streamStr += ", "
+			}
+		}
+	}
+
+	if streamOutput, ok := ss["output"]; ok {
+		streamStr += "(output) "
+
+		streamInterface := streamOutput.([]interface{})
+		for i, v := range streamInterface {
+			streamStr += fmt.Sprintf("%v", v)
+
+			if i < len(streamInterface)-1 {
+				streamStr += ", "
+			}
+		}
+	}
+	return streamStr
 }
 
 func PrintConnectorsTable(connectors []*meroxa.Connector, hideHeaders bool) {

--- a/utils/display.go
+++ b/utils/display.go
@@ -222,7 +222,7 @@ func ConnectorTable(connector *meroxa.Connector) string {
 	if connector.Trace != "" {
 		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
 			{Align: simpletable.AlignRight, Text: "Trace:"},
-			{Text: strings.Title(connector.Trace)},
+			{Text: connector.Trace},
 		})
 	}
 	mainTable.SetStyle(simpletable.StyleCompact)

--- a/utils/display.go
+++ b/utils/display.go
@@ -215,7 +215,7 @@ func ConnectorTable(connector *meroxa.Connector) string {
 		},
 		{
 			{Align: simpletable.AlignRight, Text: "Pipeline:"},
-			{Text: strings.Title(connector.PipelineName)},
+			{Text: connector.PipelineName},
 		},
 	}
 

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -198,15 +198,17 @@ func TestConnectorRunningTable(t *testing.T) {
 		Trace:      "",
 		PipelineID: 1,
 	}
-	var failedConnector *meroxa.Connector
+	failedConnector := &meroxa.Connector{}
 	deepCopy(connector, failedConnector)
 	failedConnector.State = "failed"
 	failedConnector.Trace = "exception goes here"
 
 	tests := map[string]*meroxa.Connector{
-		"running": connector, failedConnector}
+		"running": connector,
+		"failed":  failedConnector,
+	}
 
-	tableHeaders := []string{"ID", "NAME", "TYPE", "STREAMS", "STATE", "PIPELINE"}
+	tableHeaders := []string{"ID", "Name", "Type", "Streams", "State", "Pipeline"}
 
 	for name, connector := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -221,29 +223,22 @@ func TestConnectorRunningTable(t *testing.T) {
 			}
 
 			switch name {
-			case "Base":
-				if !strings.Contains(out, connection.Name) {
-					t.Errorf("%s, not found", connection.Name)
+			case "running":
+				if !strings.Contains(out, connector.Name) {
+					t.Errorf("%s, not found", connector.Name)
 				}
-				if !strings.Contains(out, strconv.Itoa(connection.ID)) {
-					t.Errorf("%d, not found", connection.ID)
+				if !strings.Contains(out, strconv.Itoa(connector.ID)) {
+					t.Errorf("%d, not found", connector.ID)
 				}
-			case "ID_Alignment":
-				if !strings.Contains(out, connectionIDAlign.Name) {
-					t.Errorf("%s, not found", connectionIDAlign.Name)
+			case "failed":
+				if !strings.Contains(out, connector.Name) {
+					t.Errorf("%s, not found", connector.Name)
 				}
-				if !strings.Contains(out, strconv.Itoa(connectionIDAlign.ID)) {
-					t.Errorf("%d, not found", connectionIDAlign.ID)
+				if !strings.Contains(out, strconv.Itoa(connector.ID)) {
+					t.Errorf("%d, not found", connector.ID)
 				}
-			case "Input_Output":
-				if !strings.Contains(out, connectionInputOutput.Name) {
-					t.Errorf("%s, not found", connection.Name)
-				}
-				if !strings.Contains(out, "input-foo") {
-					t.Errorf("%s, not found", "input-foo")
-				}
-				if !strings.Contains(out, "output-foo") {
-					t.Errorf("%s, not found", "output-foo")
+				if !strings.Contains(out, connector.Trace) {
+					t.Errorf("%s, not found", connector.Trace)
 				}
 			}
 			fmt.Println(out)

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -183,7 +183,75 @@ func TestResourceTypesTableWithoutHeaders(t *testing.T) {
 	}
 }
 
-func TestConnectionsTable(t *testing.T) {
+func TestConnectorRunningTable(t *testing.T) {
+	connector := &meroxa.Connector{
+		ID:            0,
+		Type:          "jdbc",
+		Name:          "base",
+		Configuration: nil,
+		Metadata:      nil,
+		Streams: map[string]interface{}{
+			"dynamic": "false",
+			"output":  []interface{}{"output-foo", "output-bar"},
+		},
+		State:      "running",
+		Trace:      "",
+		PipelineID: 1,
+	}
+	var failedConnector *meroxa.Connector
+	deepCopy(connector, failedConnector)
+	failedConnector.State = "failed"
+	failedConnector.Trace = "exception goes here"
+
+	tests := map[string]*meroxa.Connector{
+		"running": connector, failedConnector}
+
+	tableHeaders := []string{"ID", "NAME", "TYPE", "STREAMS", "STATE", "PIPELINE"}
+
+	for name, connector := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := CaptureOutput(func() {
+				fmt.Println(ConnectorTable(connector))
+			})
+
+			for _, header := range tableHeaders {
+				if !strings.Contains(out, header) {
+					t.Errorf("%s header is missing", header)
+				}
+			}
+
+			switch name {
+			case "Base":
+				if !strings.Contains(out, connection.Name) {
+					t.Errorf("%s, not found", connection.Name)
+				}
+				if !strings.Contains(out, strconv.Itoa(connection.ID)) {
+					t.Errorf("%d, not found", connection.ID)
+				}
+			case "ID_Alignment":
+				if !strings.Contains(out, connectionIDAlign.Name) {
+					t.Errorf("%s, not found", connectionIDAlign.Name)
+				}
+				if !strings.Contains(out, strconv.Itoa(connectionIDAlign.ID)) {
+					t.Errorf("%d, not found", connectionIDAlign.ID)
+				}
+			case "Input_Output":
+				if !strings.Contains(out, connectionInputOutput.Name) {
+					t.Errorf("%s, not found", connection.Name)
+				}
+				if !strings.Contains(out, "input-foo") {
+					t.Errorf("%s, not found", "input-foo")
+				}
+				if !strings.Contains(out, "output-foo") {
+					t.Errorf("%s, not found", "output-foo")
+				}
+			}
+			fmt.Println(out)
+		})
+	}
+}
+
+func TestConnectorsTable(t *testing.T) {
 	connectionIDAlign := &meroxa.Connector{}
 	connectionInputOutput := &meroxa.Connector{}
 	connection := &meroxa.Connector{
@@ -264,7 +332,7 @@ func TestConnectionsTable(t *testing.T) {
 	}
 }
 
-func TestConnectionsTableWithoutHeaders(t *testing.T) {
+func TestConnectorsTableWithoutHeaders(t *testing.T) {
 	connection := &meroxa.Connector{
 		ID:            0,
 		Type:          "jdbc",


### PR DESCRIPTION
# Description of change

A trace error is returned along with failed connectors. This PR displays the contents of the trace when the `connector describe` command is used.

Fixes https://github.com/meroxa/product/issues/186

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
➜  cli git:(ah/output-trace) ✗ meroxa connector describe cdbsrc
  ID     NAME         TYPE                      STREAMS                 STATE    PIPELINE
====== ======== ================= ==================================== ======== ==========
 2470   cdbsrc   cosmosdb-source   (output) resource-2957-203946-demo   failed   vercel
```

**After this pull-request**

```
➜  cli git:(ah/output-trace) ✗ ./meroxa connector describe cdbsrc
       ID:   2470
     Name:   cdbsrc
     Type:   cosmosdb-source
  Streams:   (output) resource-2957-203946-demo
    State:   failed
 Pipeline:   Vercel
    Trace:   java.lang.RuntimeException: Client initialization failed. Check if the endpoint is reachable and if your auth token is valid
             at com.azure.cosmos.implementation.RxDocumentClientImpl.initializeGatewayConfigurationReader(RxDocumentClientImpl.java:392)
             at com.azure.cosmos.implementation.RxDocumentClientImpl.init(RxDocumentClientImpl.java:419)
             at com.azure.cosmos.implementation.AsyncDocumentClient$Builder.build(AsyncDocumentClient.java:241)
             at com.azure.cosmos.CosmosAsyncClient.<init>(CosmosAsyncClient.java:123)
             at com.azure.cosmos.CosmosClientBuilder.buildAsyncClient(CosmosClientBuilder.java:741)
             at com.azure.cosmos.kafka.connect.source.CosmosDBSourceTask.getCosmosClient(CosmosDBSourceTask.java:241)
             at com.azure.cosmos.kafka.connect.source.CosmosDBSourceTask.start(CosmosDBSourceTask.java:58)
             at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:213)
             at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:184)
             at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:234)
             at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
             at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
             at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
             at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
             at java.base/java.lang.Thread.run(Thread.java:834)
```

# Additional references

*Any additional links (if appropriate)*

# Documentation updated

No doc change required.
