### PR TITLE
doc: Indicate possible states when updating a pipeline or a connector

### DIFF
--- a/cmd/meroxa/root/connectors/update.go
+++ b/cmd/meroxa/root/connectors/update.go
@@ -45,12 +45,12 @@ type Update struct {
 	flags struct {
 		Config string `long:"config" short:"c" usage:"new connector configuration"`
 		Name   string `long:"name" usage:"new connector name"`
-		State  string `long:"state" usage:"new connector state"`
+		State  string `long:"state" usage:"new connector state (pause | resume | restart)"`
 	}
 }
 
 func (u *Update) Usage() string {
-	return "update NAME --state pause | resume | restart --name new-name --config new-configuration"
+	return "update NAME"
 }
 
 func (u *Update) Docs() builder.Docs {
@@ -59,7 +59,8 @@ func (u *Update) Docs() builder.Docs {
 		Example: "\n" +
 			"meroxa connector update old-name --name new-name' \n" +
 			"meroxa connector update connector-name --state pause' \n" +
-			"meroxa connector update connector-name --config '{\"table.name.format\":\"public.copy\"}' \n",
+			"meroxa connector update connector-name --config '{\"table.name.format\":\"public.copy\"}' \n" +
+			"meroxa connector update connector-name --state restart' \n",
 	}
 }
 

--- a/cmd/meroxa/root/pipelines/update.go
+++ b/cmd/meroxa/root/pipelines/update.go
@@ -44,7 +44,7 @@ type Update struct {
 	}
 
 	flags struct {
-		State    string `long:"state" usage:"new pipeline state"`
+		State    string `long:"state" usage:"new pipeline state (pause | resume | restart)"`
 		Name     string `long:"name" usage:"new pipeline name"`
 		Metadata string `long:"metadata" short:"m" usage:"new pipeline metadata"`
 	}
@@ -60,7 +60,8 @@ func (u *Update) Docs() builder.Docs {
 		Example: "\n" +
 			"meroxa pipeline update old-name --name new-name\n" +
 			"meroxa pipeline update pipeline-name --state pause\n" +
-			"meroxa pipeline update pipeline-name --metadata '{\"key\":\"value\"}'",
+			"meroxa pipeline update pipeline-name --metadata '{\"key\":\"value\"}'\n" +
+			"meroxa pipeline update pipeline-name --state restart",
 	}
 }
 

--- a/docs/cmd/md/meroxa_connectors_update.md
+++ b/docs/cmd/md/meroxa_connectors_update.md
@@ -3,7 +3,7 @@
 Update connector name, configuration or state
 
 ```
-meroxa connectors update NAME --state pause | resume | restart --name new-name --config new-configuration [flags]
+meroxa connectors update NAME [flags]
 ```
 
 ### Examples
@@ -13,6 +13,7 @@ meroxa connectors update NAME --state pause | resume | restart --name new-name -
 meroxa connector update old-name --name new-name' 
 meroxa connector update connector-name --state pause' 
 meroxa connector update connector-name --config '{"table.name.format":"public.copy"}' 
+meroxa connector update connector-name --state restart' 
 
 ```
 
@@ -22,7 +23,7 @@ meroxa connector update connector-name --config '{"table.name.format":"public.co
   -c, --config string   new connector configuration
   -h, --help            help for update
       --name string     new connector name
-      --state string    new connector state
+      --state string    new connector state (pause | resume | restart)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/md/meroxa_pipelines_update.md
+++ b/docs/cmd/md/meroxa_pipelines_update.md
@@ -13,6 +13,7 @@ meroxa pipelines update NAME [flags]
 meroxa pipeline update old-name --name new-name
 meroxa pipeline update pipeline-name --state pause
 meroxa pipeline update pipeline-name --metadata '{"key":"value"}'
+meroxa pipeline update pipeline-name --state restart
 ```
 
 ### Options
@@ -21,7 +22,7 @@ meroxa pipeline update pipeline-name --metadata '{"key":"value"}'
   -h, --help              help for update
   -m, --metadata string   new pipeline metadata
       --name string       new pipeline name
-      --state string      new pipeline state
+      --state string      new pipeline state (pause | resume | restart)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/www/meroxa-connectors-update.md
+++ b/docs/cmd/www/meroxa-connectors-update.md
@@ -10,7 +10,7 @@ url: /cli/cmd/meroxa-connectors-update/
 Update connector name, configuration or state
 
 ```
-meroxa connectors update NAME --state pause | resume | restart --name new-name --config new-configuration [flags]
+meroxa connectors update NAME [flags]
 ```
 
 ### Examples
