### PR TITLE
Show common environment when no environment provided

### DIFF
--- a/cmd/meroxa/root/environments/create_test.go
+++ b/cmd/meroxa/root/environments/create_test.go
@@ -111,7 +111,7 @@ func TestCreateEnvironmentExecution(t *testing.T) {
 	c.flags.Type = "private"
 	c.flags.Provider = "aws"
 	c.flags.Region = "aws"
-	c.flags.Config = []string{"aws_access_key_id=my_access_key", "aws_access_secret=my_access_secret"}
+	c.flags.Config = []string{"aws_access_key_id=my_access_key", "aws_secret_access_key=my_access_secret"}
 
 	cfg := stringSliceToMap(c.flags.Config)
 

--- a/utils/display.go
+++ b/utils/display.go
@@ -314,16 +314,25 @@ func ConnectorTable(connector *meroxa.Connector) string {
 			{Text: connector.Trace},
 		})
 	}
-	var env string
-	if connector.Environment != nil && connector.Environment.Name != "" {
-		env = connector.Environment.Name
+	if connector.Environment != nil {
+		if envUUID := connector.Environment.UUID; envUUID != "" {
+			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: "Environment UUID:"},
+				{Text: envUUID},
+			})
+		}
+		if envName := connector.Environment.Name; envName != "" {
+			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: "Environment Name:"},
+				{Text: envName},
+			})
+		}
 	} else {
-		env = string(meroxa.EnvironmentTypeCommon)
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "Environment Name:"},
+			{Text: string(meroxa.EnvironmentTypeCommon)},
+		})
 	}
-	mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
-		{Align: simpletable.AlignRight, Text: "Environment:"},
-		{Text: env},
-	})
 
 	mainTable.SetStyle(simpletable.StyleCompact)
 

--- a/utils/display.go
+++ b/utils/display.go
@@ -115,6 +115,11 @@ func ResourceTable(res *meroxa.Resource) string {
 				{Text: e},
 			})
 		}
+	} else {
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "Environment Name:"},
+			{Text: string(meroxa.EnvironmentTypeCommon)},
+		})
 	}
 
 	mainTable.SetStyle(simpletable.StyleCompact)
@@ -152,6 +157,11 @@ func PipelineTable(p *meroxa.Pipeline) string {
 				{Text: pN},
 			})
 		}
+	} else {
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "Environment Name:"},
+			{Text: string(meroxa.EnvironmentTypeCommon)},
+		})
 	}
 
 	mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -479,7 +479,7 @@ func TestPipelineTable(t *testing.T) {
 	}
 
 	tableHeaders := []string{"UUID", "ID", "Name", "State"}
-	var envHeader = "Environment"
+	var envHeader = "Environment Name"
 
 	for name, p := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -504,15 +504,12 @@ func TestPipelineTable(t *testing.T) {
 				if !strings.Contains(out, pipelineBase.UUID) {
 					t.Errorf("%s, not found", pipelineBase.UUID)
 				}
-				if strings.Contains(out, envHeader) {
-					t.Errorf("%q header is not necessary", envHeader)
+				if !strings.Contains(out, envHeader) {
+					t.Errorf("%q not found", envHeader)
 				}
 			case "With_Environment":
-				if !strings.Contains(out, envHeader) {
-					t.Errorf("%q header is missing", envHeader)
-				}
-				if !strings.Contains(out, pipelineWithEnv.Environment.Name) {
-					t.Errorf("expected environment name to be %q", pipelineWithEnv.Environment.Name)
+				if !strings.Contains(out, pipelineWithEnv.Environment.UUID) {
+					t.Errorf("expected environment UUID to be %q", pipelineWithEnv.Environment.UUID)
 				}
 			}
 			fmt.Println(out)


### PR DESCRIPTION
# Description of change

*A brief description of the change, what it is and why it was made.*

Fixes https://github.com/meroxa/cli/issues/229
Fixes https://github.com/meroxa/cli/issues/230

# Type of change

- [ ]  New feature
- [X ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [ X]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

$ m pipeline describe jtnewname
  UUID:   9b16822d-a546-4cf8-be6b-300471f6dab2 
    ID:   2961                                 
  Name:   jtnewname                            
 State:   Healthy                              

$ m connector describe mongodb-connector
        UUID:   a69160c7-0014-40e7-a953-fe5042876ebe        
          ID:   5532                                        
        Name:   mongodb-connector                           
        Type:   debezium-mongo-source                       
     Streams:   (output) resource-6633-459461.meroxa.meroxa 
       State:   pending                                     
    Pipeline:   jtest                                       
 Environment:   janelle-dec9     


**After this pull-request**                     

$ m pipeline describe jtnewname
             UUID:   9b16822d-a546-4cf8-be6b-300471f6dab2 
               ID:   2961                                 
             Name:   jtnewname                            
 Environment Name:   common                               
            State:   Healthy                              

$ m connector describe mongodb-connector
             UUID:   91ee0a06-436f-4c7f-a459-0a920c623ed0        
               ID:   5533                                        
             Name:   mongodb-connector                           
             Type:   debezium-mongo-source                       
          Streams:   (output) resource-6633-666758.meroxa.meroxa 
            State:   running                                     
         Pipeline:   jtest                                       
 Environment UUID:   514280e6-6825-4728-b98a-cc4a24cb38aa        
 Environment Name:   janelle-dec9 

# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
