### PR TITLE
Unhide environment flags

### DIFF
--- a/cmd/meroxa/root/environments/create_test.go
+++ b/cmd/meroxa/root/environments/create_test.go
@@ -111,7 +111,7 @@ func TestCreateEnvironmentExecution(t *testing.T) {
 	c.flags.Type = "private"
 	c.flags.Provider = "aws"
 	c.flags.Region = "aws"
-	c.flags.Config = []string{"aws_access_key_id=my_access_key", "aws_access_secret=my_access_secret"}
+	c.flags.Config = []string{"aws_access_key_id=my_access_key", "aws_secret_access_key=my_access_secret"}
 
 	cfg := stringSliceToMap(c.flags.Config)
 

--- a/cmd/meroxa/root/environments/environments.go
+++ b/cmd/meroxa/root/environments/environments.go
@@ -17,6 +17,8 @@ limitations under the License.
 package environments
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/meroxa/cli/cmd/meroxa/builder"
@@ -48,8 +50,9 @@ func (*Environments) Aliases() []string {
 	return []string{"env", "environment"}
 }
 
-func (*Environments) FeatureFlag() string {
-	return "environments"
+func (*Environments) FeatureFlag() (string, error) {
+	return "environments", fmt.Errorf(`no access to the Meroxa self-hosted environments feature.
+Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sme`)
 }
 
 func (e *Environments) Logger(logger log.Logger) {

--- a/cmd/meroxa/root/pipelines/create.go
+++ b/cmd/meroxa/root/pipelines/create.go
@@ -75,6 +75,7 @@ func (c *Create) Execute(ctx context.Context) error {
 		p.Metadata = metadata
 	}
 
+	// If the environment specified is not the common environment.
 	if c.flags.Environment != "" && c.flags.Environment != string(meroxa.EnvironmentTypeCommon) {
 		err := builder.CheckFeatureFlag(c, &environments.Environments{})
 		if err != nil {

--- a/cmd/meroxa/root/pipelines/create.go
+++ b/cmd/meroxa/root/pipelines/create.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/root/environments"
 	"github.com/meroxa/cli/log"
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 )
@@ -53,7 +54,7 @@ type Create struct {
 	flags struct {
 		Metadata string `long:"metadata" short:"m" usage:"pipeline metadata"`
 		// TODO: Add support to builder to create flags with an alias (--env | --environment)
-		Environment string `long:"env" usage:"environment (name or UUID) where pipeline will be created" hidden:"true"`
+		Environment string `long:"env" usage:"environment (name or UUID) where pipeline will be created"`
 	}
 }
 
@@ -74,11 +75,16 @@ func (c *Create) Execute(ctx context.Context) error {
 		p.Metadata = metadata
 	}
 
-	if c.flags.Environment != "" {
+	if c.flags.Environment != "" && c.flags.Environment != string(meroxa.EnvironmentTypeCommon) {
+		err := builder.CheckFeatureFlag(c, &environments.Environments{})
+		if err != nil {
+			return err
+		}
+
 		env = c.flags.Environment
 		p.Environment = &meroxa.EnvironmentIdentifier{}
 
-		_, err := uuid.Parse(c.flags.Environment)
+		_, err = uuid.Parse(c.flags.Environment)
 
 		if err == nil {
 			p.Environment.UUID = c.flags.Environment

--- a/cmd/meroxa/root/pipelines/create_test.go
+++ b/cmd/meroxa/root/pipelines/create_test.go
@@ -24,12 +24,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/meroxa/cli/cmd/meroxa/builder"
-	"github.com/meroxa/cli/utils"
-
 	"github.com/golang/mock/gomock"
 
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/global"
 	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils"
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 	"github.com/meroxa/meroxa-go/pkg/mock"
 )
@@ -66,7 +66,7 @@ func TestCreatePipelineFlags(t *testing.T) {
 		hidden    bool
 	}{
 		{name: "metadata", required: false, shorthand: "m", hidden: false},
-		{name: "env", required: false, hidden: true},
+		{name: "env", required: false, hidden: false},
 	}
 
 	c := builder.BuildCobraCommand(&Create{})
@@ -164,6 +164,16 @@ func TestCreatePipelineWithEnvironmentExecution(t *testing.T) {
 	pName := "my-pipeline"
 	env := "my-env"
 
+	c := &Create{
+		client: client,
+		logger: logger,
+	}
+	// Set up feature flags
+	if global.Config == nil {
+		build := builder.BuildCobraCommand(c)
+		_ = global.PersistentPreRunE(build)
+	}
+
 	pi := &meroxa.CreatePipelineInput{
 		Name:        pName,
 		Environment: &meroxa.EnvironmentIdentifier{Name: env},
@@ -189,13 +199,21 @@ func TestCreatePipelineWithEnvironmentExecution(t *testing.T) {
 		).
 		Return(p, nil)
 
-	c := &Create{
-		client: client,
-		logger: logger,
-	}
-
 	c.args.Name = pi.Name
 	c.flags.Environment = pi.Environment.Name
+
+	// override feature flags
+	featureFlags := global.Config.Get(global.UserFeatureFlagsEnv)
+	startingFlags := ""
+	if featureFlags != nil {
+		startingFlags = featureFlags.(string)
+	}
+	newFlags := ""
+	if startingFlags != "" {
+		newFlags = startingFlags + " "
+	}
+	newFlags += "environments"
+	global.Config.Set(global.UserFeatureFlagsEnv, newFlags)
 
 	err := c.Execute(ctx)
 
@@ -221,5 +239,56 @@ Pipeline %q successfully created!
 
 	if !reflect.DeepEqual(gotPipeline, *p) {
 		t.Fatalf("expected \"%v\", got \"%v\"", *p, gotPipeline)
+	}
+
+	// Clear environments feature flags
+	global.Config.Set(global.UserFeatureFlagsEnv, startingFlags)
+}
+
+func TestCreatePipelineWithEnvironmentExecutionWithoutFeatureFlag(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockClient(ctrl)
+	logger := log.NewTestLogger()
+	pName := "my-pipeline"
+	env := "my-env"
+
+	c := &Create{
+		client: client,
+		logger: logger,
+	}
+
+	pi := &meroxa.CreatePipelineInput{
+		Name:        pName,
+		Environment: &meroxa.EnvironmentIdentifier{Name: env},
+	}
+
+	p := &meroxa.Pipeline{
+		ID:   1,
+		Name: pName,
+		Environment: &meroxa.EnvironmentIdentifier{
+			UUID: "2560fbcc-b9ee-461a-a959-fa5656422dc2",
+			Name: env,
+		},
+		State: "healthy",
+	}
+
+	p.Name = pName
+
+	c.args.Name = pi.Name
+	c.flags.Environment = pi.Environment.Name
+
+	err := c.Execute(ctx)
+
+	if err == nil {
+		t.Fatalf("unexpected success")
+	}
+
+	gotError := err.Error()
+	wantError := `no access to the Meroxa self-hosted environments feature.
+Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sme`
+
+	if gotError != wantError {
+		t.Fatalf("expected error:\n%s\ngot:\n%s", wantError, gotError)
 	}
 }

--- a/cmd/meroxa/root/pipelines/create_test.go
+++ b/cmd/meroxa/root/pipelines/create_test.go
@@ -65,8 +65,8 @@ func TestCreatePipelineFlags(t *testing.T) {
 		shorthand string
 		hidden    bool
 	}{
-		{name: "metadata", required: false, shorthand: "m", hidden: false},
-		{name: "env", required: false, hidden: false},
+		{name: "metadata", shorthand: "m"},
+		{name: "env"},
 	}
 
 	c := builder.BuildCobraCommand(&Create{})

--- a/cmd/meroxa/root/resources/create.go
+++ b/cmd/meroxa/root/resources/create.go
@@ -123,6 +123,7 @@ func (c *Create) Execute(ctx context.Context) error {
 		Metadata: nil,
 	}
 
+	// If the environment specified is not the common environment.
 	if c.flags.Environment != "" && c.flags.Environment != string(meroxa.EnvironmentTypeCommon) {
 		err := builder.CheckFeatureFlag(c, &environments.Environments{})
 		if err != nil {

--- a/cmd/meroxa/root/resources/create.go
+++ b/cmd/meroxa/root/resources/create.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+
 	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/root/environments"
 	"github.com/meroxa/cli/log"
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 )
@@ -45,7 +47,7 @@ type Create struct {
 		Metadata string `long:"metadata"    short:"m" usage:"resource metadata"`
 
 		// TODO: Add support to builder to create flags with an alias (--env | --environment)
-		Environment string `long:"env" usage:"environment (name or UUID) where resource will be created" hidden:"true"`
+		Environment string `long:"env" usage:"environment (name or UUID) where resource will be created"`
 
 		// credentials
 		Username      string `long:"username"    short:"" usage:"username"`
@@ -121,11 +123,16 @@ func (c *Create) Execute(ctx context.Context) error {
 		Metadata: nil,
 	}
 
-	if c.flags.Environment != "" {
+	if c.flags.Environment != "" && c.flags.Environment != string(meroxa.EnvironmentTypeCommon) {
+		err := builder.CheckFeatureFlag(c, &environments.Environments{})
+		if err != nil {
+			return err
+		}
+
 		input.Environment = &meroxa.EnvironmentIdentifier{}
 		env = c.flags.Environment
 
-		_, err := uuid.Parse(c.flags.Environment)
+		_, err = uuid.Parse(c.flags.Environment)
 
 		if err == nil {
 			input.Environment.UUID = c.flags.Environment

--- a/docs/cmd/md/meroxa.md
+++ b/docs/cmd/md/meroxa.md
@@ -33,6 +33,7 @@ meroxa resources list --types
 * [meroxa connect](meroxa_connect.md)	 - Connect two resources together
 * [meroxa connectors](meroxa_connectors.md)	 - Manage connectors on Meroxa
 * [meroxa endpoints](meroxa_endpoints.md)	 - Manage endpoints on Meroxa
+* [meroxa environments](meroxa_environments.md)	 - Manage environments on Meroxa
 * [meroxa login](meroxa_login.md)	 - Login or Sign up to the Meroxa Platform
 * [meroxa logout](meroxa_logout.md)	 - Clears local login credentials of the Meroxa Platform
 * [meroxa open](meroxa_open.md)	 - Open in a web browser

--- a/docs/cmd/md/meroxa_environments.md
+++ b/docs/cmd/md/meroxa_environments.md
@@ -1,0 +1,28 @@
+## meroxa environments
+
+Manage environments on Meroxa
+
+### Options
+
+```
+  -h, --help   help for environments
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa](meroxa.md)	 - The Meroxa CLI
+* [meroxa environments create](meroxa_environments_create.md)	 - Create an environment
+* [meroxa environments describe](meroxa_environments_describe.md)	 - Describe environment
+* [meroxa environments list](meroxa_environments_list.md)	 - List environments
+* [meroxa environments remove](meroxa_environments_remove.md)	 - Remove environment
+* [meroxa environments update](meroxa_environments_update.md)	 - Update an environment
+

--- a/docs/cmd/md/meroxa_environments_create.md
+++ b/docs/cmd/md/meroxa_environments_create.md
@@ -1,0 +1,40 @@
+## meroxa environments create
+
+Create an environment
+
+```
+meroxa environments create NAME [flags]
+```
+
+### Examples
+
+```
+
+meroxa env create my-env --type self_hosted --provider aws --region us-east-1 --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret
+
+```
+
+### Options
+
+```
+  -c, --config strings    environment configuration based on type and provider (e.g.: --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret)
+  -h, --help              help for create
+      --provider string   environment cloud provider to use
+      --region string     environment region
+      --type string       environment type, when not specified
+  -y, --yes               skip confirmation prompt
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa environments](meroxa_environments.md)	 - Manage environments on Meroxa
+

--- a/docs/cmd/md/meroxa_environments_describe.md
+++ b/docs/cmd/md/meroxa_environments_describe.md
@@ -1,17 +1,15 @@
-## meroxa pipelines create
+## meroxa environments describe
 
-Create a pipeline
+Describe environment
 
 ```
-meroxa pipelines create NAME [flags]
+meroxa environments describe [NAMEorUUID] [flags]
 ```
 
 ### Options
 
 ```
-      --env string        environment (name or UUID) where pipeline will be created
-  -h, --help              help for create
-  -m, --metadata string   pipeline metadata
+  -h, --help   help for describe
 ```
 
 ### Options inherited from parent commands
@@ -25,5 +23,5 @@ meroxa pipelines create NAME [flags]
 
 ### SEE ALSO
 
-* [meroxa pipelines](meroxa_pipelines.md)	 - Manage pipelines on Meroxa
+* [meroxa environments](meroxa_environments.md)	 - Manage environments on Meroxa
 

--- a/docs/cmd/md/meroxa_environments_list.md
+++ b/docs/cmd/md/meroxa_environments_list.md
@@ -1,17 +1,16 @@
-## meroxa pipelines create
+## meroxa environments list
 
-Create a pipeline
+List environments
 
 ```
-meroxa pipelines create NAME [flags]
+meroxa environments list [flags]
 ```
 
 ### Options
 
 ```
-      --env string        environment (name or UUID) where pipeline will be created
-  -h, --help              help for create
-  -m, --metadata string   pipeline metadata
+  -h, --help         help for list
+      --no-headers   display output without headers
 ```
 
 ### Options inherited from parent commands
@@ -25,5 +24,5 @@ meroxa pipelines create NAME [flags]
 
 ### SEE ALSO
 
-* [meroxa pipelines](meroxa_pipelines.md)	 - Manage pipelines on Meroxa
+* [meroxa environments](meroxa_environments.md)	 - Manage environments on Meroxa
 

--- a/docs/cmd/md/meroxa_environments_remove.md
+++ b/docs/cmd/md/meroxa_environments_remove.md
@@ -1,17 +1,16 @@
-## meroxa pipelines create
+## meroxa environments remove
 
-Create a pipeline
+Remove environment
 
 ```
-meroxa pipelines create NAME [flags]
+meroxa environments remove NAMEorUUID [flags]
 ```
 
 ### Options
 
 ```
-      --env string        environment (name or UUID) where pipeline will be created
-  -h, --help              help for create
-  -m, --metadata string   pipeline metadata
+  -f, --force   skip confirmation
+  -h, --help    help for remove
 ```
 
 ### Options inherited from parent commands
@@ -25,5 +24,5 @@ meroxa pipelines create NAME [flags]
 
 ### SEE ALSO
 
-* [meroxa pipelines](meroxa_pipelines.md)	 - Manage pipelines on Meroxa
+* [meroxa environments](meroxa_environments.md)	 - Manage environments on Meroxa
 

--- a/docs/cmd/md/meroxa_environments_update.md
+++ b/docs/cmd/md/meroxa_environments_update.md
@@ -1,0 +1,38 @@
+## meroxa environments update
+
+Update an environment
+
+```
+meroxa environments update NAMEorUUID [flags]
+```
+
+### Examples
+
+```
+
+meroxa env update my-env --name new-name --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret"
+
+```
+
+### Options
+
+```
+  -c, --config strings   updated environment configuration based on type and provider (e.g.: --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret)
+  -h, --help             help for update
+      --name string      updated environment name, when specified
+  -y, --yes              skip confirmation prompt
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa environments](meroxa_environments.md)	 - Manage environments on Meroxa
+

--- a/docs/cmd/md/meroxa_resources_create.md
+++ b/docs/cmd/md/meroxa_resources_create.md
@@ -27,6 +27,7 @@ meroxa resources create slack --type url -u $WEBHOOK_URL
       --ca-cert string           trusted certificates for verifying resource
       --client-cert string       client certificate for authenticating to the resource
       --client-key string        client private key for authenticating to the resource
+      --env string               environment (name or UUID) where resource will be created
   -h, --help                     help for create
   -m, --metadata string          resource metadata
       --password string          password

--- a/docs/cmd/www/meroxa-environments-create.md
+++ b/docs/cmd/www/meroxa-environments-create.md
@@ -1,0 +1,47 @@
+---
+createdAt: 
+updatedAt: 
+title: "meroxa environments create"
+slug: meroxa-environments-create
+url: /cli/cmd/meroxa-environments-create/
+---
+## meroxa environments create
+
+Create an environment
+
+```
+meroxa environments create NAME [flags]
+```
+
+### Examples
+
+```
+
+meroxa env create my-env --type self_hosted --provider aws --region us-east-1 --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret
+
+```
+
+### Options
+
+```
+  -c, --config strings    environment configuration based on type and provider (e.g.: --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret)
+  -h, --help              help for create
+      --provider string   environment cloud provider to use
+      --region string     environment region
+      --type string       environment type, when not specified
+  -y, --yes               skip confirmation prompt
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa environments](/cli/cmd/meroxa-environments/)	 - Manage environments on Meroxa
+

--- a/docs/cmd/www/meroxa-environments-describe.md
+++ b/docs/cmd/www/meroxa-environments-describe.md
@@ -1,0 +1,34 @@
+---
+createdAt: 
+updatedAt: 
+title: "meroxa environments describe"
+slug: meroxa-environments-describe
+url: /cli/cmd/meroxa-environments-describe/
+---
+## meroxa environments describe
+
+Describe environment
+
+```
+meroxa environments describe [NAMEorUUID] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for describe
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa environments](/cli/cmd/meroxa-environments/)	 - Manage environments on Meroxa
+

--- a/docs/cmd/www/meroxa-environments-list.md
+++ b/docs/cmd/www/meroxa-environments-list.md
@@ -1,0 +1,35 @@
+---
+createdAt: 
+updatedAt: 
+title: "meroxa environments list"
+slug: meroxa-environments-list
+url: /cli/cmd/meroxa-environments-list/
+---
+## meroxa environments list
+
+List environments
+
+```
+meroxa environments list [flags]
+```
+
+### Options
+
+```
+  -h, --help         help for list
+      --no-headers   display output without headers
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa environments](/cli/cmd/meroxa-environments/)	 - Manage environments on Meroxa
+

--- a/docs/cmd/www/meroxa-environments-remove.md
+++ b/docs/cmd/www/meroxa-environments-remove.md
@@ -1,0 +1,35 @@
+---
+createdAt: 
+updatedAt: 
+title: "meroxa environments remove"
+slug: meroxa-environments-remove
+url: /cli/cmd/meroxa-environments-remove/
+---
+## meroxa environments remove
+
+Remove environment
+
+```
+meroxa environments remove NAMEorUUID [flags]
+```
+
+### Options
+
+```
+  -f, --force   skip confirmation
+  -h, --help    help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa environments](/cli/cmd/meroxa-environments/)	 - Manage environments on Meroxa
+

--- a/docs/cmd/www/meroxa-environments-update.md
+++ b/docs/cmd/www/meroxa-environments-update.md
@@ -1,0 +1,45 @@
+---
+createdAt: 
+updatedAt: 
+title: "meroxa environments update"
+slug: meroxa-environments-update
+url: /cli/cmd/meroxa-environments-update/
+---
+## meroxa environments update
+
+Update an environment
+
+```
+meroxa environments update NAMEorUUID [flags]
+```
+
+### Examples
+
+```
+
+meroxa env update my-env --name new-name --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret"
+
+```
+
+### Options
+
+```
+  -c, --config strings   updated environment configuration based on type and provider (e.g.: --config aws_access_key_id=my_access_key --config aws_access_secret=my_access_secret)
+  -h, --help             help for update
+      --name string      updated environment name, when specified
+  -y, --yes              skip confirmation prompt
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa environments](/cli/cmd/meroxa-environments/)	 - Manage environments on Meroxa
+

--- a/docs/cmd/www/meroxa-environments.md
+++ b/docs/cmd/www/meroxa-environments.md
@@ -1,0 +1,35 @@
+---
+createdAt: 
+updatedAt: 
+title: "meroxa environments"
+slug: meroxa-environments
+url: /cli/cmd/meroxa-environments/
+---
+## meroxa environments
+
+Manage environments on Meroxa
+
+### Options
+
+```
+  -h, --help   help for environments
+```
+
+### Options inherited from parent commands
+
+```
+      --cli-config-file string   meroxa configuration file
+      --debug                    display any debugging information
+      --json                     output json
+      --timeout duration         set the duration of the client timeout in seconds (default 10s)
+```
+
+### SEE ALSO
+
+* [meroxa](/cli/cmd/meroxa/)	 - The Meroxa CLI
+* [meroxa environments create](/cli/cmd/meroxa-environments-create/)	 - Create an environment
+* [meroxa environments describe](/cli/cmd/meroxa-environments-describe/)	 - Describe environment
+* [meroxa environments list](/cli/cmd/meroxa-environments-list/)	 - List environments
+* [meroxa environments remove](/cli/cmd/meroxa-environments-remove/)	 - Remove environment
+* [meroxa environments update](/cli/cmd/meroxa-environments-update/)	 - Update an environment
+

--- a/docs/cmd/www/meroxa-pipelines-create.md
+++ b/docs/cmd/www/meroxa-pipelines-create.md
@@ -16,6 +16,7 @@ meroxa pipelines create NAME [flags]
 ### Options
 
 ```
+      --env string        environment (name or UUID) where pipeline will be created
   -h, --help              help for create
   -m, --metadata string   pipeline metadata
 ```

--- a/docs/cmd/www/meroxa-resources-create.md
+++ b/docs/cmd/www/meroxa-resources-create.md
@@ -34,6 +34,7 @@ meroxa resources create slack --type url -u $WEBHOOK_URL
       --ca-cert string           trusted certificates for verifying resource
       --client-cert string       client certificate for authenticating to the resource
       --client-key string        client private key for authenticating to the resource
+      --env string               environment (name or UUID) where resource will be created
   -h, --help                     help for create
   -m, --metadata string          resource metadata
       --password string          password

--- a/docs/cmd/www/meroxa.md
+++ b/docs/cmd/www/meroxa.md
@@ -40,6 +40,7 @@ meroxa resources list --types
 * [meroxa connect](/cli/cmd/meroxa-connect/)	 - Connect two resources together
 * [meroxa connectors](/cli/cmd/meroxa-connectors/)	 - Manage connectors on Meroxa
 * [meroxa endpoints](/cli/cmd/meroxa-endpoints/)	 - Manage endpoints on Meroxa
+* [meroxa environments](/cli/cmd/meroxa-environments/)	 - Manage environments on Meroxa
 * [meroxa login](/cli/cmd/meroxa-login/)	 - Login or Sign up to the Meroxa Platform
 * [meroxa logout](/cli/cmd/meroxa-logout/)	 - Clears local login credentials of the Meroxa Platform
 * [meroxa open](/cli/cmd/meroxa-open/)	 - Open in a web browser

--- a/etc/completion/meroxa.completion.sh
+++ b/etc/completion/meroxa.completion.sh
@@ -1170,6 +1170,238 @@ _meroxa_endpoints()
     noun_aliases=()
 }
 
+_meroxa_environments_create()
+{
+    last_command="meroxa_environments_create"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    two_word_flags+=("-c")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--provider=")
+    two_word_flags+=("--provider")
+    flags+=("--region=")
+    two_word_flags+=("--region")
+    flags+=("--type=")
+    two_word_flags+=("--type")
+    flags+=("--yes")
+    flags+=("-y")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_environments_describe()
+{
+    last_command="meroxa_environments_describe"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_environments_help()
+{
+    last_command="meroxa_environments_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_environments_list()
+{
+    last_command="meroxa_environments_list"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--no-headers")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_environments_remove()
+{
+    last_command="meroxa_environments_remove"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--force")
+    flags+=("-f")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_environments_update()
+{
+    last_command="meroxa_environments_update"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--config=")
+    two_word_flags+=("--config")
+    two_word_flags+=("-c")
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--name=")
+    two_word_flags+=("--name")
+    flags+=("--yes")
+    flags+=("-y")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_environments()
+{
+    last_command="meroxa_environments"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("create")
+    commands+=("describe")
+    commands+=("help")
+    commands+=("list")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("ls")
+        aliashash["ls"]="list"
+    fi
+    commands+=("remove")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("delete")
+        aliashash["delete"]="remove"
+        command_aliases+=("rm")
+        aliashash["rm"]="remove"
+    fi
+    commands+=("update")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _meroxa_help()
 {
     last_command="meroxa_help"
@@ -1352,6 +1584,8 @@ _meroxa_pipelines_create()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--env=")
+    two_word_flags+=("--env")
     flags+=("--help")
     flags+=("-h")
     flags+=("--metadata=")
@@ -1582,6 +1816,8 @@ _meroxa_resources_create()
     two_word_flags+=("--client-cert")
     flags+=("--client-key=")
     two_word_flags+=("--client-key")
+    flags+=("--env=")
+    two_word_flags+=("--env")
     flags+=("--help")
     flags+=("-h")
     flags+=("--metadata=")
@@ -2060,6 +2296,13 @@ _meroxa_root_command()
     if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
         command_aliases+=("endpoint")
         aliashash["endpoint"]="endpoints"
+    fi
+    commands+=("environments")
+    if [[ -z "${BASH_VERSION}" || "${BASH_VERSINFO[0]}" -gt 3 ]]; then
+        command_aliases+=("env")
+        aliashash["env"]="environments"
+        command_aliases+=("environment")
+        aliashash["environment"]="environments"
     fi
     commands+=("help")
     commands+=("login")

--- a/etc/man/man1/meroxa-api.1
+++ b/etc/man/man1/meroxa-api.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-login.1
+++ b/etc/man/man1/meroxa-auth-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-logout.1
+++ b/etc/man/man1/meroxa-auth-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-whoami.1
+++ b/etc/man/man1/meroxa-auth-whoami.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth.1
+++ b/etc/man/man1/meroxa-auth.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-billing.1
+++ b/etc/man/man1/meroxa-billing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-completion.1
+++ b/etc/man/man1/meroxa-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-config-describe.1
+++ b/etc/man/man1/meroxa-config-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-config.1
+++ b/etc/man/man1/meroxa-config.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-connect.1
+++ b/etc/man/man1/meroxa-connect.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-connectors-create.1
+++ b/etc/man/man1/meroxa-connectors-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-connectors-describe.1
+++ b/etc/man/man1/meroxa-connectors-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-connectors-list.1
+++ b/etc/man/man1/meroxa-connectors-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-connectors-logs.1
+++ b/etc/man/man1/meroxa-connectors-logs.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-connectors-remove.1
+++ b/etc/man/man1/meroxa-connectors-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-connectors-update.1
+++ b/etc/man/man1/meroxa-connectors-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-connectors.1
+++ b/etc/man/man1/meroxa-connectors.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints-create.1
+++ b/etc/man/man1/meroxa-endpoints-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints-describe.1
+++ b/etc/man/man1/meroxa-endpoints-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints-list.1
+++ b/etc/man/man1/meroxa-endpoints-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints-remove.1
+++ b/etc/man/man1/meroxa-endpoints-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints.1
+++ b/etc/man/man1/meroxa-endpoints.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-create.1
+++ b/etc/man/man1/meroxa-environments-create.1
@@ -1,0 +1,78 @@
+.nh
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-environments\-create \- Create an environment
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa environments create NAME [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Create an environment
+
+
+.SH OPTIONS
+.PP
+\fB\-c\fP, \fB\-\-config\fP=[]
+	environment configuration based on type and provider (e.g.: \-\-config aws\_access\_key\_id=my\_access\_key \-\-config aws\_access\_secret=my\_access\_secret)
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for create
+
+.PP
+\fB\-\-provider\fP=""
+	environment cloud provider to use
+
+.PP
+\fB\-\-region\fP=""
+	environment region
+
+.PP
+\fB\-\-type\fP=""
+	environment type, when not specified
+
+.PP
+\fB\-y\fP, \fB\-\-yes\fP[=false]
+	skip confirmation prompt
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-cli\-config\-file\fP=""
+	meroxa configuration file
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+.PP
+\fB\-\-timeout\fP=10s
+	set the duration of the client timeout in seconds
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+
+meroxa env create my\-env \-\-type self\_hosted \-\-provider aws \-\-region us\-east\-1 \-\-config aws\_access\_key\_id=my\_access\_key \-\-config aws\_access\_secret=my\_access\_secret
+
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-environments(1)\fP

--- a/etc/man/man1/meroxa-environments-describe.1
+++ b/etc/man/man1/meroxa-environments-describe.1
@@ -3,27 +3,23 @@
 
 .SH NAME
 .PP
-meroxa\-pipelines\-remove \- Remove pipeline
+meroxa\-environments\-describe \- Describe environment
 
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa pipelines remove NAME [flags]\fP
+\fBmeroxa environments describe [NAMEorUUID] [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
-Remove pipeline
+Describe environment
 
 
 .SH OPTIONS
 .PP
-\fB\-f\fP, \fB\-\-force\fP[=false]
-	skip confirmation
-
-.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
-	help for remove
+	help for describe
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -46,4 +42,4 @@ Remove pipeline
 
 .SH SEE ALSO
 .PP
-\fBmeroxa\-pipelines(1)\fP
+\fBmeroxa\-environments(1)\fP

--- a/etc/man/man1/meroxa-environments-list.1
+++ b/etc/man/man1/meroxa-environments-list.1
@@ -3,27 +3,27 @@
 
 .SH NAME
 .PP
-meroxa\-pipelines\-remove \- Remove pipeline
+meroxa\-environments\-list \- List environments
 
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa pipelines remove NAME [flags]\fP
+\fBmeroxa environments list [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
-Remove pipeline
+List environments
 
 
 .SH OPTIONS
 .PP
-\fB\-f\fP, \fB\-\-force\fP[=false]
-	skip confirmation
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for list
 
 .PP
-\fB\-h\fP, \fB\-\-help\fP[=false]
-	help for remove
+\fB\-\-no\-headers\fP[=false]
+	display output without headers
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -46,4 +46,4 @@ Remove pipeline
 
 .SH SEE ALSO
 .PP
-\fBmeroxa\-pipelines(1)\fP
+\fBmeroxa\-environments(1)\fP

--- a/etc/man/man1/meroxa-environments-remove.1
+++ b/etc/man/man1/meroxa-environments-remove.1
@@ -3,17 +3,17 @@
 
 .SH NAME
 .PP
-meroxa\-pipelines\-remove \- Remove pipeline
+meroxa\-environments\-remove \- Remove environment
 
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa pipelines remove NAME [flags]\fP
+\fBmeroxa environments remove NAMEorUUID [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
-Remove pipeline
+Remove environment
 
 
 .SH OPTIONS
@@ -46,4 +46,4 @@ Remove pipeline
 
 .SH SEE ALSO
 .PP
-\fBmeroxa\-pipelines(1)\fP
+\fBmeroxa\-environments(1)\fP

--- a/etc/man/man1/meroxa-environments-update.1
+++ b/etc/man/man1/meroxa-environments-update.1
@@ -1,0 +1,70 @@
+.nh
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
+
+.SH NAME
+.PP
+meroxa\-environments\-update \- Update an environment
+
+
+.SH SYNOPSIS
+.PP
+\fBmeroxa environments update NAMEorUUID [flags]\fP
+
+
+.SH DESCRIPTION
+.PP
+Update an environment
+
+
+.SH OPTIONS
+.PP
+\fB\-c\fP, \fB\-\-config\fP=[]
+	updated environment configuration based on type and provider (e.g.: \-\-config aws\_access\_key\_id=my\_access\_key \-\-config aws\_access\_secret=my\_access\_secret)
+
+.PP
+\fB\-h\fP, \fB\-\-help\fP[=false]
+	help for update
+
+.PP
+\fB\-\-name\fP=""
+	updated environment name, when specified
+
+.PP
+\fB\-y\fP, \fB\-\-yes\fP[=false]
+	skip confirmation prompt
+
+
+.SH OPTIONS INHERITED FROM PARENT COMMANDS
+.PP
+\fB\-\-cli\-config\-file\fP=""
+	meroxa configuration file
+
+.PP
+\fB\-\-debug\fP[=false]
+	display any debugging information
+
+.PP
+\fB\-\-json\fP[=false]
+	output json
+
+.PP
+\fB\-\-timeout\fP=10s
+	set the duration of the client timeout in seconds
+
+
+.SH EXAMPLE
+.PP
+.RS
+
+.nf
+
+meroxa env update my\-env \-\-name new\-name \-\-config aws\_access\_key\_id=my\_access\_key \-\-config aws\_access\_secret=my\_access\_secret"
+
+
+.fi
+.RE
+
+
+.SH SEE ALSO
+.PP
+\fBmeroxa\-environments(1)\fP

--- a/etc/man/man1/meroxa-environments.1
+++ b/etc/man/man1/meroxa-environments.1
@@ -3,27 +3,23 @@
 
 .SH NAME
 .PP
-meroxa\-pipelines\-remove \- Remove pipeline
+meroxa\-environments \- Manage environments on Meroxa
 
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa pipelines remove NAME [flags]\fP
+\fBmeroxa environments [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
-Remove pipeline
+Manage environments on Meroxa
 
 
 .SH OPTIONS
 .PP
-\fB\-f\fP, \fB\-\-force\fP[=false]
-	skip confirmation
-
-.PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
-	help for remove
+	help for environments
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -46,4 +42,4 @@ Remove pipeline
 
 .SH SEE ALSO
 .PP
-\fBmeroxa\-pipelines(1)\fP
+\fBmeroxa(1)\fP, \fBmeroxa\-environments\-create(1)\fP, \fBmeroxa\-environments\-describe(1)\fP, \fBmeroxa\-environments\-list(1)\fP, \fBmeroxa\-environments\-remove(1)\fP, \fBmeroxa\-environments\-update(1)\fP

--- a/etc/man/man1/meroxa-login.1
+++ b/etc/man/man1/meroxa-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-logout.1
+++ b/etc/man/man1/meroxa-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-open-billing.1
+++ b/etc/man/man1/meroxa-open-billing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-open.1
+++ b/etc/man/man1/meroxa-open.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-pipelines-create.1
+++ b/etc/man/man1/meroxa-pipelines-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -17,6 +17,10 @@ Create a pipeline
 
 
 .SH OPTIONS
+.PP
+\fB\-\-env\fP=""
+	environment (name or UUID) where pipeline will be created
+
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]
 	help for create

--- a/etc/man/man1/meroxa-pipelines-describe.1
+++ b/etc/man/man1/meroxa-pipelines-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-pipelines-list.1
+++ b/etc/man/man1/meroxa-pipelines-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-pipelines-update.1
+++ b/etc/man/man1/meroxa-pipelines-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-pipelines.1
+++ b/etc/man/man1/meroxa-pipelines.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-create.1
+++ b/etc/man/man1/meroxa-resources-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -28,6 +28,10 @@ Use the create command to add resources to your Meroxa resource catalog.
 .PP
 \fB\-\-client\-key\fP=""
 	client private key for authenticating to the resource
+
+.PP
+\fB\-\-env\fP=""
+	environment (name or UUID) where resource will be created
 
 .PP
 \fB\-h\fP, \fB\-\-help\fP[=false]

--- a/etc/man/man1/meroxa-resources-describe.1
+++ b/etc/man/man1/meroxa-resources-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-list.1
+++ b/etc/man/man1/meroxa-resources-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-remove.1
+++ b/etc/man/man1/meroxa-resources-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-rotate-tunnel-key.1
+++ b/etc/man/man1/meroxa-resources-rotate-tunnel-key.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-update.1
+++ b/etc/man/man1/meroxa-resources-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-validate.1
+++ b/etc/man/man1/meroxa-resources-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources.1
+++ b/etc/man/man1/meroxa-resources.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-transforms-list.1
+++ b/etc/man/man1/meroxa-transforms-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-transforms.1
+++ b/etc/man/man1/meroxa-transforms.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-version.1
+++ b/etc/man/man1/meroxa-version.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-whoami.1
+++ b/etc/man/man1/meroxa-whoami.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa.1
+++ b/etc/man/man1/meroxa.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Dec 2021" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Jan 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -48,4 +48,4 @@ meroxa resources list \-\-types
 
 .SH SEE ALSO
 .PP
-\fBmeroxa\-api(1)\fP, \fBmeroxa\-auth(1)\fP, \fBmeroxa\-billing(1)\fP, \fBmeroxa\-completion(1)\fP, \fBmeroxa\-config(1)\fP, \fBmeroxa\-connect(1)\fP, \fBmeroxa\-connectors(1)\fP, \fBmeroxa\-endpoints(1)\fP, \fBmeroxa\-login(1)\fP, \fBmeroxa\-logout(1)\fP, \fBmeroxa\-open(1)\fP, \fBmeroxa\-pipelines(1)\fP, \fBmeroxa\-resources(1)\fP, \fBmeroxa\-transforms(1)\fP, \fBmeroxa\-version(1)\fP, \fBmeroxa\-whoami(1)\fP
+\fBmeroxa\-api(1)\fP, \fBmeroxa\-auth(1)\fP, \fBmeroxa\-billing(1)\fP, \fBmeroxa\-completion(1)\fP, \fBmeroxa\-config(1)\fP, \fBmeroxa\-connect(1)\fP, \fBmeroxa\-connectors(1)\fP, \fBmeroxa\-endpoints(1)\fP, \fBmeroxa\-environments(1)\fP, \fBmeroxa\-login(1)\fP, \fBmeroxa\-logout(1)\fP, \fBmeroxa\-open(1)\fP, \fBmeroxa\-pipelines(1)\fP, \fBmeroxa\-resources(1)\fP, \fBmeroxa\-transforms(1)\fP, \fBmeroxa\-version(1)\fP, \fBmeroxa\-whoami(1)\fP

--- a/utils/display.go
+++ b/utils/display.go
@@ -115,6 +115,11 @@ func ResourceTable(res *meroxa.Resource) string {
 				{Text: e},
 			})
 		}
+	} else {
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "Environment Name:"},
+			{Text: string(meroxa.EnvironmentTypeCommon)},
+		})
 	}
 
 	mainTable.SetStyle(simpletable.StyleCompact)
@@ -152,6 +157,11 @@ func PipelineTable(p *meroxa.Pipeline) string {
 				{Text: pN},
 			})
 		}
+	} else {
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "Environment Name:"},
+			{Text: string(meroxa.EnvironmentTypeCommon)},
+		})
 	}
 
 	mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
@@ -304,16 +314,25 @@ func ConnectorTable(connector *meroxa.Connector) string {
 			{Text: connector.Trace},
 		})
 	}
-	var env string
-	if connector.Environment != nil && connector.Environment.Name != "" {
-		env = connector.Environment.Name
+	if connector.Environment != nil {
+		if envUUID := connector.Environment.UUID; envUUID != "" {
+			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: "Environment UUID:"},
+				{Text: envUUID},
+			})
+		}
+		if envName := connector.Environment.Name; envName != "" {
+			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: "Environment Name:"},
+				{Text: envName},
+			})
+		}
 	} else {
-		env = string(meroxa.EnvironmentTypeCommon)
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "Environment Name:"},
+			{Text: string(meroxa.EnvironmentTypeCommon)},
+		})
 	}
