### PR TITLE
Tweak environment flags

### DIFF
--- a/cmd/meroxa/root/environments/create_test.go
+++ b/cmd/meroxa/root/environments/create_test.go
@@ -111,14 +111,9 @@ func TestCreateEnvironmentExecution(t *testing.T) {
 	c.flags.Type = "dedicated"
 	c.flags.Provider = "aws"
 	c.flags.Region = "aws"
-	c.flags.Config = `{"aws_access_key_id":"my_access_key", "aws_access_secret":"my_access_secret"}`
+	c.flags.Config = []string{"aws_access_key_id=my_access_key", "aws_access_secret=my_access_secret"}
 
-	cfg := map[string]interface{}{}
-	err := json.Unmarshal([]byte(c.flags.Config), &cfg)
-
-	if err != nil {
-		t.Fatalf("not expected error, got %q", err.Error())
-	}
+	cfg := stringSliceToMap(c.flags.Config)
 
 	e := &meroxa.CreateEnvironmentInput{
 		Type:          meroxa.EnvironmentType(c.flags.Type),
@@ -150,7 +145,7 @@ func TestCreateEnvironmentExecution(t *testing.T) {
 		).
 		Return(rE, nil)
 
-	err = c.Execute(ctx)
+	err := c.Execute(ctx)
 
 	if err != nil {
 		t.Fatalf("not expected error, got \"%s\"", err.Error())


### PR DESCRIPTION
# Description of change

The current format for a config flag (and metadata) can be a bit error prone, so switching that to a string array format.

Also, introducing default values for environment create flags.

If we like it, can consider rolling out to other commands.

Fixes <GitHub Issue>

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [X]  Refactor
- [ ]  Documentation

# How was this tested?

- [X ]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
Flags:
  -c, --config string     environment configuration based on type and provider (e.g.: --config '{"aws_access_key_id":"my_access_key", "aws_secret_access_key":"my_secret_access_key"}')
```

**After this pull-request**

```
Flags:
  -c, --config strings    environment configuration based on type and provider (e.g.: --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret)
```