@@ -20,6 +20,7 @@ meroxa connectors update NAME --state pause | resume | restart --name new-name -
 meroxa connector update old-name --name new-name' 
 meroxa connector update connector-name --state pause' 
 meroxa connector update connector-name --config '{"table.name.format":"public.copy"}' 
+meroxa connector update connector-name --state restart' 
 
 ```
 
@@ -29,7 +30,7 @@ meroxa connector update connector-name --config '{"table.name.format":"public.co
   -c, --config string   new connector configuration
   -h, --help            help for update
       --name string     new connector name
-      --state string    new connector state
+      --state string    new connector state (pause | resume | restart)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cmd/www/meroxa-pipelines-update.md
+++ b/docs/cmd/www/meroxa-pipelines-update.md
@@ -20,6 +20,7 @@ meroxa pipelines update NAME [flags]
 meroxa pipeline update old-name --name new-name
 meroxa pipeline update pipeline-name --state pause
 meroxa pipeline update pipeline-name --metadata '{"key":"value"}'
+meroxa pipeline update pipeline-name --state restart
 ```
 
 ### Options
@@ -28,7 +29,7 @@ meroxa pipeline update pipeline-name --metadata '{"key":"value"}'
   -h, --help              help for update
   -m, --metadata string   new pipeline metadata
       --name string       new pipeline name
-      --state string      new pipeline state
+      --state string      new pipeline state (pause | resume | restart)
 ```
 
 ### Options inherited from parent commands

--- a/etc/man/man1/meroxa-connectors-update.1
+++ b/etc/man/man1/meroxa-connectors-update.1
@@ -8,7 +8,7 @@ meroxa\-connectors\-update \- Update connector name, configuration or state
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa connectors update NAME \-\-state pause | resume | restart \-\-name new\-name \-\-config new\-configuration [flags]\fP
+\fBmeroxa connectors update NAME [flags]\fP
 
 
 .SH DESCRIPTION
@@ -31,7 +31,7 @@ Update connector name, configuration or state
 
 .PP
 \fB\-\-state\fP=""
-	new connector state
+	new connector state (pause | resume | restart)
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -61,6 +61,7 @@ Update connector name, configuration or state
 meroxa connector update old\-name \-\-name new\-name' 
 meroxa connector update connector\-name \-\-state pause' 
 meroxa connector update connector\-name \-\-config '{"table.name.format":"public.copy"}' 
+meroxa connector update connector\-name \-\-state restart' 
 
 
 .fi

--- a/etc/man/man1/meroxa-pipelines-update.1
+++ b/etc/man/man1/meroxa-pipelines-update.1
@@ -31,7 +31,7 @@ Update pipeline name, state or metadata
 
 .PP
 \fB\-\-state\fP=""
-	new pipeline state
+	new pipeline state (pause | resume | restart)
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -61,6 +61,7 @@ Update pipeline name, state or metadata
 meroxa pipeline update old\-name \-\-name new\-name
 meroxa pipeline update pipeline\-name \-\-state pause
 meroxa pipeline update pipeline\-name \-\-metadata '{"key":"value"}'
+meroxa pipeline update pipeline\-name \-\-state restart
 
 .fi
 .RE


### PR DESCRIPTION
# Description of change

Working on https://meroxa.zendesk.com/agent/tickets/121 I realized we don't indicate well the different possible states when updating a pipeline. For `connectors update` we showed them as part of `usage` although it also included `[FLAGS]` right after it so it wasn't entirely right. This pull-request makes that a bit clearer.

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [x]  Documentation

# Demo

**Before this pull-request**

```
Usage:
  meroxa pipelines update NAME [flags]

Examples:

meroxa pipeline update old-name --name new-name
meroxa pipeline update pipeline-name --state pause
meroxa pipeline update pipeline-name --metadata '{"key":"value"}'

Flags:
...
      --state string      new pipeline state
```

**After this pull-request**

```
Usage:
  meroxa pipelines update NAME [flags]

Examples:

meroxa pipeline update old-name --name new-name
meroxa pipeline update pipeline-name --state pause
meroxa pipeline update pipeline-name --metadata '{"key":"value"}'
meroxa pipeline update pipeline-name --state restart

Flags:
...
      --state string      new pipeline state (pause | resume | restart)
```

# Additional references

I wonder if those states comma separated would make more sense.

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