-	mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
-		{Align: simpletable.AlignRight, Text: "Environment:"},
-		{Text: env},
-	})
 
 	mainTable.SetStyle(simpletable.StyleCompact)
 

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -479,7 +479,7 @@ func TestPipelineTable(t *testing.T) {
 	}
 
 	tableHeaders := []string{"UUID", "ID", "Name", "State"}
-	var envHeader = "Environment"
+	var envHeader = "Environment Name"
 
 	for name, p := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -504,15 +504,12 @@ func TestPipelineTable(t *testing.T) {
 				if !strings.Contains(out, pipelineBase.UUID) {
 					t.Errorf("%s, not found", pipelineBase.UUID)
 				}
-				if strings.Contains(out, envHeader) {
-					t.Errorf("%q header is not necessary", envHeader)
+				if !strings.Contains(out, envHeader) {
+					t.Errorf("%q not found", envHeader)
 				}
 			case "With_Environment":
-				if !strings.Contains(out, envHeader) {
-					t.Errorf("%q header is missing", envHeader)
-				}
-				if !strings.Contains(out, pipelineWithEnv.Environment.Name) {
-					t.Errorf("expected environment name to be %q", pipelineWithEnv.Environment.Name)
+				if !strings.Contains(out, pipelineWithEnv.Environment.UUID) {
+					t.Errorf("expected environment UUID to be %q", pipelineWithEnv.Environment.UUID)
 				}
 			}
 			fmt.Println(out)


### PR DESCRIPTION
# Description of change
 Ensure all customers can see the environment commands & flags
Ensure that customers who do not have permissions to use the flags get a message with a link to sign up for beta https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sme

Fixes https://github.com/meroxa/cli/issues/237

# Type of change

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

# Demo

**Before this pull-request**

$ m --help
The Meroxa CLI allows quick and easy access to the Meroxa Data Platform.

Using the CLI you are able to create and manage sophisticated data pipelines
with only a few simple commands. You can get started by listing the supported
resource types:

meroxa resources list --types

Usage:
  meroxa [command]

Available Commands:
  api          Invoke Meroxa API
  auth         Authentication commands for Meroxa
  billing      Open your billing page in a web browser
  completion   Generate completion script
  config       Manage your Meroxa CLI configuration
  connect      Connect two resources together
  connectors   Manage connectors on Meroxa
  endpoints    Manage endpoints on Meroxa
  help         Help about any command
  login        Login or Sign up to the Meroxa Platform
  logout       Clears local login credentials of the Meroxa Platform
  open         Open in a web browser
  pipelines    Manage pipelines on Meroxa
  resources    Manage resources on Meroxa
  transforms   Manage transforms on Meroxa
  version      Display the Meroxa CLI version
  whoami       Display the current logged in user


Flags:
      --cli-config-file string   meroxa configuration file
      --debug                    display any debugging information
  -h, --help                     help for meroxa
      --json                     output json
      --timeout duration         set the duration of the client timeout in seconds (default 10s)

Use "meroxa [command] --help" for more information about a command.


$ m pipeline create --help
Create a pipeline

Usage:
  meroxa pipelines create NAME [flags]

Flags:
  -h, --help              help for create
  -m, --metadata string   pipeline metadata

Global Flags:
      --cli-config-file string   meroxa configuration file
      --debug                    display any debugging information
      --json                     output json
      --timeout duration         set the duration of the client timeout in seconds (default 10s)

$ m resource create --help
Use the create command to add resources to your Meroxa resource catalog.

Usage:
  meroxa resources create [NAME] --type TYPE --url URL [flags]

Aliases:
  create, add

Examples:

meroxa resources create store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":true}'
meroxa resources create datalake --type s3 -u "s3://$AWS_ACCESS_KEY_ID:$AWS_ACCESS_KEY_SECRET@us-east-1/meroxa-demos"
meroxa resources create warehouse --type redshift -u $REDSHIFT_URL
meroxa resources create slack --type url -u $WEBHOOK_URL


Flags:
      --ca-cert string           trusted certificates for verifying resource
      --client-cert string       client certificate for authenticating to the resource
      --client-key string        client private key for authenticating to the resource
  -h, --help                     help for create
  -m, --metadata string          resource metadata
      --password string          password
      --ssh-private-key string   SSH tunneling private key
      --ssh-url string           SSH tunneling address
      --ssl                      use SSL
      --type string              resource type (required)
  -u, --url string               resource url (required)
      --username string          username

Global Flags:
      --cli-config-file string   meroxa configuration file
      --debug                    display any debugging information
      --json                     output json
      --timeout duration         set the duration of the client timeout in seconds (default 10s)

$ m pipeline create test-pipeline --env jan12
Creating pipeline "test-pipeline" in "jan12" environment...
Error: user lacks permission for environment operation

$ m resource create source --type mongodb -u mongodb+srv://userIsEjprKh:nP4fkPGm5gSCJWoV@cluster0.toy9e.mongodb.net/meroxa --env jan12
Creating "mongodb" resource in "jan12" environment...
Error: user lacks permission for environment operation

**After this pull-request**

$ m --help
The Meroxa CLI allows quick and easy access to the Meroxa Data Platform.

Using the CLI you are able to create and manage sophisticated data pipelines
with only a few simple commands. You can get started by listing the supported
resource types:

meroxa resources list --types

Usage:
  meroxa [command]

Available Commands:
  api          Invoke Meroxa API
  auth         Authentication commands for Meroxa
  billing      Open your billing page in a web browser
  completion   Generate completion script
  config       Manage your Meroxa CLI configuration
  connect      Connect two resources together
  connectors   Manage connectors on Meroxa
  endpoints    Manage endpoints on Meroxa
 ** environments Manage environments on Meroxa**
  help         Help about any command
  login        Login or Sign up to the Meroxa Platform
  logout       Clears local login credentials of the Meroxa Platform
  open         Open in a web browser
  pipelines    Manage pipelines on Meroxa
  resources    Manage resources on Meroxa
  transforms   Manage transforms on Meroxa
  version      Display the Meroxa CLI version
  whoami       Display the current logged in user


Flags:
      --cli-config-file string   meroxa configuration file
      --debug                    display any debugging information
  -h, --help                     help for meroxa
      --json                     output json
      --timeout duration         set the duration of the client timeout in seconds (default 10s)

Use "meroxa [command] --help" for more information about a command.


$ m pipelines create --help
Create a pipeline

Usage:
  meroxa pipelines create NAME [flags]

Flags:
  **    --env string        environment (name or UUID) where pipeline will be created**
  -h, --help              help for create
  -m, --metadata string   pipeline metadata

Global Flags:
      --cli-config-file string   meroxa configuration file
      --debug                    display any debugging information
      --json                     output json
      --timeout duration         set the duration of the client timeout in seconds (default 10s)


$ m resource create --help
Use the create command to add resources to your Meroxa resource catalog.

Usage:
  meroxa resources create [NAME] --type TYPE --url URL [flags]

Aliases:
  create, add

Examples:

meroxa resources create store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":true}'
meroxa resources create datalake --type s3 -u "s3://$AWS_ACCESS_KEY_ID:$AWS_ACCESS_KEY_SECRET@us-east-1/meroxa-demos"
meroxa resources create warehouse --type redshift -u $REDSHIFT_URL
meroxa resources create slack --type url -u $WEBHOOK_URL


Flags:
      --ca-cert string           trusted certificates for verifying resource
      --client-cert string       client certificate for authenticating to the resource
      --client-key string        client private key for authenticating to the resource
 **     --env string               environment (name or UUID) where resource will be created**
  -h, --help                     help for create
  -m, --metadata string          resource metadata
      --password string          password
      --ssh-private-key string   SSH tunneling private key
      --ssh-url string           SSH tunneling address
      --ssl                      use SSL
      --type string              resource type (required)
  -u, --url string               resource url (required)
      --username string          username

Global Flags:
      --cli-config-file string   meroxa configuration file
      --debug                    display any debugging information
      --json                     output json
      --timeout duration         set the duration of the client timeout in seconds (default 10s)

$ m pipeline create test-pipeline --env jan12
Error: no access to the Meroxa self-hosted environments feature.
Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sme

$ m resource create source --type mongodb -u mongodb+srv://userIsEjprKh:nP4fkPGm5gSCJWoV@cluster0.toy9e.mongodb.net/meroxa --env jan12
Error: no access to the Meroxa self-hosted environments feature.
Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sme


# Additional references

*Any additional links (if appropriate)*

# Documentation updated

*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨

*Provide PR link:* 
