### PR TITLE
fix: go releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v4
         with:
-          gpg-private-key: ${{ secrets.MEROXA_MACHINE_GPG_KEY }}
+          gpg_private_key: ${{ secrets.MEROXA_MACHINE_GPG_KEY }}
           passphrase: ${{ secrets.MEROXA_MACHINE_GPG_PASSPHRASE }}
       -
         name: Run GoReleaser


### PR DESCRIPTION
# Description of change

Fix [latest release attempt to 1.5.0](https://github.com/meroxa/cli/runs/4353356352?check_suite_focus=true).

Looks like this was changed in [this changelog](https://github.com/crazy-max/ghaction-import-gpg/blob/cb4264d3319acaa2bea23d51ef67f80b4f775013/CHANGELOG.md#400-20210905), and we hadn't noticed it until we [bumped to latest `goreleaser` action (`v2`)](https://github.com/meroxa/cli/pull/218/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R32).

# Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation
