### PR TITLE
Update example for env create

### DIFF
--- a/cmd/meroxa/root/environments/create.go
+++ b/cmd/meroxa/root/environments/create.go
@@ -275,7 +275,7 @@ func (c *Create) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Create an environment",
 		Example: `
-meroxa env create my-env --type self_hosted --provider aws --region us-east-1 --config "{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}"
+meroxa env create my-env --type self_hosted --provider aws --region us-east-1 --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret
 `,
 	}
 }


### PR DESCRIPTION
# Description of change

Fix outdated help instructions for env create 

Fixes <GitHub Issue>

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

```
meroxa env create --help                                                                                                                                                  
Create an environment

Usage:
  meroxa environments create NAME [flags]

Examples:

meroxa env create my-env --type self_hosted --provider aws --region us-east-1 --config "{\"aws_access_key_id\":\"my_access_key\", \"aws_secret_access_key\":\"my_secret_access_key\"}"


```
**After this pull-request**

```
meroxa env create --help
Create an environment

Usage:
  meroxa environments create NAME [flags]

Examples:

meroxa env create my-env --type self_hosted --provider aws --region us-east-1 --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret
```


*Provide PR link:* 
