### PR TITLE
Environment create example doesn't work copy-paste'd

### DIFF
--- a/cmd/meroxa/root/environments/create.go
+++ b/cmd/meroxa/root/environments/create.go
@@ -264,6 +264,7 @@ func (c *Create) Usage() string {
 	return "create NAME"
 }
 
+//nolint:lll
 func (c *Create) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Create an environment",

--- a/cmd/meroxa/root/environments/create.go
+++ b/cmd/meroxa/root/environments/create.go
@@ -268,11 +268,7 @@ func (c *Create) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Create an environment",
 		Example: `
-meroxa env create my-env \
-	--type hosted \ 
-	--provider aws \ 
-	--region us-east-1 \ 
-	--config '{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}'
+meroxa env create my-env --type hosted --provider aws --region us-east-1 --config "{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}"
 `,
 	}
 }


### PR DESCRIPTION
# Description of change

In the env create example, the --config string doesn't marshal to a map and the \ for newline get translated to returns

Fixes <GitHub Issue>

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [X ]  Documentation

# How was this tested?

- [ X]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**
Usage:
  meroxa environments create NAME [flags]

Examples:

meroxa env create my-env \
	--type hosted \ 
	--provider aws \ 
	--region us-east-1 \ 
	--config '{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}'

Flags:
  -c, --config string     environment configuration based on type and provider (e.g.: --config '{"aws_access_key_id":"my_access_key", "aws_secret_access_key":"my_secret_access_key"}')


**After this pull-request**
Usage:
  meroxa environments create NAME [flags]

Examples:

meroxa env create my-env --type hosted --provider aws --region us-east-1 --config "{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}"

Flags:
  -c, --config string     environment configuration based on type and provider (e.g.: --config "{"aws_access_key_id":"my_access_key", "aws_secret_access_key":"my_secret_access_key"}")


# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
