### PR TITLE
annotate required flags in docs

### DIFF
--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -451,6 +451,10 @@ func buildCommandWithFlags(cmd *cobra.Command, c Command) {
 			flags = cmd.Flags()
 		}
 
+		if f.Required {
+			f.Usage += " (required)"
+		}
+
 		switch val := f.Ptr.(type) {
 		case *string:
 			if f.Default == nil {

--- a/cmd/meroxa/global/global.go
+++ b/cmd/meroxa/global/global.go
@@ -56,7 +56,7 @@ func RegisterGlobalFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&flagCLIConfigFile, "cli-config-file", "", "meroxa configuration file")
 	cmd.PersistentFlags().StringVar(&flagAPIURL, "api-url", "", "API url")
 	cmd.PersistentFlags().BoolVar(&flagDebug, "debug", false, "display any debugging information")
-	cmd.PersistentFlags().DurationVar(&flagTimeout, "timeout", time.Second*10, "set the duration of the client timeout in seconds (default 10s)") // nolint:gomnd,lll
+	cmd.PersistentFlags().DurationVar(&flagTimeout, "timeout", time.Second*10, "set the duration of the client timeout in seconds") // nolint:gomnd,lll
 
 	if err := cmd.PersistentFlags().MarkHidden("api-url"); err != nil {
 		panic(fmt.Sprintf("could not mark flag as hidden: %v", err))

--- a/docs/cmd/md/meroxa.md
+++ b/docs/cmd/md/meroxa.md
@@ -20,7 +20,7 @@ meroxa resources list --types
       --debug                    display any debugging information
   -h, --help                     help for meroxa
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_api.md
+++ b/docs/cmd/md/meroxa_api.md
@@ -26,7 +26,7 @@ meroxa api POST /v1/endpoints '{"protocol": "HTTP", "stream": "resource-2-499379
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_auth.md
+++ b/docs/cmd/md/meroxa_auth.md
@@ -14,7 +14,7 @@ Authentication commands for Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_auth_login.md
+++ b/docs/cmd/md/meroxa_auth_login.md
@@ -18,7 +18,7 @@ meroxa auth login [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_auth_logout.md
+++ b/docs/cmd/md/meroxa_auth_logout.md
@@ -18,7 +18,7 @@ meroxa auth logout [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_auth_whoami.md
+++ b/docs/cmd/md/meroxa_auth_whoami.md
@@ -25,7 +25,7 @@ meroxa whoami
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_billing.md
+++ b/docs/cmd/md/meroxa_billing.md
@@ -18,7 +18,7 @@ meroxa billing [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_completion.md
+++ b/docs/cmd/md/meroxa_completion.md
@@ -52,7 +52,7 @@ meroxa completion [bash|zsh|fish|powershell]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_config.md
+++ b/docs/cmd/md/meroxa_config.md
@@ -18,7 +18,7 @@ meroxa config [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_config_describe.md
+++ b/docs/cmd/md/meroxa_config_describe.md
@@ -35,7 +35,7 @@ refresh_token: c337a0d...c0f928b
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_connect.md
+++ b/docs/cmd/md/meroxa_connect.md
@@ -26,11 +26,11 @@ meroxa connect --from RESOURCE-NAME --to RESOURCE-NAME [flags]
 
 ```
   -c, --config string     connector configuration
-      --from string       source resource name
+      --from string       source resource name (required)
   -h, --help              help for connect
       --input string      command delimited list of input streams
-      --pipeline string   pipeline name to attach connectors to
-      --to string         destination resource name
+      --pipeline string   pipeline name to attach connectors to (required)
+      --to string         destination resource name (required)
 ```
 
 ### Options inherited from parent commands
@@ -39,7 +39,7 @@ meroxa connect --from RESOURCE-NAME --to RESOURCE-NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_connectors.md
+++ b/docs/cmd/md/meroxa_connectors.md
@@ -14,7 +14,7 @@ Manage connectors on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_connectors_create.md
+++ b/docs/cmd/md/meroxa_connectors_create.md
@@ -27,7 +27,7 @@ meroxa connectors create [NAME] --to pg2redshift --input orders --pipeline my-pi
       --from string       resource name to use as source
   -h, --help              help for create
       --input string      command delimited list of input streams
-      --pipeline string   pipeline name to attach connector to
+      --pipeline string   pipeline name to attach connector to (required)
       --to string         resource name to use as destination
 ```
 
@@ -37,7 +37,7 @@ meroxa connectors create [NAME] --to pg2redshift --input orders --pipeline my-pi
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_connectors_describe.md
+++ b/docs/cmd/md/meroxa_connectors_describe.md
@@ -18,7 +18,7 @@ meroxa connectors describe [NAME] [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_connectors_list.md
+++ b/docs/cmd/md/meroxa_connectors_list.md
@@ -20,7 +20,7 @@ meroxa connectors list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_connectors_logs.md
+++ b/docs/cmd/md/meroxa_connectors_logs.md
@@ -18,7 +18,7 @@ meroxa connectors logs NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_connectors_remove.md
+++ b/docs/cmd/md/meroxa_connectors_remove.md
@@ -19,7 +19,7 @@ meroxa connectors remove NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_connectors_update.md
+++ b/docs/cmd/md/meroxa_connectors_update.md
@@ -31,7 +31,7 @@ meroxa connector update connector-name --config '{"table.name.format":"public.co
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_endpoints.md
+++ b/docs/cmd/md/meroxa_endpoints.md
@@ -14,7 +14,7 @@ Manage endpoints on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_endpoints_create.md
+++ b/docs/cmd/md/meroxa_endpoints_create.md
@@ -20,8 +20,8 @@ meroxa endpoints create my-endpoint --protocol http --stream my-stream
 
 ```
   -h, --help              help for create
-  -p, --protocol string   protocol, value can be http or grpc
-  -s, --stream string     stream name
+  -p, --protocol string   protocol, value can be http or grpc (required)
+  -s, --stream string     stream name (required)
 ```
 
 ### Options inherited from parent commands
@@ -30,7 +30,7 @@ meroxa endpoints create my-endpoint --protocol http --stream my-stream
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_endpoints_describe.md
+++ b/docs/cmd/md/meroxa_endpoints_describe.md
@@ -18,7 +18,7 @@ meroxa endpoints describe [NAME] [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_endpoints_list.md
+++ b/docs/cmd/md/meroxa_endpoints_list.md
@@ -19,7 +19,7 @@ meroxa endpoints list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_endpoints_remove.md
+++ b/docs/cmd/md/meroxa_endpoints_remove.md
@@ -19,7 +19,7 @@ meroxa endpoints remove NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_login.md
+++ b/docs/cmd/md/meroxa_login.md
@@ -18,7 +18,7 @@ meroxa login [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_logout.md
+++ b/docs/cmd/md/meroxa_logout.md
@@ -18,7 +18,7 @@ meroxa logout [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_open.md
+++ b/docs/cmd/md/meroxa_open.md
@@ -14,7 +14,7 @@ Open in a web browser
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_open_billing.md
+++ b/docs/cmd/md/meroxa_open_billing.md
@@ -18,7 +18,7 @@ meroxa open billing [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_pipelines.md
+++ b/docs/cmd/md/meroxa_pipelines.md
@@ -14,7 +14,7 @@ Manage pipelines on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_pipelines_create.md
+++ b/docs/cmd/md/meroxa_pipelines_create.md
@@ -19,7 +19,7 @@ meroxa pipelines create NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_pipelines_list.md
+++ b/docs/cmd/md/meroxa_pipelines_list.md
@@ -19,7 +19,7 @@ meroxa pipelines list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_pipelines_remove.md
+++ b/docs/cmd/md/meroxa_pipelines_remove.md
@@ -19,7 +19,7 @@ meroxa pipelines remove NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_pipelines_update.md
+++ b/docs/cmd/md/meroxa_pipelines_update.md
@@ -30,7 +30,7 @@ meroxa pipeline update pipeline-name --metadata '{"key":"value"}'
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_resources.md
+++ b/docs/cmd/md/meroxa_resources.md
@@ -14,7 +14,7 @@ Manage resources on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_resources_create.md
+++ b/docs/cmd/md/meroxa_resources_create.md
@@ -33,8 +33,8 @@ meroxa resources create slack --type url -u $WEBHOOK_URL
       --ssh-private-key string   SSH tunneling private key
       --ssh-url string           SSH tunneling address
       --ssl                      use SSL
-      --type string              resource type
-  -u, --url string               resource url
+      --type string              resource type (required)
+  -u, --url string               resource url (required)
       --username string          username
 ```
 
@@ -44,7 +44,7 @@ meroxa resources create slack --type url -u $WEBHOOK_URL
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_resources_describe.md
+++ b/docs/cmd/md/meroxa_resources_describe.md
@@ -18,7 +18,7 @@ meroxa resources describe [NAME] [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_resources_list.md
+++ b/docs/cmd/md/meroxa_resources_list.md
@@ -20,7 +20,7 @@ meroxa resources list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_resources_remove.md
+++ b/docs/cmd/md/meroxa_resources_remove.md
@@ -19,7 +19,7 @@ meroxa resources remove NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_resources_rotate-tunnel-key.md
+++ b/docs/cmd/md/meroxa_resources_rotate-tunnel-key.md
@@ -23,7 +23,7 @@ meroxa resources rotate-tunnel-key NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_resources_update.md
+++ b/docs/cmd/md/meroxa_resources_update.md
@@ -32,7 +32,7 @@ meroxa resources update NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_resources_validate.md
+++ b/docs/cmd/md/meroxa_resources_validate.md
@@ -22,7 +22,7 @@ meroxa resources validate NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_transforms.md
+++ b/docs/cmd/md/meroxa_transforms.md
@@ -14,7 +14,7 @@ Manage transforms on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_transforms_list.md
+++ b/docs/cmd/md/meroxa_transforms_list.md
@@ -19,7 +19,7 @@ meroxa transforms list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_version.md
+++ b/docs/cmd/md/meroxa_version.md
@@ -18,7 +18,7 @@ meroxa version [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/md/meroxa_whoami.md
+++ b/docs/cmd/md/meroxa_whoami.md
@@ -25,7 +25,7 @@ meroxa whoami
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-api.md
+++ b/docs/cmd/www/meroxa-api.md
@@ -33,7 +33,7 @@ meroxa api POST /v1/endpoints '{"protocol": "HTTP", "stream": "resource-2-499379
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-auth-login.md
+++ b/docs/cmd/www/meroxa-auth-login.md
@@ -25,7 +25,7 @@ meroxa auth login [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-auth-logout.md
+++ b/docs/cmd/www/meroxa-auth-logout.md
@@ -25,7 +25,7 @@ meroxa auth logout [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-auth-whoami.md
+++ b/docs/cmd/www/meroxa-auth-whoami.md
@@ -32,7 +32,7 @@ meroxa whoami
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-auth.md
+++ b/docs/cmd/www/meroxa-auth.md
@@ -21,7 +21,7 @@ Authentication commands for Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-billing.md
+++ b/docs/cmd/www/meroxa-billing.md
@@ -25,7 +25,7 @@ meroxa billing [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-completion.md
+++ b/docs/cmd/www/meroxa-completion.md
@@ -59,7 +59,7 @@ meroxa completion [bash|zsh|fish|powershell]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-config-describe.md
+++ b/docs/cmd/www/meroxa-config-describe.md
@@ -42,7 +42,7 @@ refresh_token: c337a0d...c0f928b
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-config.md
+++ b/docs/cmd/www/meroxa-config.md
@@ -25,7 +25,7 @@ meroxa config [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-connect.md
+++ b/docs/cmd/www/meroxa-connect.md
@@ -33,11 +33,11 @@ meroxa connect --from RESOURCE-NAME --to RESOURCE-NAME [flags]
 
 ```
   -c, --config string     connector configuration
-      --from string       source resource name
+      --from string       source resource name (required)
   -h, --help              help for connect
       --input string      command delimited list of input streams
-      --pipeline string   pipeline name to attach connectors to
-      --to string         destination resource name
+      --pipeline string   pipeline name to attach connectors to (required)
+      --to string         destination resource name (required)
 ```
 
 ### Options inherited from parent commands
@@ -46,7 +46,7 @@ meroxa connect --from RESOURCE-NAME --to RESOURCE-NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-connectors-create.md
+++ b/docs/cmd/www/meroxa-connectors-create.md
@@ -34,7 +34,7 @@ meroxa connectors create [NAME] --to pg2redshift --input orders --pipeline my-pi
       --from string       resource name to use as source
   -h, --help              help for create
       --input string      command delimited list of input streams
-      --pipeline string   pipeline name to attach connector to
+      --pipeline string   pipeline name to attach connector to (required)
       --to string         resource name to use as destination
 ```
 
@@ -44,7 +44,7 @@ meroxa connectors create [NAME] --to pg2redshift --input orders --pipeline my-pi
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-connectors-describe.md
+++ b/docs/cmd/www/meroxa-connectors-describe.md
@@ -25,7 +25,7 @@ meroxa connectors describe [NAME] [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-connectors-list.md
+++ b/docs/cmd/www/meroxa-connectors-list.md
@@ -27,7 +27,7 @@ meroxa connectors list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-connectors-logs.md
+++ b/docs/cmd/www/meroxa-connectors-logs.md
@@ -25,7 +25,7 @@ meroxa connectors logs NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-connectors-remove.md
+++ b/docs/cmd/www/meroxa-connectors-remove.md
@@ -26,7 +26,7 @@ meroxa connectors remove NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-connectors-update.md
+++ b/docs/cmd/www/meroxa-connectors-update.md
@@ -38,7 +38,7 @@ meroxa connector update connector-name --config '{"table.name.format":"public.co
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-connectors.md
+++ b/docs/cmd/www/meroxa-connectors.md
@@ -21,7 +21,7 @@ Manage connectors on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-endpoints-create.md
+++ b/docs/cmd/www/meroxa-endpoints-create.md
@@ -27,8 +27,8 @@ meroxa endpoints create my-endpoint --protocol http --stream my-stream
 
 ```
   -h, --help              help for create
-  -p, --protocol string   protocol, value can be http or grpc
-  -s, --stream string     stream name
+  -p, --protocol string   protocol, value can be http or grpc (required)
+  -s, --stream string     stream name (required)
 ```
 
 ### Options inherited from parent commands
@@ -37,7 +37,7 @@ meroxa endpoints create my-endpoint --protocol http --stream my-stream
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-endpoints-describe.md
+++ b/docs/cmd/www/meroxa-endpoints-describe.md
@@ -25,7 +25,7 @@ meroxa endpoints describe [NAME] [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-endpoints-list.md
+++ b/docs/cmd/www/meroxa-endpoints-list.md
@@ -26,7 +26,7 @@ meroxa endpoints list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-endpoints-remove.md
+++ b/docs/cmd/www/meroxa-endpoints-remove.md
@@ -26,7 +26,7 @@ meroxa endpoints remove NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-endpoints.md
+++ b/docs/cmd/www/meroxa-endpoints.md
@@ -21,7 +21,7 @@ Manage endpoints on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-login.md
+++ b/docs/cmd/www/meroxa-login.md
@@ -25,7 +25,7 @@ meroxa login [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-logout.md
+++ b/docs/cmd/www/meroxa-logout.md
@@ -25,7 +25,7 @@ meroxa logout [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-open-billing.md
+++ b/docs/cmd/www/meroxa-open-billing.md
@@ -25,7 +25,7 @@ meroxa open billing [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-open.md
+++ b/docs/cmd/www/meroxa-open.md
@@ -21,7 +21,7 @@ Open in a web browser
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-pipelines-create.md
+++ b/docs/cmd/www/meroxa-pipelines-create.md
@@ -26,7 +26,7 @@ meroxa pipelines create NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-pipelines-list.md
+++ b/docs/cmd/www/meroxa-pipelines-list.md
@@ -26,7 +26,7 @@ meroxa pipelines list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-pipelines-remove.md
+++ b/docs/cmd/www/meroxa-pipelines-remove.md
@@ -26,7 +26,7 @@ meroxa pipelines remove NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-pipelines-update.md
+++ b/docs/cmd/www/meroxa-pipelines-update.md
@@ -37,7 +37,7 @@ meroxa pipeline update pipeline-name --metadata '{"key":"value"}'
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-pipelines.md
+++ b/docs/cmd/www/meroxa-pipelines.md
@@ -21,7 +21,7 @@ Manage pipelines on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-resources-create.md
+++ b/docs/cmd/www/meroxa-resources-create.md
@@ -40,8 +40,8 @@ meroxa resources create slack --type url -u $WEBHOOK_URL
       --ssh-private-key string   SSH tunneling private key
       --ssh-url string           SSH tunneling address
       --ssl                      use SSL
-      --type string              resource type
-  -u, --url string               resource url
+      --type string              resource type (required)
+  -u, --url string               resource url (required)
       --username string          username
 ```
 
@@ -51,7 +51,7 @@ meroxa resources create slack --type url -u $WEBHOOK_URL
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-resources-describe.md
+++ b/docs/cmd/www/meroxa-resources-describe.md
@@ -25,7 +25,7 @@ meroxa resources describe [NAME] [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-resources-list.md
+++ b/docs/cmd/www/meroxa-resources-list.md
@@ -27,7 +27,7 @@ meroxa resources list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-resources-remove.md
+++ b/docs/cmd/www/meroxa-resources-remove.md
@@ -26,7 +26,7 @@ meroxa resources remove NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-resources-rotate-tunnel-key.md
+++ b/docs/cmd/www/meroxa-resources-rotate-tunnel-key.md
@@ -30,7 +30,7 @@ meroxa resources rotate-tunnel-key NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-resources-update.md
+++ b/docs/cmd/www/meroxa-resources-update.md
@@ -39,7 +39,7 @@ meroxa resources update NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-resources-validate.md
+++ b/docs/cmd/www/meroxa-resources-validate.md
@@ -29,7 +29,7 @@ meroxa resources validate NAME [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-resources.md
+++ b/docs/cmd/www/meroxa-resources.md
@@ -21,7 +21,7 @@ Manage resources on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-transforms-list.md
+++ b/docs/cmd/www/meroxa-transforms-list.md
@@ -26,7 +26,7 @@ meroxa transforms list [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-transforms.md
+++ b/docs/cmd/www/meroxa-transforms.md
@@ -21,7 +21,7 @@ Manage transforms on Meroxa
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-version.md
+++ b/docs/cmd/www/meroxa-version.md
@@ -25,7 +25,7 @@ meroxa version [flags]
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa-whoami.md
+++ b/docs/cmd/www/meroxa-whoami.md
@@ -32,7 +32,7 @@ meroxa whoami
       --cli-config-file string   meroxa configuration file
       --debug                    display any debugging information
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/docs/cmd/www/meroxa.md
+++ b/docs/cmd/www/meroxa.md
@@ -27,7 +27,7 @@ meroxa resources list --types
       --debug                    display any debugging information
   -h, --help                     help for meroxa
       --json                     output json
-      --timeout duration         set the duration of the client timeout in seconds (default 10s) (default 10s)
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
 ```
 
 ### SEE ALSO

--- a/etc/man/man1/meroxa-api.1
+++ b/etc/man/man1/meroxa-api.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Invoke Meroxa API
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa-auth-login.1
+++ b/etc/man/man1/meroxa-auth-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Login or Sign up to the Meroxa Platform
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-auth-logout.1
+++ b/etc/man/man1/meroxa-auth-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Clears local login credentials of the Meroxa Platform
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-auth-whoami.1
+++ b/etc/man/man1/meroxa-auth-whoami.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Display the current logged in user
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa-auth.1
+++ b/etc/man/man1/meroxa-auth.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Authentication commands for Meroxa
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-billing.1
+++ b/etc/man/man1/meroxa-billing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Open your billing page in a web browser
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-completion.1
+++ b/etc/man/man1/meroxa-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -73,7 +73,7 @@ $ meroxa completion fish > \~/.config/fish/completions/meroxa.fish
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-config-describe.1
+++ b/etc/man/man1/meroxa-config-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ This command will return the content of your configuration file where you could 
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa-config.1
+++ b/etc/man/man1/meroxa-config.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Manage your Meroxa CLI configuration
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-connect.1
+++ b/etc/man/man1/meroxa-connect.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -38,7 +38,7 @@ meroxa connector create \-\-to redshift \-\-input orders \-\-pipeline my\-pipeli
 
 .PP
 \fB\-\-from\fP=""
-	source resource name
+	source resource name (required)
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
@@ -50,11 +50,11 @@ meroxa connector create \-\-to redshift \-\-input orders \-\-pipeline my\-pipeli
 
 .PP
 \fB\-\-pipeline\fP=""
-	pipeline name to attach connectors to
+	pipeline name to attach connectors to (required)
 
 .PP
 \fB\-\-to\fP=""
-	destination resource name
+	destination resource name (required)
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -72,7 +72,7 @@ meroxa connector create \-\-to redshift \-\-input orders \-\-pipeline my\-pipeli
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-connectors-create.1
+++ b/etc/man/man1/meroxa-connectors-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -35,7 +35,7 @@ Use \fB\fCconnectors create\fR to create a connector from a source (\-\-from) or
 
 .PP
 \fB\-\-pipeline\fP=""
-	pipeline name to attach connector to
+	pipeline name to attach connector to (required)
 
 .PP
 \fB\-\-to\fP=""
@@ -57,7 +57,7 @@ Use \fB\fCconnectors create\fR to create a connector from a source (\-\-from) or
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa-connectors-describe.1
+++ b/etc/man/man1/meroxa-connectors-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Describe connector
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-connectors-list.1
+++ b/etc/man/man1/meroxa-connectors-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -45,7 +45,7 @@ List connectors
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-connectors-logs.1
+++ b/etc/man/man1/meroxa-connectors-logs.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Print logs for a connector
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-connectors-remove.1
+++ b/etc/man/man1/meroxa-connectors-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ Remove connector
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-connectors-update.1
+++ b/etc/man/man1/meroxa-connectors-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -49,7 +49,7 @@ Update connector name, configuration or state
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa-connectors.1
+++ b/etc/man/man1/meroxa-connectors.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Manage connectors on Meroxa
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-endpoints-create.1
+++ b/etc/man/man1/meroxa-endpoints-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -23,11 +23,11 @@ Use create endpoint to expose an endpoint to a connector stream
 
 .PP
 \fB\-p\fP, \fB\-\-protocol\fP=""
-	protocol, value can be http or grpc
+	protocol, value can be http or grpc (required)
 
 .PP
 \fB\-s\fP, \fB\-\-stream\fP=""
-	stream name
+	stream name (required)
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -45,7 +45,7 @@ Use create endpoint to expose an endpoint to a connector stream
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa-endpoints-describe.1
+++ b/etc/man/man1/meroxa-endpoints-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Describe endpoint
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-endpoints-list.1
+++ b/etc/man/man1/meroxa-endpoints-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ List endpoints
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-endpoints-remove.1
+++ b/etc/man/man1/meroxa-endpoints-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ Remove endpoint
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-endpoints.1
+++ b/etc/man/man1/meroxa-endpoints.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Manage endpoints on Meroxa
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-login.1
+++ b/etc/man/man1/meroxa-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Login or Sign up to the Meroxa Platform
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-logout.1
+++ b/etc/man/man1/meroxa-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Clears local login credentials of the Meroxa Platform
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-open-billing.1
+++ b/etc/man/man1/meroxa-open-billing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Open your billing page in a web browser
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-open.1
+++ b/etc/man/man1/meroxa-open.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Open in a web browser
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-pipelines-create.1
+++ b/etc/man/man1/meroxa-pipelines-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ Create a pipeline
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-pipelines-list.1
+++ b/etc/man/man1/meroxa-pipelines-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ List pipelines
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-pipelines-remove.1
+++ b/etc/man/man1/meroxa-pipelines-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ Remove pipeline
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-pipelines-update.1
+++ b/etc/man/man1/meroxa-pipelines-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -49,7 +49,7 @@ Update pipeline name, state or metadata
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa-pipelines.1
+++ b/etc/man/man1/meroxa-pipelines.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Manage pipelines on Meroxa
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-resources-create.1
+++ b/etc/man/man1/meroxa-resources-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -55,11 +55,11 @@ Use the create command to add resources to your Meroxa resource catalog.
 
 .PP
 \fB\-\-type\fP=""
-	resource type
+	resource type (required)
 
 .PP
 \fB\-u\fP, \fB\-\-url\fP=""
-	resource url
+	resource url (required)
 
 .PP
 \fB\-\-username\fP=""
@@ -81,7 +81,7 @@ Use the create command to add resources to your Meroxa resource catalog.
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa-resources-describe.1
+++ b/etc/man/man1/meroxa-resources-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Describe resource
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-resources-list.1
+++ b/etc/man/man1/meroxa-resources-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -45,7 +45,7 @@ List resources and resource types
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-resources-remove.1
+++ b/etc/man/man1/meroxa-resources-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ Remove resource
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-resources-rotate-tunnel-key.1
+++ b/etc/man/man1/meroxa-resources-rotate-tunnel-key.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ Rotate the tunnel key for a Meroxa resource.
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-resources-update.1
+++ b/etc/man/man1/meroxa-resources-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -77,7 +77,7 @@ Use the update command to update various Meroxa resources.
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-resources-validate.1
+++ b/etc/man/man1/meroxa-resources-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Validate a Meroxa resource.
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-resources.1
+++ b/etc/man/man1/meroxa-resources.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Manage resources on Meroxa
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-transforms-list.1
+++ b/etc/man/man1/meroxa-transforms-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -41,7 +41,7 @@ List transforms
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-transforms.1
+++ b/etc/man/man1/meroxa-transforms.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Manage transforms on Meroxa
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-version.1
+++ b/etc/man/man1/meroxa-version.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Display the Meroxa CLI version
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO

--- a/etc/man/man1/meroxa-whoami.1
+++ b/etc/man/man1/meroxa-whoami.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -37,7 +37,7 @@ Display the current logged in user
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH EXAMPLE

--- a/etc/man/man1/meroxa.1
+++ b/etc/man/man1/meroxa.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Sep 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Oct 2021" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -43,7 +43,7 @@ meroxa resources list \-\-types
 
 .PP
 \fB\-\-timeout\fP=10s
-	set the duration of the client timeout in seconds (default 10s)
+	set the duration of the client timeout in seconds
 
 
 .SH SEE ALSO


### PR DESCRIPTION
# Description of change

Inspired by @hariso comment I created this PR, which adds the string "(required)" to the docs of all required flags. It also removes the suffix "(default 10s)" from the timeout flag, since that's automatically added by cobra.

~I did not update the docs yet as I want to first make sure we actually want to do this.~
Documentation is changed: https://github.com/meroxa/meroxa-docs/pull/45

# Type of change

- [X]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [X]  Documentation

# How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
$ meroxa connector create --help
Use `connectors create` to create a connector from a source (--from) or to a destination (--to) within a pipeline (--pipeline)

Usage:
  meroxa connectors create [NAME] [flags]

Examples:

meroxa connectors create [NAME] --from pg2kafka --input accounts --pipeline my-pipeline
meroxa connectors create [NAME] --to pg2redshift --input orders --pipeline my-pipeline # --input will be the desired stream
meroxa connectors create [NAME] --to pg2redshift --input orders --pipeline my-pipeline


Flags:
      --from string       resource name to use as source
  -h, --help              help for create
      --input string      command delimited list of input streams
      --pipeline string   pipeline name to attach connector to
      --to string         resource name to use as destination

Global Flags:
      --config string      config file
      --debug              display any debugging information
      --json               output json
      --timeout duration   set the duration of the client timeout in seconds (default 10s) (default 10s)
```

**After this pull-request**

```
$ meroxa connectors create --help
Use `connectors create` to create a connector from a source (--from) or to a destination (--to) within a pipeline (--pipeline)

Usage:
  meroxa connectors create [NAME] [flags]

Examples:

meroxa connectors create [NAME] --from pg2kafka --input accounts --pipeline my-pipeline
meroxa connectors create [NAME] --to pg2redshift --input orders --pipeline my-pipeline # --input will be the desired stream
meroxa connectors create [NAME] --to pg2redshift --input orders --pipeline my-pipeline


Flags:
  -c, --config string     connector configuration
      --from string       resource name to use as source
  -h, --help              help for create
      --input string      command delimited list of input streams
      --pipeline string   pipeline name to attach connector to (required)
      --to string         resource name to use as destination

Global Flags:
      --cli-config-file string   meroxa configuration file
      --debug                    display any debugging information
      --json                     output json
      --timeout duration         set the duration of the client timeout in seconds (default 10s)
```