### PR TITLE
Rename environment offerings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /meroxa
 /cli
+.envrc

--- a/cmd/meroxa/root/environments/create.go
+++ b/cmd/meroxa/root/environments/create.go
@@ -180,7 +180,7 @@ func (c *Create) Prompt() error {
 	if c.flags.Type == "" {
 		vType := func(input string) error {
 			switch input {
-			case "hosted", "dedicated":
+			case "self_hosted", "private":
 				return nil
 			default:
 				return errors.New("unsupported environment type")
@@ -188,8 +188,8 @@ func (c *Create) Prompt() error {
 		}
 
 		p := promptui.Prompt{
-			Label:    "Type (hosted or dedicated)",
-			Default:  "hosted",
+			Label:    "Type (self_hosted or private)",
+			Default:  "self_hosted",
 			Validate: vType,
 		}
 
@@ -275,7 +275,7 @@ func (c *Create) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Create an environment",
 		Example: `
-meroxa env create my-env --type hosted --provider aws --region us-east-1 --config "{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}"
+meroxa env create my-env --type self_hosted --provider aws --region us-east-1 --config "{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}"
 `,
 	}
 }

--- a/cmd/meroxa/root/environments/create_test.go
+++ b/cmd/meroxa/root/environments/create_test.go
@@ -108,7 +108,7 @@ func TestCreateEnvironmentExecution(t *testing.T) {
 	}
 
 	c.args.Name = "my-env"
-	c.flags.Type = "dedicated"
+	c.flags.Type = "private"
 	c.flags.Provider = "aws"
 	c.flags.Region = "aws"
 	c.flags.Config = []string{"aws_access_key_id=my_access_key", "aws_access_secret=my_access_secret"}

--- a/cmd/meroxa/root/environments/list_test.go
+++ b/cmd/meroxa/root/environments/list_test.go
@@ -37,7 +37,7 @@ func TestListEnvironmentsExecution(t *testing.T) {
 	logger := log.NewTestLogger()
 
 	ee := &meroxa.Environment{
-		Type:     meroxa.EnvironmentTypeDedicated,
+		Type:     meroxa.EnvironmentTypePrivate,
 		Name:     "environment-1234",
 		Provider: meroxa.EnvironmentProviderAws,
 		Region:   meroxa.EnvironmentRegionUsEast2,

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20211201105336-fe1f1bcf8764
+	github.com/meroxa/meroxa-go v0.0.0-20220103162704-95e9ee778a21
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/meroxa/meroxa-go v0.0.0-20211201105336-fe1f1bcf8764 h1:DRjjwhtxG8VAEYIole15SP9DluTDMxcBsTnmru59r2o=
-github.com/meroxa/meroxa-go v0.0.0-20211201105336-fe1f1bcf8764/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
+github.com/meroxa/meroxa-go v0.0.0-20220103162704-95e9ee778a21 h1:Oo0jXKgynImgmqZuMzYqEJCqrT/5grNIGnaDY5PU1kk=
+github.com/meroxa/meroxa-go v0.0.0-20220103162704-95e9ee778a21/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -551,7 +551,7 @@ func TestPipelinesTableWithoutHeaders(t *testing.T) {
 
 func TestEnvironmentsTable(t *testing.T) {
 	e := &meroxa.Environment{
-		Type:     meroxa.EnvironmentTypeDedicated,
+		Type:     meroxa.EnvironmentTypePrivate,
 		Name:     "environment-1234",
 		Provider: meroxa.EnvironmentProviderAws,
 		Region:   meroxa.EnvironmentRegionUsEast2,
@@ -603,7 +603,7 @@ func TestEnvironmentsTable(t *testing.T) {
 
 func TestEnvironmentsTableWithoutHeaders(t *testing.T) {
 	e := &meroxa.Environment{
-		Type:     meroxa.EnvironmentTypeDedicated,
+		Type:     meroxa.EnvironmentTypePrivate,
 		Name:     "environment-1234",
 		Provider: meroxa.EnvironmentProviderAws,
 		Region:   meroxa.EnvironmentRegionUsEast2,

--- a/utils/tests.go
+++ b/utils/tests.go
@@ -132,7 +132,7 @@ func GenerateEnvironment(environmentName string) meroxa.Environment {
 
 	return meroxa.Environment{
 		UUID:     "fd572375-77ce-4448-a071-ee4707a599d6",
-		Type:     meroxa.EnvironmentTypeDedicated,
+		Type:     meroxa.EnvironmentTypePrivate,
 		Name:     environmentName,
 		Region:   meroxa.EnvironmentRegionUsEast2,
 		Provider: meroxa.EnvironmentProviderAws,

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/environment.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/environment.go
@@ -55,9 +55,9 @@ const (
 type EnvironmentType string
 
 const (
-	EnvironmentTypeHosted    EnvironmentType = "hosted"
-	EnvironmentTypeDedicated EnvironmentType = "dedicated"
-	EnvironmentTypeCommon    EnvironmentType = "common"
+	EnvironmentTypeSelfHosted EnvironmentType = "self_hosted"
+	EnvironmentTypePrivate    EnvironmentType = "private"
+	EnvironmentTypeCommon     EnvironmentType = "common"
 )
 
 type EnvironmentProvider string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,7 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 ## explicit; go 1.9
 github.com/mattn/go-runewidth
-# github.com/meroxa/meroxa-go v0.0.0-20211201105336-fe1f1bcf8764
+# github.com/meroxa/meroxa-go v0.0.0-20220103162704-95e9ee778a21
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock


### PR DESCRIPTION
# Description of change

We want to rename environment offerings to the following:
Dedicated -> Private
Hosted -> Self-hosted

Fixes https://github.com/meroxa/cli/issues/232

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
meroxa env create --help
Create an environment

Usage:
  meroxa environments create NAME [flags]

Examples:

meroxa env create my-env \
	--type hosted \ 
	--provider aws \ 
	--region us-east-1 \ 
	--config '{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}'
```

```
meroxa env create       
Environment name (optional): 
Type (hosted or dedicated): hosted
Cloud provider: aws
Region: us-east-1
✗ Does your environment require configuration: 
Environment details:
	Type: hosted
	Provider: aws
	Region: us-east-1
```

**After this pull-request**

```
meroxa env create --help
Create an environment

Usage:
  meroxa environments create NAME [flags]

Examples:

meroxa env create my-env --type self_hosted --provider aws --region us-east-1 --config "{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}"

```

```
meroxa env create
Environment name (optional): 
Type (self_hosted or private): self_hosted
Cloud provider: aws
Region: us-east-1
✔ Region: us-east-1█
Environment details:
	Type: self_hosted
	Provider: aws
	Region: us-east-1
```

# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
