### PR TITLE
Allow default values for flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ docs:
 	rm -rf docs/cmd && mkdir -p docs/cmd/{md,www}
 	rm -rf etc && mkdir -p etc/man/man1 && mkdir -p etc/completion
 	go run gen-docs/main.go
+
+.PHONY: lint
+lint:
+	docker run --rm -v $(CURDIR):/app -w /app golangci/golangci-lint:latest golangci-lint run --timeout 5m -v

--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -488,6 +488,11 @@ func buildCommandWithExecute(cmd *cobra.Command, c Command) {
 
 // nolint:funlen,gocyclo // this function has a big switch statement, can't get around that
 func buildCommandWithFlags(cmd *cobra.Command, c Command) {
+	const base = 10
+	const bits16 = 16
+	const bits32 = 32
+	const bits64 = 64
+
 	v, ok := c.(CommandWithFlags)
 	if !ok {
 		return
@@ -512,7 +517,7 @@ func buildCommandWithFlags(cmd *cobra.Command, c Command) {
 			}
 			flags.StringVarP(val, f.Long, f.Short, f.Default.(string), f.Usage)
 		case *int:
-			def := 0
+			var def int
 			if f.Default != nil {
 				i, err := strconv.Atoi(f.Default.(string))
 				if err == nil {
@@ -521,7 +526,7 @@ func buildCommandWithFlags(cmd *cobra.Command, c Command) {
 			}
 			flags.IntVarP(val, f.Long, f.Short, def, f.Usage)
 		case *int8:
-			var def int8 = 0
+			var def int8
 			if f.Default != nil {
 				i, err := strconv.Atoi(f.Default.(string))
 				if err == nil {
@@ -530,25 +535,25 @@ func buildCommandWithFlags(cmd *cobra.Command, c Command) {
 			}
 			flags.Int8VarP(val, f.Long, f.Short, def, f.Usage)
 		case *int16:
-			var def int16 = 0
+			var def int16
 			if f.Default != nil {
-				i, err := strconv.Atoi(f.Default.(string))
+				i, err := strconv.ParseInt(f.Default.(string), base, bits16)
 				if err == nil {
 					def = int16(i)
 				}
 			}
 			flags.Int16VarP(val, f.Long, f.Short, def, f.Usage)
 		case *int32:
-			var def int32 = 0
+			var def int32
 			if f.Default != nil {
-				i, err := strconv.Atoi(f.Default.(string))
+				i, err := strconv.ParseInt(f.Default.(string), base, bits32)
 				if err == nil {
 					def = int32(i)
 				}
 			}
 			flags.Int32VarP(val, f.Long, f.Short, def, f.Usage)
 		case *int64:
-			var def int64 = 0
+			var def int64
 			if f.Default != nil {
 				i, err := strconv.Atoi(f.Default.(string))
 				if err != nil {
@@ -557,18 +562,18 @@ func buildCommandWithFlags(cmd *cobra.Command, c Command) {
 			}
 			flags.Int64VarP(val, f.Long, f.Short, def, f.Usage)
 		case *float32:
-			var def float32 = 0
+			var def float32
 			if f.Default != nil {
-				f32, err := strconv.ParseFloat(f.Default.(string), 32)
+				f32, err := strconv.ParseFloat(f.Default.(string), bits32)
 				if err == nil {
 					def = float32(f32)
 				}
 			}
 			flags.Float32VarP(val, f.Long, f.Short, def, f.Usage)
 		case *float64:
-			var def float64 = 0
+			var def float64
 			if f.Default != nil {
-				f64, err := strconv.ParseFloat(f.Default.(string), 64)
+				f64, err := strconv.ParseFloat(f.Default.(string), bits64)
 				if err == nil {
 					def = f64
 				}

--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -511,85 +512,107 @@ func buildCommandWithFlags(cmd *cobra.Command, c Command) {
 			}
 			flags.StringVarP(val, f.Long, f.Short, f.Default.(string), f.Usage)
 		case *int:
-			if f.Default == nil {
-				f.Default = 0
+			def := 0
+			if f.Default != nil {
+				i, err := strconv.Atoi(f.Default.(string))
+				if err == nil {
+					def = i
+				}
 			}
-			flags.IntVarP(val, f.Long, f.Short, f.Default.(int), f.Usage)
+			flags.IntVarP(val, f.Long, f.Short, def, f.Usage)
 		case *int8:
-			if f.Default == nil {
-				f.Default = int8(0)
+			var def int8 = 0
+			if f.Default != nil {
+				i, err := strconv.Atoi(f.Default.(string))
+				if err == nil {
+					def = int8(i)
+				}
 			}
-			flags.Int8VarP(val, f.Long, f.Short, f.Default.(int8), f.Usage)
+			flags.Int8VarP(val, f.Long, f.Short, def, f.Usage)
 		case *int16:
-			if f.Default == nil {
-				f.Default = int16(0)
+			var def int16 = 0
+			if f.Default != nil {
+				i, err := strconv.Atoi(f.Default.(string))
+				if err == nil {
+					def = int16(i)
+				}
 			}
-			flags.Int16VarP(val, f.Long, f.Short, f.Default.(int16), f.Usage)
+			flags.Int16VarP(val, f.Long, f.Short, def, f.Usage)
 		case *int32:
-			if f.Default == nil {
-				f.Default = int32(0)
+			var def int32 = 0
+			if f.Default != nil {
+				i, err := strconv.Atoi(f.Default.(string))
+				if err == nil {
+					def = int32(i)
+				}
 			}
-			flags.Int32VarP(val, f.Long, f.Short, f.Default.(int32), f.Usage)
+			flags.Int32VarP(val, f.Long, f.Short, def, f.Usage)
 		case *int64:
-			if f.Default == nil {
-				f.Default = int64(0)
+			var def int64 = 0
+			if f.Default != nil {
+				i, err := strconv.Atoi(f.Default.(string))
+				if err != nil {
+					def = int64(i)
+				}
 			}
-			flags.Int64VarP(val, f.Long, f.Short, f.Default.(int64), f.Usage)
+			flags.Int64VarP(val, f.Long, f.Short, def, f.Usage)
 		case *float32:
-			if f.Default == nil {
-				f.Default = float32(0)
+			var def float32 = 0
+			if f.Default != nil {
+				f32, err := strconv.ParseFloat(f.Default.(string), 32)
+				if err == nil {
+					def = float32(f32)
+				}
 			}
-			flags.Float32VarP(val, f.Long, f.Short, f.Default.(float32), f.Usage)
+			flags.Float32VarP(val, f.Long, f.Short, def, f.Usage)
 		case *float64:
-			if f.Default == nil {
-				f.Default = float64(0)
+			var def float64 = 0
+			if f.Default != nil {
+				f64, err := strconv.ParseFloat(f.Default.(string), 64)
+				if err == nil {
+					def = f64
+				}
 			}
-			flags.Float64VarP(val, f.Long, f.Short, f.Default.(float64), f.Usage)
+			flags.Float64VarP(val, f.Long, f.Short, def, f.Usage)
 		case *bool:
-			if f.Default == nil {
-				f.Default = false
+			def := false
+			if f.Default != nil {
+				b, err := strconv.ParseBool(f.Default.(string))
+				if err == nil {
+					def = b
+				}
 			}
-			flags.BoolVarP(val, f.Long, f.Short, f.Default.(bool), f.Usage)
+			flags.BoolVarP(val, f.Long, f.Short, def, f.Usage)
 		case *time.Duration:
-			if f.Default == nil {
-				f.Default = time.Duration(0)
+			def := time.Duration(0)
+			if f.Default != nil {
+				t, err := time.ParseDuration(f.Default.(string))
+				if err == nil {
+					def = t
+				}
 			}
-			flags.DurationVarP(val, f.Long, f.Short, f.Default.(time.Duration), f.Usage)
+			flags.DurationVarP(val, f.Long, f.Short, def, f.Usage)
 		case *[]bool:
-			if f.Default == nil {
-				f.Default = []bool(nil)
-			}
-			flags.BoolSliceVarP(val, f.Long, f.Short, f.Default.([]bool), f.Usage)
+			// ignore default
+			flags.BoolSliceVarP(val, f.Long, f.Short, []bool{}, f.Usage)
 		case *[]float32:
-			if f.Default == nil {
-				f.Default = []float32(nil)
-			}
-			flags.Float32SliceVarP(val, f.Long, f.Short, f.Default.([]float32), f.Usage)
+			// ignore default
+			flags.Float32SliceVarP(val, f.Long, f.Short, []float32{}, f.Usage)
 		case *[]float64:
-			if f.Default == nil {
-				f.Default = []float64(nil)
-			}
-			flags.Float64SliceVarP(val, f.Long, f.Short, f.Default.([]float64), f.Usage)
+			// ignore default
+			flags.Float64SliceVarP(val, f.Long, f.Short, []float64{}, f.Usage)
 		case *[]int32:
-			if f.Default == nil {
-				f.Default = []int32(nil)
-			}
-			flags.Int32SliceVarP(val, f.Long, f.Short, f.Default.([]int32), f.Usage)
+			// ignore default
+			flags.Int32SliceVarP(val, f.Long, f.Short, []int32{}, f.Usage)
 		case *[]int64:
-			if f.Default == nil {
-				f.Default = []int64(nil)
-			}
-			flags.Int64SliceVarP(val, f.Long, f.Short, f.Default.([]int64), f.Usage)
+			// ignore default
+			flags.Int64SliceVarP(val, f.Long, f.Short, []int64{}, f.Usage)
 		case *[]int:
-			if f.Default == nil {
-				f.Default = []int(nil)
-			}
-			flags.IntSliceVarP(val, f.Long, f.Short, f.Default.([]int), f.Usage)
+			// ignore default
+			flags.IntSliceVarP(val, f.Long, f.Short, []int{}, f.Usage)
 		case *[]string:
-			if f.Default == nil {
-				f.Default = []string(nil)
-			}
-			flags.StringSliceVarP(val, f.Long, f.Short, f.Default.([]string), f.Usage)
+			// ignore default
+			flags.StringSliceVarP(val, f.Long, f.Short, []string{}, f.Usage)
 		default:
 			panic(fmt.Errorf("unexpected flag value type: %T", val))
 		}

--- a/cmd/meroxa/builder/builder_test.go
+++ b/cmd/meroxa/builder/builder_test.go
@@ -42,7 +42,7 @@ func (c *testCmd) Aliases() []string {
 }
 func (c *testCmd) Flags() []builder.Flag {
 	return []builder.Flag{
-		{Long: "long-foo", Short: "l", Usage: "test flag", Required: false, Persistent: false, Ptr: &c.flagLongFoo},
+		{Long: "long-foo", Short: "l", Usage: "test flag", Required: false, Persistent: false, Ptr: &c.flagLongFoo, Default: "hi"},
 	}
 }
 func (c *testCmd) SubCommands() []*cobra.Command {
@@ -231,23 +231,23 @@ func (t *testCmdWithFlags) Usage() string {
 
 func (t *testCmdWithFlags) Flags() []builder.Flag {
 	return []builder.Flag{
-		{Long: "flag1", Short: "a", Usage: "flag1 usage", Required: true, Persistent: false, Ptr: &t.flag1},
-		{Long: "flag2", Short: "b", Usage: "flag2 usage", Required: false, Persistent: true, Ptr: &t.flag2},
-		{Long: "flag3", Short: "c", Usage: "flag3 usage", Required: true, Persistent: false, Ptr: &t.flag3},
-		{Long: "flag4", Short: "d", Usage: "flag4 usage", Required: false, Persistent: true, Ptr: &t.flag4},
-		{Long: "flag5", Short: "e", Usage: "flag5 usage", Required: true, Persistent: false, Ptr: &t.flag5},
-		{Long: "flag6", Short: "f", Usage: "flag6 usage", Required: false, Persistent: true, Ptr: &t.flag6},
-		{Long: "flag7", Short: "g", Usage: "flag7 usage", Required: true, Persistent: false, Ptr: &t.flag7},
-		{Long: "flag8", Short: "h", Usage: "flag8 usage", Required: false, Persistent: true, Ptr: &t.flag8},
-		{Long: "flag9", Short: "i", Usage: "flag9 usage", Required: true, Persistent: false, Ptr: &t.flag9},
-		{Long: "flag10", Short: "j", Usage: "flag10 usage", Required: false, Persistent: true, Ptr: &t.flag10},
-		{Long: "flag11", Short: "k", Usage: "flag11 usage", Required: true, Persistent: false, Ptr: &t.flag11},
-		{Long: "flag12", Short: "l", Usage: "flag12 usage", Required: false, Persistent: true, Ptr: &t.flag12},
-		{Long: "flag13", Short: "m", Usage: "flag13 usage", Required: true, Persistent: false, Ptr: &t.flag13},
-		{Long: "flag14", Short: "n", Usage: "flag14 usage", Required: false, Persistent: true, Ptr: &t.flag14},
-		{Long: "flag15", Short: "o", Usage: "flag15 usage", Required: true, Persistent: false, Ptr: &t.flag15},
-		{Long: "flag16", Short: "p", Usage: "flag16 usage", Required: false, Persistent: true, Ptr: &t.flag16},
-		{Long: "flag17", Short: "q", Usage: "flag17 usage", Required: true, Persistent: false, Ptr: &t.flag17},
+		{Long: "flag1", Short: "a", Usage: "flag1 usage", Required: true, Persistent: false, Ptr: &t.flag1, Default: "a"},
+		{Long: "flag2", Short: "b", Usage: "flag2 usage", Required: false, Persistent: true, Ptr: &t.flag2, Default: "1"},
+		{Long: "flag3", Short: "c", Usage: "flag3 usage", Required: true, Persistent: false, Ptr: &t.flag3, Default: "2"},
+		{Long: "flag4", Short: "d", Usage: "flag4 usage", Required: false, Persistent: true, Ptr: &t.flag4, Default: "3"},
+		{Long: "flag5", Short: "e", Usage: "flag5 usage", Required: true, Persistent: false, Ptr: &t.flag5, Default: "4"},
+		{Long: "flag6", Short: "f", Usage: "flag6 usage", Required: false, Persistent: true, Ptr: &t.flag6, Default: "5"},
+		{Long: "flag7", Short: "g", Usage: "flag7 usage", Required: true, Persistent: false, Ptr: &t.flag7, Default: "6"},
+		{Long: "flag8", Short: "h", Usage: "flag8 usage", Required: false, Persistent: true, Ptr: &t.flag8, Default: "7"},
+		{Long: "flag9", Short: "i", Usage: "flag9 usage", Required: true, Persistent: false, Ptr: &t.flag9, Default: "false"},
+		{Long: "flag10", Short: "j", Usage: "flag10 usage", Required: false, Persistent: true, Ptr: &t.flag10, Default: ""},
+		{Long: "flag11", Short: "k", Usage: "flag11 usage", Required: true, Persistent: false, Ptr: &t.flag11, Default: ""},
+		{Long: "flag12", Short: "l", Usage: "flag12 usage", Required: false, Persistent: true, Ptr: &t.flag12, Default: ""},
+		{Long: "flag13", Short: "m", Usage: "flag13 usage", Required: true, Persistent: false, Ptr: &t.flag13, Default: ""},
+		{Long: "flag14", Short: "n", Usage: "flag14 usage", Required: false, Persistent: true, Ptr: &t.flag14, Default: ""},
+		{Long: "flag15", Short: "o", Usage: "flag15 usage", Required: true, Persistent: false, Ptr: &t.flag15, Default: ""},
+		{Long: "flag16", Short: "p", Usage: "flag16 usage", Required: false, Persistent: true, Ptr: &t.flag16, Default: ""},
+		{Long: "flag17", Short: "q", Usage: "flag17 usage", Required: true, Persistent: false, Ptr: &t.flag17, Default: ""},
 	}
 }
 

--- a/cmd/meroxa/builder/flags.go
+++ b/cmd/meroxa/builder/flags.go
@@ -36,6 +36,7 @@ func buildFlag(val reflect.Value, sf reflect.StructField) (Flag, error) {
 		tagNamePersistent = "persistent"
 		tagNameUsage      = "usage"
 		tagNameHidden     = "hidden"
+		tagNameDefault    = "default"
 	)
 
 	var (
@@ -45,6 +46,7 @@ func buildFlag(val reflect.Value, sf reflect.StructField) (Flag, error) {
 		persistent bool
 		usage      string
 		hidden     bool
+		def        interface{}
 	)
 
 	if v, ok := sf.Tag.Lookup(tagNameLong); ok {
@@ -77,6 +79,15 @@ func buildFlag(val reflect.Value, sf reflect.StructField) (Flag, error) {
 			return Flag{}, fmt.Errorf("error parsing tag \"hidden\": %w", err)
 		}
 	}
+	if v, ok := sf.Tag.Lookup(tagNameDefault); ok {
+		var err error
+		if v != "" {
+			def = v
+		}
+		if err != nil {
+			return Flag{}, fmt.Errorf("error parsing tag \"default\": %w", err)
+		}
+	}
 
 	return Flag{
 		Long:       long,
@@ -84,7 +95,7 @@ func buildFlag(val reflect.Value, sf reflect.StructField) (Flag, error) {
 		Usage:      usage,
 		Required:   required,
 		Persistent: persistent,
-		Default:    nil,
+		Default:    def,
 		Ptr:        val.Addr().Interface(),
 		Hidden:     hidden,
 	}, nil


### PR DESCRIPTION
# Description of change

Defaults show the most likely valid values for a flag in the command documentation
Defaults allow the user to specify fewer flag values, only overrides
I didn't bother with defaults for slices because it seems unlikely to be valuable for the amount of effort.  Maybe marshaling json? meh


# Type of change

- [ x ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [ x ]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

Flags:
  -c, --config string     environment configuration based on type and provider (e.g.: --config '{"aws_access_key_id":"my_access_key", "aws_secret_access_key":"my_secret_access_key"}')
  -h, --help              help for create
      --provider string   environment cloud provider to use
      --region string     environment region
      --type string       environment type, when not specified
  -y, --yes               skip confirmation prompt



**After this pull-request**

for example
Flags:
  -c, --config string     environment configuration based on type and provider (e.g.: --config '{"aws_access_key_id":"my_access_key", "aws_secret_access_key":"my_secret_access_key"}')
  -h, --help              help for create
      --provider string   environment cloud provider to use (default "aws")
      --region string     environment region (default "us-east-1")
      --type string       environment type, when not specified (default "hosted")
  -y, --yes               skip confirmation prompt

# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
