### PR TITLE
Update CI actions in release workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,29 +32,29 @@ jobs:
       - name: Build and Run
         working-directory: ./acceptance
         env:
-          AUTH0_CLIENT_ID: ${{ secrets.AUTH0_ACCEPTANCE_STAGING_CLIENT_ID }}
-          AUTH0_DOMAIN: ${{ secrets.AUTH0_STAGING_DOMAIN }}
-          AUTH0_AUDIENCE: ${{ secrets.AUTH0_STAGING_AUDIENCE }}
-          AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_ACCEPTANCE_STAGING_CLIENT_SECRET }}
-          AUTH0_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
-          AUTH0_USERNAME: ${{ secrets.AUTH0_USERNAME }}
+          MEROXA_AUTH_CLIENT_ID: ${{ secrets.AUTH0_ACCEPTANCE_STAGING_CLIENT_ID }}
+          MEROXA_AUTH_DOMAIN: ${{ secrets.AUTH0_STAGING_DOMAIN }}
+          MEROXA_AUTH_AUDIENCE: ${{ secrets.AUTH0_STAGING_AUDIENCE }}
+          MEROXA_AUTH_CLIENT_SECRET: ${{ secrets.AUTH0_ACCEPTANCE_STAGING_CLIENT_SECRET }}
+          MEROXA_AUTH_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
+          MEROXA_AUTH_USERNAME: ${{ secrets.AUTH0_USERNAME }}
           PG_URL: ${{ secrets.TEST_DB_URL }}
           PRIVATE_PG_URL: ${{ secrets.TEST_PRIVATE_PG_URL }}
           MYSQL_URL:  ${{ secrets.TEST_MYSQL_URL }}
           SQLSERVER_URL: ${{ secrets.TEST_SQLSERVER_URL }}
-          API_URL: "https://api.staging.meroxa.io"
+          MEROXA_API_URL: "https://api.staging.meroxa.io"
           BASTION_PRIVATE_KEY: ${{ secrets.TEST_BASTION_PRIVATE_KEY }}
           BASTION_USER: "ec2-user"
           BASTION_URL: ${{ secrets.TEST_BASTION_URL }}
         run: |
           docker build -t meroxa/acceptance --build-arg=CLI_PATH=./cli .
           docker run \
-            -e AUTH0_DOMAIN=${AUTH0_DOMAIN} \
-            -e AUTH0_CLIENT_ID=${AUTH0_CLIENT_ID} \
-            -e AUTH0_CLIENT_SECRET=${AUTH0_CLIENT_SECRET} \
-            -e AUTH0_PASSWORD=${AUTH0_PASSWORD} \
-            -e AUTH0_USERNAME=${AUTH0_USERNAME} \
-            -e AUTH0_AUDIENCE=${AUTH0_AUDIENCE} \
+            -e MEROXA_AUTH_DOMAIN=${MEROXA_AUTH_DOMAIN} \
+            -e MEROXA_AUTH_CLIENT_ID=${MEROXA_AUTH_CLIENT_ID} \
+            -e MEROXA_AUTH_CLIENT_SECRET=${MEROXA_AUTH_CLIENT_SECRET} \
+            -e MEROXA_AUTH_PASSWORD=${MEROXA_AUTH_PASSWORD} \
+            -e MEROXA_AUTH_USERNAME=${MEROXA_AUTH_USERNAME} \
+            -e MEROXA_AUTH_AUDIENCE=${MEROXA_AUTH_AUDIENCE} \
             -e ACCEPTANCE_TEST_POSTGRES_URL=${PG_URL} \
             -e ACCEPTANCE_TEST_PRIVATE_POSTGRES_URL=${PRIVATE_PG_URL} \
             -e ACCEPTANCE_TEST_MYSQL_URL=${MYSQL_URL} \
@@ -62,4 +62,5 @@ jobs:
             -e ACCEPTANCE_TEST_BASTION_PRIVATE_KEY="${BASTION_PRIVATE_KEY}" \
             -e ACCEPTANCE_TEST_BASTION_USER=${BASTION_USER} \
             -e ACCEPTANCE_TEST_BASTION_URL=${BASTION_URL} \
-            meroxa/acceptance -test.v -api-host $API_URL
+            -e ACCEPTANCE_TEST_API_HOST=${MEROXA_API_URL} \
+            meroxa/acceptance -test.v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,13 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v3.1.0
+        uses: crazy-max/ghaction-import-gpg@v4
         with:
           gpg-private-key: ${{ secrets.MEROXA_MACHINE_GPG_KEY }}
           passphrase: ${{ secrets.MEROXA_MACHINE_GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
# Description of change

Updates CI actions that are part of the release workflow to the latest version. This should solve the problem with a deprecated setting in the generated brew formula (see https://github.com/meroxa/homebrew-taps/pull/1).

# Type of change

- [X]  CI Action

# How was this tested?

**This was not tested.** I went through the documentation of the CI actions and looks like the config did not change from what we had before.