### PR TITLE
feat(pipelines): Add environments

### DIFF
--- a/cmd/meroxa/root/pipelines/create.go
+++ b/cmd/meroxa/root/pipelines/create.go
@@ -58,13 +58,7 @@ type Create struct {
 }
 
 func (c *Create) Execute(ctx context.Context) error {
-	env := string(meroxa.EnvironmentTypeCommon)
-
-	if c.flags.Environment != "" {
-		env = c.flags.Environment
-	}
-
-	c.logger.Infof(ctx, "Creating pipeline %q in %q environment...", c.args.Name, env)
+	var env string
 
 	p := &meroxa.CreatePipelineInput{
 		Name: c.args.Name,
@@ -81,6 +75,7 @@ func (c *Create) Execute(ctx context.Context) error {
 	}
 
 	if c.flags.Environment != "" {
+		env = c.flags.Environment
 		p.Environment = &meroxa.PipelineEnvironment{}
 
 		_, err := uuid.Parse(c.flags.Environment)
@@ -90,8 +85,11 @@ func (c *Create) Execute(ctx context.Context) error {
 		} else {
 			p.Environment.Name = c.flags.Environment
 		}
+	} else {
+		env = string(meroxa.EnvironmentTypeCommon)
 	}
 
+	c.logger.Infof(ctx, "Creating pipeline %q in %q environment...", c.args.Name, env)
 	pipeline, err := c.client.CreatePipeline(ctx, p)
 
 	if err != nil {

--- a/cmd/meroxa/root/pipelines/describe.go
+++ b/cmd/meroxa/root/pipelines/describe.go
@@ -1,0 +1,88 @@
+/*
+Copyright © 2021 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelines
+
+import (
+	"context"
+	"errors"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+var (
+	_ builder.CommandWithDocs    = (*Describe)(nil)
+	_ builder.CommandWithArgs    = (*Describe)(nil)
+	_ builder.CommandWithClient  = (*Describe)(nil)
+	_ builder.CommandWithLogger  = (*Describe)(nil)
+	_ builder.CommandWithExecute = (*Describe)(nil)
+)
+
+type describeResourceClient interface {
+	GetPipelineByName(ctx context.Context, name string) (*meroxa.Pipeline, error)
+}
+
+type Describe struct {
+	client describeResourceClient
+	logger log.Logger
+
+	args struct {
+		Name string
+	}
+}
+
+func (d *Describe) Usage() string {
+	return "describe [NAME]"
+}
+
+func (d *Describe) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Describe pipeline",
+	}
+}
+
+func (d *Describe) Execute(ctx context.Context) error {
+	p, err := d.client.GetPipelineByName(ctx, d.args.Name)
+	if err != nil {
+		return err
+	}
+
+	d.logger.Info(ctx, utils.PipelineTable(p))
+
+	d.logger.JSON(ctx, p)
+
+	return nil
+}
+
+func (d *Describe) Client(client meroxa.Client) {
+	d.client = client
+}
+
+func (d *Describe) Logger(logger log.Logger) {
+	d.logger = logger
+}
+
+func (d *Describe) ParseArgs(args []string) error {
+	if len(args) < 1 {
+		return errors.New("requires pipeline name")
+	}
+
+	d.args.Name = args[0]
+	return nil
+}

--- a/cmd/meroxa/root/pipelines/describe_test.go
+++ b/cmd/meroxa/root/pipelines/describe_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright © 2021 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pipelines
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+	"github.com/meroxa/meroxa-go/pkg/mock"
+)
+
+func TestDescribePipelineArgs(t *testing.T) {
+	tests := []struct {
+		args []string
+		err  error
+		name string
+	}{
+		{args: nil, err: errors.New("requires pipeline name"), name: ""},
+		{args: []string{"pipeline-name"}, err: nil, name: "pipeline-name"},
+	}
+
+	for _, tt := range tests {
+		ar := &Describe{}
+		err := ar.ParseArgs(tt.args)
+
+		if err != nil && tt.err.Error() != err.Error() {
+			t.Fatalf("expected \"%s\" got \"%s\"", tt.err, err)
+		}
+
+		if tt.name != ar.args.Name {
+			t.Fatalf("expected \"%s\" got \"%s\"", tt.name, ar.args.Name)
+		}
+	}
+}
+
+func TestDescribePipelineExecution(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockClient(ctrl)
+	logger := log.NewTestLogger()
+
+	p := utils.GeneratePipelineWithEnvironment()
+	client.
+		EXPECT().
+		GetPipelineByName(
+			ctx,
+			p.Name,
+		).
+		Return(&p, nil)
+
+	dp := &Describe{
+		client: client,
+		logger: logger,
+	}
+	dp.args.Name = p.Name
+
+	err := dp.Execute(ctx)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	gotLeveledOutput := logger.LeveledOutput()
+	wantLeveledOutput := utils.PipelineTable(&p)
+
+	if !strings.Contains(gotLeveledOutput, wantLeveledOutput) {
+		t.Fatalf("expected output:\n%s\ngot:\n%s", wantLeveledOutput, gotLeveledOutput)
+	}
+
+	gotJSONOutput := logger.JSONOutput()
+	var gotPipeline meroxa.Pipeline
+	err = json.Unmarshal([]byte(gotJSONOutput), &gotPipeline)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	if !reflect.DeepEqual(gotPipeline, p) {
+		t.Fatalf("expected \"%v\", got \"%v\"", p, gotPipeline)
+	}
+}

--- a/cmd/meroxa/root/pipelines/pipelines.go
+++ b/cmd/meroxa/root/pipelines/pipelines.go
@@ -46,6 +46,7 @@ func (*Pipelines) Docs() builder.Docs {
 func (*Pipelines) SubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		builder.BuildCobraCommand(&Create{}),
+		builder.BuildCobraCommand(&Describe{}),
 		builder.BuildCobraCommand(&List{}),
 		builder.BuildCobraCommand(&Remove{}),
 		builder.BuildCobraCommand(&Update{}),

--- a/docs/cmd/md/meroxa_pipelines.md
+++ b/docs/cmd/md/meroxa_pipelines.md
@@ -21,6 +21,7 @@ Manage pipelines on Meroxa
 
 * [meroxa](meroxa.md)	 - The Meroxa CLI
 * [meroxa pipelines create](meroxa_pipelines_create.md)	 - Create a pipeline
+* [meroxa pipelines describe](meroxa_pipelines_describe.md)	 - Describe pipeline
 * [meroxa pipelines list](meroxa_pipelines_list.md)	 - List pipelines
 * [meroxa pipelines remove](meroxa_pipelines_remove.md)	 - Remove pipeline
 * [meroxa pipelines update](meroxa_pipelines_update.md)	 - Update pipeline name, state or metadata

--- a/docs/cmd/md/meroxa_pipelines_describe.md
+++ b/docs/cmd/md/meroxa_pipelines_describe.md
@@ -1,0 +1,27 @@
+## meroxa pipelines describe
+
+Describe pipeline
+
+```
+meroxa pipelines describe [NAME] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa pipelines](meroxa_pipelines.md)	 - Manage pipelines on Meroxa
+

--- a/docs/cmd/www/meroxa-pipelines-describe.md
+++ b/docs/cmd/www/meroxa-pipelines-describe.md
@@ -1,0 +1,34 @@
+---
+createdAt: 
+updatedAt: 
+title: "meroxa pipelines describe"
+slug: meroxa-pipelines-describe
+url: /cli/cmd/meroxa-pipelines-describe/
+---
+## meroxa pipelines describe
+
+Describe pipeline
+
+```
+meroxa pipelines describe [NAME] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa pipelines](/cli/cmd/meroxa-pipelines/)	 - Manage pipelines on Meroxa
+

--- a/docs/cmd/www/meroxa-pipelines.md
+++ b/docs/cmd/www/meroxa-pipelines.md
@@ -28,6 +28,7 @@ Manage pipelines on Meroxa
 
 * [meroxa](/cli/cmd/meroxa/)	 - The Meroxa CLI
 * [meroxa pipelines create](/cli/cmd/meroxa-pipelines-create/)	 - Create a pipeline
+* [meroxa pipelines describe](/cli/cmd/meroxa-pipelines-describe/)	 - Describe pipeline
 * [meroxa pipelines list](/cli/cmd/meroxa-pipelines-list/)	 - List pipelines
 * [meroxa pipelines remove](/cli/cmd/meroxa-pipelines-remove/)	 - Remove pipeline
 * [meroxa pipelines update](/cli/cmd/meroxa-pipelines-update/)	 - Update pipeline name, state or metadata

--- a/etc/completion/meroxa.completion.sh
+++ b/etc/completion/meroxa.completion.sh
@@ -1369,6 +1369,34 @@ _meroxa_pipelines_create()
     noun_aliases=()
 }
 
+_meroxa_pipelines_describe()
+{
+    last_command="meroxa_pipelines_describe"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _meroxa_pipelines_help()
 {
     last_command="meroxa_pipelines_help"
@@ -1498,6 +1526,7 @@ _meroxa_pipelines()
 
     commands=()
     commands+=("create")
+    commands+=("describe")
     commands+=("help")
     commands+=("list")
     if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then

--- a/etc/man/man1/meroxa-pipelines-describe.1
+++ b/etc/man/man1/meroxa-pipelines-describe.1
@@ -3,23 +3,23 @@
 
 .SH NAME
 .PP
-meroxa\-pipelines \- Manage pipelines on Meroxa
+meroxa\-pipelines\-describe \- Describe pipeline
 
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa pipelines [flags]\fP
+\fBmeroxa pipelines describe [NAME] [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
-Manage pipelines on Meroxa
+Describe pipeline
 
 
 .SH OPTIONS
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
-	help for pipelines
+	help for describe
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -42,4 +42,4 @@ Manage pipelines on Meroxa
 
 .SH SEE ALSO
 .PP
-\fBmeroxa(1)\fP, \fBmeroxa\-pipelines\-create(1)\fP, \fBmeroxa\-pipelines\-describe(1)\fP, \fBmeroxa\-pipelines\-list(1)\fP, \fBmeroxa\-pipelines\-remove(1)\fP, \fBmeroxa\-pipelines\-update(1)\fP
+\fBmeroxa\-pipelines(1)\fP

--- a/go.mod
+++ b/go.mod
@@ -55,3 +55,5 @@ require (
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20211129114423-a076cb0bbfbd
+	github.com/meroxa/meroxa-go v0.0.0-20211129120745-db529ae4ef81
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect
@@ -55,5 +55,3 @@ require (
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.sum
+++ b/go.sum
@@ -223,6 +223,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/meroxa/meroxa-go v0.0.0-20211129120745-db529ae4ef81 h1:/XY4BLcUE5GXMmjiLAtbJAIg3v9L2U6/NIwaY7i44rc=
+github.com/meroxa/meroxa-go v0.0.0-20211129120745-db529ae4ef81/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,6 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/meroxa/meroxa-go v0.0.0-20211129114423-a076cb0bbfbd h1:NtbUYqnzKWSg8Kg/KStwaKOkhZRvYsIqgBz4DeZg1xs=
-github.com/meroxa/meroxa-go v0.0.0-20211129114423-a076cb0bbfbd/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/utils/display.go
+++ b/utils/display.go
@@ -122,6 +122,52 @@ func ResourceTable(res *meroxa.Resource) string {
 	return mainTable.String()
 }
 
+func PipelineTable(p *meroxa.Pipeline) string {
+	mainTable := simpletable.New()
+	mainTable.Body.Cells = [][]*simpletable.Cell{
+		{
+			{Align: simpletable.AlignRight, Text: "UUID:"},
+			{Text: p.UUID},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "ID:"},
+			{Text: fmt.Sprintf("%d", p.ID)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Name:"},
+			{Text: p.Name},
+		},
+	}
+
+	if p.Environment != nil {
+		if pU := p.Environment.UUID; pU != "" {
+			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: "Environment UUID:"},
+				{Text: pU},
+			})
+		}
+		if pN := p.Environment.Name; pN != "" {
+			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: "Environment Name:"},
+				{Text: pN},
+			})
+		}
+	}
+
+	mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+		{Align: simpletable.AlignRight, Text: "State:"},
+		{Text: strings.Title(string(p.State))},
+	})
+
+	mainTable.SetStyle(simpletable.StyleCompact)
+
+	return mainTable.String()
+}
+
+func PrintPipelineTable(pipeline *meroxa.Pipeline) {
+	fmt.Println(PipelineTable(pipeline))
+}
+
 func ResourcesTable(resources []*meroxa.Resource, hideHeaders bool) string {
 	if len(resources) != 0 {
 		table := simpletable.New()

--- a/utils/display.go
+++ b/utils/display.go
@@ -364,17 +364,29 @@ func PipelinesTable(pipelines []*meroxa.Pipeline, hideHeaders bool) string {
 		if !hideHeaders {
 			table.Header = &simpletable.Header{
 				Cells: []*simpletable.Cell{
+					{Align: simpletable.AlignCenter, Text: "UUID"},
 					{Align: simpletable.AlignCenter, Text: "ID"},
 					{Align: simpletable.AlignCenter, Text: "NAME"},
+					{Align: simpletable.AlignCenter, Text: "ENVIRONMENT"},
 					{Align: simpletable.AlignCenter, Text: "STATE"},
 				},
 			}
 		}
 
 		for _, p := range pipelines {
+			var env string
+
+			if p.Environment != nil && p.Environment.Name != "" {
+				env = p.Environment.Name
+			} else {
+				env = string(meroxa.EnvironmentTypeCommon)
+			}
+
 			r := []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: p.UUID},
 				{Align: simpletable.AlignRight, Text: strconv.Itoa(p.ID)},
 				{Align: simpletable.AlignCenter, Text: p.Name},
+				{Align: simpletable.AlignCenter, Text: env},
 				{Align: simpletable.AlignCenter, Text: string(p.State)},
 			}
 

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -376,20 +376,32 @@ func TestConnectorsTableWithoutHeaders(t *testing.T) {
 
 func TestPipelinesTable(t *testing.T) {
 	pipelineIDAlign := &meroxa.Pipeline{}
+	pipelineWithEnv := &meroxa.Pipeline{}
+
 	pipelineBase := &meroxa.Pipeline{
+		UUID: "6f380820-dfed-4a69-b708-10d134866a35",
 		ID:   0,
 		Name: "pipeline-base",
 	}
 	deepCopy(pipelineBase, pipelineIDAlign)
-	pipelineIDAlign.ID = 1000
+	pipelineIDAlign.UUID = "0e1d29b9-2e62-4cc2-a49d-126f2e1b15ef"
 	pipelineIDAlign.Name = "pipeline-align"
+	pipelineIDAlign.ID = 1000
 
-	tests := map[string][]*meroxa.Pipeline{
-		"Base":         {pipelineBase},
-		"ID_Alignment": {pipelineBase, pipelineIDAlign},
+	deepCopy(pipelineBase, pipelineWithEnv)
+	pipelineWithEnv.UUID = "038de172-c4b0-49d8-a1d9-26fbeaa2f726"
+	pipelineWithEnv.Environment = &meroxa.PipelineEnvironment{
+		UUID: "e56b1b2e-b6d7-455d-887e-84a0823d84a8",
+		Name: "my-environment",
 	}
 
-	tableHeaders := []string{"ID", "NAME", "STATE"}
+	tests := map[string][]*meroxa.Pipeline{
+		"Base":             {pipelineBase},
+		"ID_Alignment":     {pipelineBase, pipelineIDAlign},
+		"With_Environment": {pipelineBase, pipelineIDAlign, pipelineWithEnv},
+	}
+
+	tableHeaders := []string{"UUID", "ID", "NAME", "ENVIRONMENT", "STATE"}
 
 	for name, pipelines := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -411,14 +423,22 @@ func TestPipelinesTable(t *testing.T) {
 				if !strings.Contains(out, strconv.Itoa(pipelineBase.ID)) {
 					t.Errorf("%d, not found", pipelineBase.ID)
 				}
-			case "ID_Alignment":
-				if !strings.Contains(out, pipelineBase.Name) {
-					t.Errorf("%s, not found", pipelineBase.Name)
+				if !strings.Contains(out, string(meroxa.EnvironmentTypeCommon)) {
+					t.Errorf("environment should be %s", string(meroxa.EnvironmentTypeCommon))
 				}
-				if !strings.Contains(out, strconv.Itoa(pipelineBase.ID)) {
-					t.Errorf("%d, not found", pipelineBase.ID)
+			case "ID_Alignment":
+				if !strings.Contains(out, pipelineIDAlign.Name) {
+					t.Errorf("%s, not found", pipelineIDAlign.Name)
+				}
+				if !strings.Contains(out, strconv.Itoa(pipelineIDAlign.ID)) {
+					t.Errorf("%d, not found", pipelineIDAlign.ID)
+				}
+			case "With_Environment":
+				if !strings.Contains(out, pipelineWithEnv.Environment.Name) {
+					t.Errorf("expected environment name to be %q", pipelineWithEnv.Environment.Name)
 				}
 			}
+
 			fmt.Println(out)
 		})
 	}

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -444,6 +444,69 @@ func TestPipelinesTable(t *testing.T) {
 	}
 }
 
+func TestPipelineTable(t *testing.T) {
+	pipelineWithEnv := &meroxa.Pipeline{}
+
+	pipelineBase := &meroxa.Pipeline{
+		UUID: "6f380820-dfed-4a69-b708-10d134866a35",
+		ID:   0,
+		Name: "pipeline-base",
+	}
+
+	deepCopy(pipelineBase, pipelineWithEnv)
+	pipelineWithEnv.UUID = "038de172-c4b0-49d8-a1d9-26fbeaa2f726"
+	pipelineWithEnv.Environment = &meroxa.PipelineEnvironment{
+		UUID: "e56b1b2e-b6d7-455d-887e-84a0823d84a8",
+		Name: "my-environment",
+	}
+
+	tests := map[string]*meroxa.Pipeline{
+		"Base":             pipelineBase,
+		"With_Environment": pipelineWithEnv,
+	}
+
+	tableHeaders := []string{"UUID", "ID", "Name", "State"}
+	var envHeader = "Environment"
+
+	for name, p := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := CaptureOutput(func() {
+				PrintPipelineTable(p)
+			})
+
+			for _, header := range tableHeaders {
+				if !strings.Contains(out, header) {
+					t.Errorf("%q header is missing", header)
+				}
+			}
+
+			switch name {
+			case "Base":
+				if !strings.Contains(out, pipelineBase.Name) {
+					t.Errorf("%s, not found", pipelineBase.Name)
+				}
+				if !strings.Contains(out, strconv.Itoa(pipelineBase.ID)) {
+					t.Errorf("%d, not found", pipelineBase.ID)
+				}
+				if !strings.Contains(out, pipelineBase.UUID) {
+					t.Errorf("%s, not found", pipelineBase.UUID)
+				}
+				if strings.Contains(out, envHeader) {
+					t.Errorf("%q header is not necessary", envHeader)
+				}
+			case "With_Environment":
+				if !strings.Contains(out, envHeader) {
+					t.Errorf("%q header is missing", envHeader)
+				}
+				if !strings.Contains(out, pipelineWithEnv.Environment.Name) {
+					t.Errorf("expected environment name to be %q", pipelineWithEnv.Environment.Name)
+				}
+			}
+			fmt.Println(out)
+		})
+	}
+}
+
 func TestPipelinesTableWithoutHeaders(t *testing.T) {
 	pipeline := &meroxa.Pipeline{
 		ID:   0,

--- a/utils/tests.go
+++ b/utils/tests.go
@@ -19,6 +19,17 @@ func GeneratePipeline() meroxa.Pipeline {
 	}
 }
 
+func GeneratePipelineWithEnvironment() meroxa.Pipeline {
+	p := GeneratePipeline()
+
+	p.Environment = &meroxa.PipelineEnvironment{
+		UUID: "236d6e81-6a22-4805-b64f-3fa0a57fdbdc",
+		Name: "my-env",
+	}
+
+	return p
+}
+
 func GenerateResource() meroxa.Resource {
 	return meroxa.Resource{
 		ID:       1,

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/pipeline.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const pipelinesBasePath = "/v1/pipelines"
@@ -18,21 +19,33 @@ const (
 
 // Pipeline represents the Meroxa Pipeline type within the Meroxa API
 type Pipeline struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
-	// @TODO metadata is unused in Platform-API, so deprecate over time
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
-	State    PipelineState          `json:"state"`
+	CreatedAt   time.Time              `json:"created_at"`
+	Environment *PipelineEnvironment   `json:"environment,omitempty"`
+	ID          int                    `json:"id"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"` // @TODO metadata is unused in Platform-API, so deprecate over time
+	Name        string                 `json:"name"`
+	State       PipelineState          `json:"state"`
+	UpdatedAt   time.Time              `json:"updated_at"`
+	UUID        string                 `json:"uuid"`
 }
 
+// CreatePipelineInput represents the input when creating a Meroxa Pipeline
 type CreatePipelineInput struct {
-	Name     string                 `json:"name"`
-	Metadata map[string]interface{} `json:"metadata,omitempty"`
+	Name        string                 `json:"name"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
+	Environment *PipelineEnvironment   `json:"environment,omitempty"`
 }
 
+// UpdatePipelineInput represents the input when updating a Meroxa Pipeline
 type UpdatePipelineInput struct {
 	Name     string                 `json:"name"`
 	Metadata map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// PipelineEnvironment represents the input for a Meroxa Environment created within a Meroxa Pipeline
+type PipelineEnvironment struct {
+	UUID string `json:"uuid,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // ComponentKind enum for Component "kinds" within Pipeline stages
@@ -173,8 +186,6 @@ func (c *client) GetPipelineByName(ctx context.Context, name string) (*Pipeline,
 
 	return &p, nil
 }
-
-// GetPipelineByName returns a Pipeline with the given name (scoped to the calling user)
 
 // GetPipeline returns a Pipeline with the given id
 func (c *client) GetPipeline(ctx context.Context, pipelineID int) (*Pipeline, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 ## explicit; go 1.9
 github.com/mattn/go-runewidth
-# github.com/meroxa/meroxa-go v0.0.0-20211129114423-a076cb0bbfbd
+# github.com/meroxa/meroxa-go v0.0.0-20211129114423-a076cb0bbfbd => ../meroxa-go
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
@@ -200,3 +200,4 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
+# github.com/meroxa/meroxa-go => ../meroxa-go

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 ## explicit; go 1.9
 github.com/mattn/go-runewidth
-# github.com/meroxa/meroxa-go v0.0.0-20211129114423-a076cb0bbfbd => ../meroxa-go
+# github.com/meroxa/meroxa-go v0.0.0-20211129120745-db529ae4ef81
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
@@ -200,4 +200,3 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
-# github.com/meroxa/meroxa-go => ../meroxa-go


### PR DESCRIPTION
# Description of change

- Fixes https://github.com/meroxa/cli/issues/211
- Fixes https://github.com/meroxa/cli/issues/212
- Fixes https://github.com/meroxa/cli/issues/213

Depends on https://github.com/meroxa/meroxa-go/pull/84

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
❯ meroxa pipelines ls                              
  ID               NAME                STATE  
====== ============================= =========
  762   meroxa-cli-to-slack/discord   healthy 
   11             default             healthy 
 1910            with-env             healthy

❯ .m pipelines describe default
Manage pipelines on Meroxa

Usage:
  meroxa pipelines [command]

Aliases:
  pipelines, pipeline

Available Commands:
  create      Create a pipeline
  list        List pipelines
  remove      Remove pipeline
  update      Update pipeline name, state or metadata
...

❯ meroxa pipelines create another-with-env --env 1a08cdec-64b2-40b1-9de4-a20477852de9
Error: unknown flag: --env
```

**After this pull-request**

```
❯ .m pipelines ls
                 UUID                    ID               NAME               ENVIRONMENT    STATE  
====================================== ====== ============================= ============= =========
 fd1052f6-b728-4996-9122-28bba4112363    762   meroxa-cli-to-slack/discord     common      healthy 
 5ccbadec-b3c4-430f-bd5c-942414e9890a     11             default               common      healthy 
 4ff99dae-470d-4b50-b937-fd6a36308b4b   1910            with-env                 foo       healthy 

❯ .m pipelines describe default
  UUID:   5ccbadec-b3c4-430f-bd5c-942414e9890a 
    ID:   11                                   
  Name:   default                              
 State:   Healthy  

❯ .m pipelines describe with-env
             UUID:   4ff99dae-470d-4b50-b937-fd6a36308b4b 
               ID:   1910                                 
             Name:   with-env                             
 Environment UUID:   1a08cdec-64b2-40b1-9de4-a20477852de9 
 Environment Name:   foo                                  
            State:   Healthy  

❯ .m pipelines create with-env --env foo
Creating pipeline "another-with-env" in "foo" environment...
Pipeline "with-env" successfully created!

❯ .m pipelines describe with-env               
             UUID:  3db69335-4c24-40f6-ba30-193cfa2b11a3
               ID:   1914                                 
             Name:   with-env                     
 Environment UUID:   1a08cdec-64b2-40b1-9de4-a20477852de9 
 Environment Name:   foo                                  
            State:   Healthy  

❯ .m pipelines create another-with-env --env 1a08cdec-64b2-40b1-9de4-a20477852de9
Creating pipeline "another-with-env" in "1a08cdec-64b2-40b1-9de4-a20477852de9" environment...
Pipeline "another-with-env" successfully created!

❯ .m pipelines describe another-with-env               
             UUID:   985ee31a-b8d2-4990-a0fd-cff7a79ea0bc 
               ID:   1915                                 
             Name:   another-with-env                     
 Environment UUID:   1a08cdec-64b2-40b1-9de4-a20477852de9 
 Environment Name:   foo                                  
            State:   Healthy  
```

# Additional references

It also makes some other changes that are timely as we use more UUIDs everywhere.