### PR TITLE
Add repo velocity reporting

### DIFF
--- a/.github/workflows/velocity_metrics.yml
+++ b/.github/workflows/velocity_metrics.yml
@@ -1,0 +1,35 @@
+name: Velocity Workflow
+on:
+  pull_request:
+    types: [opened, closed]
+jobs:
+  metrics:
+    if: |
+      (github.event.action == 'closed' &&
+      github.event.pull_request.merged == true) ||
+      github.event.action == 'opened'
+    name: Track merge request activity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      # Optional step that allows tagging time to merge with a team
+      - uses: tspascoal/get-user-teams-membership@v1
+        id: actorTeams
+        if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
+        with:
+          username: ${{ github.event.pull_request.user.login }}
+          GITHUB_TOKEN: ${{ secrets.MEROXA_MACHINE }}
+
+      - id: datadog-metrics
+        uses: scribd/github-action-datadog-reporting@v1
+        with:
+          datadog-metric-prefix: 'github_action_reporting.repo_velocity'
+          metrics-type: 'velocity'
+          teams: ${{ steps.actorTeams.outputs.teams }}
+        env:
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+          OCTOKIT_TOKEN: ${{ secrets.MEROXA_MACHINE }}
+          


### PR DESCRIPTION
# Description of change
For issue https://github.com/meroxa/infra/issues/454:

This change adds [github-action-datadog-reporting](
https://github.com/scribd/github-action-datadog-reporting) to this repository.
* Repo Velocity (Prefix `github_action_reporting.repo_velocity`):
  * PR time to open
  * PR time to merge
  * PR lines changed 

# Type of change

- [x]  New feature