### PR TITLE
Add `meroxa functions`

### DIFF
--- a/cmd/meroxa/root/environments/list_test.go
+++ b/cmd/meroxa/root/environments/list_test.go
@@ -40,7 +40,7 @@ func TestListEnvironmentsExecution(t *testing.T) {
 		Type:     meroxa.EnvironmentTypePrivate,
 		Name:     "environment-1234",
 		Provider: meroxa.EnvironmentProviderAws,
-		Region:   meroxa.EnvironmentRegionUsEast2,
+		Region:   meroxa.EnvironmentRegionUsEast1,
 		Status:   meroxa.EnvironmentViewStatus{State: meroxa.EnvironmentStateProvisioned},
 		UUID:     "531428f7-4e86-4094-8514-d397d49026f7",
 	}

--- a/cmd/meroxa/root/functions/create.go
+++ b/cmd/meroxa/root/functions/create.go
@@ -108,7 +108,7 @@ func (c *Create) parseEnvVars(envVars []string) (map[string]string, error) {
 	m := make(map[string]string)
 	for _, ev := range envVars {
 		var (
-			split = strings.SplitN(ev, "=", 2)
+			split = strings.SplitN(ev, "=", 2) //nolint
 			key   = split[0]
 			val   = split[1]
 		)

--- a/cmd/meroxa/root/functions/create.go
+++ b/cmd/meroxa/root/functions/create.go
@@ -1,0 +1,143 @@
+package functions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/mattn/go-shellwords"
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+var (
+	_ builder.CommandWithDocs    = (*Create)(nil)
+	_ builder.CommandWithArgs    = (*Create)(nil)
+	_ builder.CommandWithFlags   = (*Create)(nil)
+	_ builder.CommandWithClient  = (*Create)(nil)
+	_ builder.CommandWithLogger  = (*Create)(nil)
+	_ builder.CommandWithExecute = (*Create)(nil)
+)
+
+type createFunctionClient interface {
+	CreateFunction(ctx context.Context, input *meroxa.CreateFunctionInput) (*meroxa.Function, error)
+}
+
+type Create struct {
+	client createFunctionClient
+	logger log.Logger
+
+	args struct {
+		Name string
+	}
+
+	flags struct {
+		InputStream string   `long:"input-stream" usage:"an input stream to the function" required:"true"`
+		Image       string   `long:"image" usage:"Docker image name" required:"true"`
+		Command     string   `long:"command" usage:"Entrypoint command"`
+		Args        string   `long:"args" usage:"Arguments to the entrypoint"`
+		EnvVars     []string `long:"env" usage:"List of environment variables to set in the function"`
+		Pipeline    string   `long:"pipeline" usage:"pipeline name to attach function to" required:"true"`
+	}
+}
+
+func (c *Create) Usage() string {
+	return "create [NAME] [flags]"
+}
+
+func (c *Create) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Create a function",
+		Long:  "Use `functions create` to create a function to process records from an input steram (--input-stream)",
+		Example: `
+meroxa functions create [NAME] --input-stream connector-output-stream --image myimage --pipeline my-pipeline
+meroxa functions create [NAME] --input-stream connector-output-stream --image myimage --pipeline my-pipeline --env FOO=BAR --env BAR=BAZ
+`,
+	}
+}
+
+func (c *Create) Execute(ctx context.Context) error {
+	envVars, err := c.parseEnvVars(c.flags.EnvVars)
+	if err != nil {
+		return err
+	}
+
+	var (
+		command []string
+		args    []string
+	)
+	if cmd := c.flags.Command; cmd != "" {
+		command, err = shellwords.Parse(cmd)
+		if err != nil {
+			return err
+		}
+	}
+	if a := c.flags.Args; a != "" {
+		args, err = shellwords.Parse(a)
+		if err != nil {
+			return err
+		}
+	}
+
+	fun, err := c.client.CreateFunction(
+		ctx,
+		&meroxa.CreateFunctionInput{
+			Name:        c.args.Name,
+			InputStream: c.flags.InputStream,
+			Pipeline: meroxa.PipelineIdentifier{
+				Name: c.flags.Pipeline,
+			},
+			Image:   c.flags.Image,
+			Command: command,
+			Args:    args,
+			EnvVars: envVars,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	c.logger.Infof(ctx, "Function %q successfully created!\n", fun.Name)
+	c.logger.JSON(ctx, fun)
+
+	return nil
+}
+
+func (c *Create) parseEnvVars(envVars []string) (map[string]string, error) {
+	m := make(map[string]string)
+	for _, ev := range envVars {
+		var (
+			split = strings.SplitN(ev, "=", 2)
+			key   = split[0]
+			val   = split[1]
+		)
+
+		if key == "" || val == "" {
+			return nil, fmt.Errorf("error parsing env var %q", ev)
+		}
+
+		m[key] = val
+	}
+
+	return m, nil
+}
+
+func (c *Create) Client(client meroxa.Client) {
+	c.client = client
+}
+
+func (c *Create) Logger(logger log.Logger) {
+	c.logger = logger
+}
+
+func (c *Create) Flags() []builder.Flag {
+	return builder.BuildFlags(&c.flags)
+}
+
+func (c *Create) ParseArgs(args []string) error {
+	if len(args) > 0 {
+		c.args.Name = args[0]
+	}
+	return nil
+}

--- a/cmd/meroxa/root/functions/create_test.go
+++ b/cmd/meroxa/root/functions/create_test.go
@@ -1,0 +1,25 @@
+package functions
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCreate(t *testing.T) {
+	c := &Create{}
+
+	m, err := c.parseEnvVars([]string{"KEY=VAL"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(map[string]string{"KEY": "VAL"}, m); diff != "" {
+		t.Fatalf("mismatch of parsed env vars (-want +got): %s", diff)
+	}
+
+	_, err = c.parseEnvVars([]string{"=VAL"})
+	if err == nil {
+		t.Fatal("error should not be nil")
+	}
+}

--- a/cmd/meroxa/root/functions/describe.go
+++ b/cmd/meroxa/root/functions/describe.go
@@ -1,0 +1,71 @@
+package functions
+
+import (
+	"context"
+	"errors"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+var (
+	_ builder.CommandWithDocs    = (*Describe)(nil)
+	_ builder.CommandWithArgs    = (*Describe)(nil)
+	_ builder.CommandWithClient  = (*Describe)(nil)
+	_ builder.CommandWithLogger  = (*Describe)(nil)
+	_ builder.CommandWithExecute = (*Describe)(nil)
+)
+
+type describeFunctionClient interface {
+	GetFunction(ctx context.Context, nameOrUUID string) (*meroxa.Function, error)
+}
+
+type Describe struct {
+	client describeFunctionClient
+	logger log.Logger
+
+	args struct {
+		NameOrUUID string
+	}
+}
+
+func (d *Describe) Usage() string {
+	return "describe [NAMEorUUID]"
+}
+
+func (d *Describe) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Describe function",
+	}
+}
+
+func (d *Describe) Execute(ctx context.Context) error {
+	fun, err := d.client.GetFunction(ctx, d.args.NameOrUUID)
+	if err != nil {
+		return err
+	}
+
+	d.logger.Info(ctx, utils.FunctionTable(fun))
+	d.logger.JSON(ctx, fun)
+
+	return nil
+}
+
+func (d *Describe) Client(client meroxa.Client) {
+	d.client = client
+}
+
+func (d *Describe) Logger(logger log.Logger) {
+	d.logger = logger
+}
+
+func (d *Describe) ParseArgs(args []string) error {
+	if len(args) < 1 {
+		return errors.New("requires function name")
+	}
+
+	d.args.NameOrUUID = args[0]
+	return nil
+}

--- a/cmd/meroxa/root/functions/functions.go
+++ b/cmd/meroxa/root/functions/functions.go
@@ -42,5 +42,6 @@ func (*Functions) Aliases() []string {
 func (*Functions) SubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		builder.BuildCobraCommand(&Create{}),
+		builder.BuildCobraCommand(&List{}),
 	}
 }

--- a/cmd/meroxa/root/functions/functions.go
+++ b/cmd/meroxa/root/functions/functions.go
@@ -43,5 +43,6 @@ func (*Functions) SubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		builder.BuildCobraCommand(&Create{}),
 		builder.BuildCobraCommand(&List{}),
+		builder.BuildCobraCommand(&Describe{}),
 	}
 }

--- a/cmd/meroxa/root/functions/functions.go
+++ b/cmd/meroxa/root/functions/functions.go
@@ -44,5 +44,6 @@ func (*Functions) SubCommands() []*cobra.Command {
 		builder.BuildCobraCommand(&Create{}),
 		builder.BuildCobraCommand(&List{}),
 		builder.BuildCobraCommand(&Describe{}),
+		builder.BuildCobraCommand(&Remove{}),
 	}
 }

--- a/cmd/meroxa/root/functions/functions.go
+++ b/cmd/meroxa/root/functions/functions.go
@@ -1,0 +1,46 @@
+package functions
+
+import (
+	"fmt"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/spf13/cobra"
+)
+
+type Functions struct{}
+
+var (
+	_ builder.CommandWithAliases     = (*Functions)(nil)
+	_ builder.CommandWithDocs        = (*Functions)(nil)
+	_ builder.CommandWithFeatureFlag = (*Functions)(nil)
+	_ builder.CommandWithSubCommands = (*Functions)(nil)
+	_ builder.CommandWithHidden      = (*Functions)(nil)
+)
+
+func (*Functions) Usage() string {
+	return "functions"
+}
+
+func (*Functions) Hidden() bool {
+	return true
+}
+
+func (*Functions) FeatureFlag() (string, error) {
+	return "functions", fmt.Errorf(`no access to the Meroxa functions feature`)
+}
+
+func (*Functions) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Manage functions on Meroxa",
+	}
+}
+
+func (*Functions) Aliases() []string {
+	return []string{"function"}
+}
+
+func (*Functions) SubCommands() []*cobra.Command {
+	return []*cobra.Command{
+		builder.BuildCobraCommand(&Create{}),
+	}
+}

--- a/cmd/meroxa/root/functions/list.go
+++ b/cmd/meroxa/root/functions/list.go
@@ -1,0 +1,67 @@
+package functions
+
+import (
+	"context"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+var (
+	_ builder.CommandWithDocs      = (*List)(nil)
+	_ builder.CommandWithClient    = (*List)(nil)
+	_ builder.CommandWithLogger    = (*List)(nil)
+	_ builder.CommandWithExecute   = (*List)(nil)
+	_ builder.CommandWithAliases   = (*List)(nil)
+	_ builder.CommandWithNoHeaders = (*List)(nil)
+)
+
+type listFunctionClient interface {
+	ListFunctions(ctx context.Context) ([]meroxa.Function, error)
+}
+
+type List struct {
+	client      listFunctionClient
+	logger      log.Logger
+	hideHeaders bool
+}
+
+func (l *List) Execute(ctx context.Context) error {
+	funs, err := l.client.ListFunctions(ctx)
+	if err != nil {
+		return err
+	}
+
+	l.logger.JSON(ctx, funs)
+	l.logger.Info(ctx, utils.FunctionsTable(funs, l.hideHeaders))
+
+	return nil
+}
+
+func (l *List) Usage() string {
+	return "list"
+}
+
+func (l *List) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "List functions",
+	}
+}
+
+func (l *List) Aliases() []string {
+	return []string{"ls"}
+}
+
+func (c *List) Client(client meroxa.Client) {
+	c.client = client
+}
+
+func (c *List) Logger(logger log.Logger) {
+	c.logger = logger
+}
+
+func (l *List) HideHeaders(hide bool) {
+	l.hideHeaders = hide
+}

--- a/cmd/meroxa/root/functions/list.go
+++ b/cmd/meroxa/root/functions/list.go
@@ -19,7 +19,7 @@ var (
 )
 
 type listFunctionClient interface {
-	ListFunctions(ctx context.Context) ([]meroxa.Function, error)
+	ListFunctions(ctx context.Context) ([]*meroxa.Function, error)
 }
 
 type List struct {
@@ -54,12 +54,12 @@ func (l *List) Aliases() []string {
 	return []string{"ls"}
 }
 
-func (c *List) Client(client meroxa.Client) {
-	c.client = client
+func (l *List) Client(client meroxa.Client) {
+	l.client = client
 }
 
-func (c *List) Logger(logger log.Logger) {
-	c.logger = logger
+func (l *List) Logger(logger log.Logger) {
+	l.logger = logger
 }
 
 func (l *List) HideHeaders(hide bool) {

--- a/cmd/meroxa/root/functions/remove.go
+++ b/cmd/meroxa/root/functions/remove.go
@@ -1,0 +1,82 @@
+package functions
+
+import (
+	"context"
+	"errors"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+var (
+	_ builder.CommandWithDocs             = (*Remove)(nil)
+	_ builder.CommandWithAliases          = (*Remove)(nil)
+	_ builder.CommandWithArgs             = (*Remove)(nil)
+	_ builder.CommandWithClient           = (*Remove)(nil)
+	_ builder.CommandWithLogger           = (*Remove)(nil)
+	_ builder.CommandWithExecute          = (*Remove)(nil)
+	_ builder.CommandWithConfirmWithValue = (*Remove)(nil)
+)
+
+type removeFunctionClient interface {
+	DeleteFunction(ctx context.Context, nameOrUUID string) (*meroxa.Function, error)
+}
+
+type Remove struct {
+	client removeFunctionClient
+	logger log.Logger
+
+	args struct {
+		NameOrUUID string
+	}
+}
+
+func (r *Remove) Usage() string {
+	return "remove NAMEorUUID"
+}
+
+func (r *Remove) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Remove function",
+	}
+}
+
+func (r *Remove) ValueToConfirm(_ context.Context) (wantInput string) {
+	return r.args.NameOrUUID
+}
+
+func (r *Remove) Execute(ctx context.Context) error {
+	r.logger.Infof(ctx, "Function %q is being removed...", r.args.NameOrUUID)
+
+	e, err := r.client.DeleteFunction(ctx, r.args.NameOrUUID)
+	if err != nil {
+		return err
+	}
+
+	r.logger.Infof(ctx, "Function %q successfully removed", r.args.NameOrUUID)
+	r.logger.JSON(ctx, e)
+
+	return nil
+}
+
+func (r *Remove) Logger(logger log.Logger) {
+	r.logger = logger
+}
+
+func (r *Remove) Client(client meroxa.Client) {
+	r.client = client
+}
+
+func (r *Remove) ParseArgs(args []string) error {
+	if len(args) < 1 {
+		return errors.New("requires function name")
+	}
+
+	r.args.NameOrUUID = args[0]
+	return nil
+}
+
+func (r *Remove) Aliases() []string {
+	return []string{"rm", "delete"}
+}

--- a/cmd/meroxa/root/root.go
+++ b/cmd/meroxa/root/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/meroxa/cli/cmd/meroxa/root/connectors"
 	"github.com/meroxa/cli/cmd/meroxa/root/endpoints"
 	"github.com/meroxa/cli/cmd/meroxa/root/environments"
+	"github.com/meroxa/cli/cmd/meroxa/root/functions"
 	"github.com/meroxa/cli/cmd/meroxa/root/login"
 	"github.com/meroxa/cli/cmd/meroxa/root/logout"
 	"github.com/meroxa/cli/cmd/meroxa/root/open"
@@ -83,6 +84,7 @@ meroxa resources list --types
 	cmd.AddCommand(builder.BuildCobraCommand(&config.Config{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&connectors.Connect{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&connectors.Connectors{}))
+	cmd.AddCommand(builder.BuildCobraCommand(&functions.Functions{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&endpoints.Endpoints{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&environments.Environments{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&login.Login{}))

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20220125232355-5ae5e80c0f00
+	github.com/meroxa/meroxa-go v0.0.0-20220126011704-43e4ed19207c
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20220106054005-172177555369
+	github.com/meroxa/meroxa-go v0.0.0-20220125232355-5ae5e80c0f00
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect
@@ -24,6 +24,8 @@ require (
 	golang.org/x/net v0.0.0-20211101193420-4a448f8816b3 // indirect
 	golang.org/x/oauth2 v0.0.0-20211028175245-ba495a64dcb5
 )
+
+require github.com/mattn/go-shellwords v1.0.12
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,8 +223,10 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/meroxa/meroxa-go v0.0.0-20220106054005-172177555369 h1:1vvy60iQj8EWpuaRZfdrw1MwN8TfcmdaE+YE1GQU5Jo=
-github.com/meroxa/meroxa-go v0.0.0-20220106054005-172177555369/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
+github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
+github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/meroxa/meroxa-go v0.0.0-20220125232355-5ae5e80c0f00 h1:4vuaU2HQSj1b2RFj9RemDSbejZx3q5Ea/Wg6nTK+/oQ=
+github.com/meroxa/meroxa-go v0.0.0-20220125232355-5ae5e80c0f00/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRR
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
-github.com/meroxa/meroxa-go v0.0.0-20220125232355-5ae5e80c0f00 h1:4vuaU2HQSj1b2RFj9RemDSbejZx3q5Ea/Wg6nTK+/oQ=
-github.com/meroxa/meroxa-go v0.0.0-20220125232355-5ae5e80c0f00/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
+github.com/meroxa/meroxa-go v0.0.0-20220126011704-43e4ed19207c h1:7L85L+/TmBp8eQHfgxjQ78ydC/+WFukuKi3od9pLMl8=
+github.com/meroxa/meroxa-go v0.0.0-20220126011704-43e4ed19207c/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/utils/display.go
+++ b/utils/display.go
@@ -494,6 +494,42 @@ func PrintPipelinesTable(pipelines []*meroxa.Pipeline, hideHeaders bool) {
 	fmt.Println(PipelinesTable(pipelines, hideHeaders))
 }
 
+func FunctionsTable(funs []meroxa.Function, hideHeaders bool) string {
+	if len(funs) == 0 {
+		return ""
+	}
+
+	table := simpletable.New()
+	if !hideHeaders {
+		table.Header = &simpletable.Header{
+			Cells: []*simpletable.Cell{
+				{Align: simpletable.AlignCenter, Text: "UUID"},
+				{Align: simpletable.AlignCenter, Text: "NAME"},
+				{Align: simpletable.AlignCenter, Text: "INPUT STREAM"},
+				{Align: simpletable.AlignCenter, Text: "OUTPUT STREAM"},
+				{Align: simpletable.AlignCenter, Text: "STATE"},
+				{Align: simpletable.AlignCenter, Text: "PIPELINE"},
+			},
+		}
+	}
+
+	for _, p := range funs {
+		r := []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: p.UUID},
+			{Align: simpletable.AlignCenter, Text: p.Name},
+			{Align: simpletable.AlignCenter, Text: p.InputStream},
+			{Align: simpletable.AlignCenter, Text: p.OutputStream},
+			{Align: simpletable.AlignCenter, Text: p.Status.State},
+			{Align: simpletable.AlignCenter, Text: p.Pipeline.Name},
+		}
+
+		table.Body.Cells = append(table.Body.Cells, r)
+	}
+
+	table.SetStyle(simpletable.StyleCompact)
+	return table.String()
+}
+
 func EnvironmentsTable(environments []*meroxa.Environment, hideHeaders bool) string {
 	if len(environments) != 0 {
 		table := simpletable.New()

--- a/utils/display.go
+++ b/utils/display.go
@@ -494,7 +494,7 @@ func PrintPipelinesTable(pipelines []*meroxa.Pipeline, hideHeaders bool) {
 	fmt.Println(PipelinesTable(pipelines, hideHeaders))
 }
 
-func FunctionsTable(funs []meroxa.Function, hideHeaders bool) string {
+func FunctionsTable(funs []*meroxa.Function, hideHeaders bool) string {
 	if len(funs) == 0 {
 		return ""
 	}

--- a/utils/display.go
+++ b/utils/display.go
@@ -531,6 +531,11 @@ func FunctionsTable(funs []meroxa.Function, hideHeaders bool) string {
 }
 
 func FunctionTable(fun *meroxa.Function) string {
+	envVars := []string{}
+	for k, v := range fun.EnvVars {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	mainTable := simpletable.New()
 	mainTable.Body.Cells = [][]*simpletable.Cell{
 		{
@@ -560,6 +565,10 @@ func FunctionTable(fun *meroxa.Function) string {
 		{
 			{Align: simpletable.AlignRight, Text: "Arguments:"},
 			{Text: strings.Join(fun.Args, " ")},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Environment Variables:"},
+			{Text: strings.Join(envVars, "\n")},
 		},
 		{
 			{Align: simpletable.AlignRight, Text: "Pipeline:"},

--- a/utils/display.go
+++ b/utils/display.go
@@ -530,6 +530,57 @@ func FunctionsTable(funs []meroxa.Function, hideHeaders bool) string {
 	return table.String()
 }
 
+func FunctionTable(fun *meroxa.Function) string {
+	mainTable := simpletable.New()
+	mainTable.Body.Cells = [][]*simpletable.Cell{
+		{
+			{Align: simpletable.AlignRight, Text: "UUID:"},
+			{Text: fun.UUID},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Name:"},
+			{Text: fun.Name},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Input Stream:"},
+			{Text: fun.InputStream},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Output Stream:"},
+			{Text: fun.OutputStream},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Image:"},
+			{Text: fun.Image},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Command:"},
+			{Text: strings.Join(fun.Command, " ")},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Arguments:"},
+			{Text: strings.Join(fun.Args, " ")},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Pipeline:"},
+			{Text: fun.Pipeline.Name},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "State:"},
+			{Text: strings.Title(fun.Status.State)},
+		},
+	}
+	mainTable.SetStyle(simpletable.StyleCompact)
+	table := mainTable.String()
+
+	details := fun.Status.Details
+	if details == "" {
+		return table
+	}
+
+	return fmt.Sprintf("%s\n\n%s", table, details)
+}
+
 func EnvironmentsTable(environments []*meroxa.Environment, hideHeaders bool) string {
 	if len(environments) != 0 {
 		table := simpletable.New()

--- a/utils/display_test.go
+++ b/utils/display_test.go
@@ -551,7 +551,7 @@ func TestEnvironmentsTable(t *testing.T) {
 		Type:     meroxa.EnvironmentTypePrivate,
 		Name:     "environment-1234",
 		Provider: meroxa.EnvironmentProviderAws,
-		Region:   meroxa.EnvironmentRegionUsEast2,
+		Region:   meroxa.EnvironmentRegionUsEast1,
 		Status:   meroxa.EnvironmentViewStatus{State: meroxa.EnvironmentStateProvisioned},
 		UUID:     "531428f7-4e86-4094-8514-d397d49026f7",
 	}
@@ -603,7 +603,7 @@ func TestEnvironmentsTableWithoutHeaders(t *testing.T) {
 		Type:     meroxa.EnvironmentTypePrivate,
 		Name:     "environment-1234",
 		Provider: meroxa.EnvironmentProviderAws,
-		Region:   meroxa.EnvironmentRegionUsEast2,
+		Region:   meroxa.EnvironmentRegionUsEast1,
 		Status:   meroxa.EnvironmentViewStatus{State: meroxa.EnvironmentStateProvisioned},
 		UUID:     "531428f7-4e86-4094-8514-d397d49026f7",
 	}

--- a/utils/tests.go
+++ b/utils/tests.go
@@ -134,7 +134,7 @@ func GenerateEnvironment(environmentName string) meroxa.Environment {
 		UUID:     "fd572375-77ce-4448-a071-ee4707a599d6",
 		Type:     meroxa.EnvironmentTypePrivate,
 		Name:     environmentName,
-		Region:   meroxa.EnvironmentRegionUsEast2,
+		Region:   meroxa.EnvironmentRegionUsEast1,
 		Provider: meroxa.EnvironmentProviderAws,
 		Status: meroxa.EnvironmentViewStatus{
 			State: meroxa.EnvironmentStateProvisioned,

--- a/vendor/github.com/mattn/go-shellwords/.travis.yml
+++ b/vendor/github.com/mattn/go-shellwords/.travis.yml
@@ -1,0 +1,16 @@
+arch:
+  - amd64
+  - ppc64le
+language: go
+sudo: false
+go:
+  - tip
+
+before_install:
+  - go get -t -v ./...
+
+script:
+  - ./go.test.sh
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/mattn/go-shellwords/LICENSE
+++ b/vendor/github.com/mattn/go-shellwords/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Yasuhiro Matsumoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/mattn/go-shellwords/README.md
+++ b/vendor/github.com/mattn/go-shellwords/README.md
@@ -1,0 +1,55 @@
+# go-shellwords
+
+[![codecov](https://codecov.io/gh/mattn/go-shellwords/branch/master/graph/badge.svg)](https://codecov.io/gh/mattn/go-shellwords)
+[![Build Status](https://travis-ci.org/mattn/go-shellwords.svg?branch=master)](https://travis-ci.org/mattn/go-shellwords)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/mattn/go-shellwords)](https://pkg.go.dev/github.com/mattn/go-shellwords)
+[![ci](https://github.com/mattn/go-shellwords/ci/badge.svg)](https://github.com/mattn/go-shellwords/actions)
+
+Parse line as shell words.
+
+## Usage
+
+```go
+args, err := shellwords.Parse("./foo --bar=baz")
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
+envs, args, err := shellwords.ParseWithEnvs("FOO=foo BAR=baz ./foo --bar=baz")
+// envs should be ["FOO=foo", "BAR=baz"]
+// args should be ["./foo", "--bar=baz"]
+```
+
+```go
+os.Setenv("FOO", "bar")
+p := shellwords.NewParser()
+p.ParseEnv = true
+args, err := p.Parse("./foo $FOO")
+// args should be ["./foo", "bar"]
+```
+
+```go
+p := shellwords.NewParser()
+p.ParseBacktick = true
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+```go
+shellwords.ParseBacktick = true
+p := shellwords.NewParser()
+args, err := p.Parse("./foo `echo $SHELL`")
+// args should be ["./foo", "/bin/bash"]
+```
+
+# Thanks
+
+This is based on cpan module [Parse::CommandLine](https://metacpan.org/pod/Parse::CommandLine).
+
+# License
+
+under the MIT License: http://mattn.mit-license.org/2017
+
+# Author
+
+Yasuhiro Matsumoto (a.k.a mattn)

--- a/vendor/github.com/mattn/go-shellwords/go.test.sh
+++ b/vendor/github.com/mattn/go-shellwords/go.test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+echo "" > coverage.txt
+
+for d in $(go list ./... | grep -v vendor); do
+    go test -coverprofile=profile.out -covermode=atomic "$d"
+    if [ -f profile.out ]; then
+        cat profile.out >> coverage.txt
+        rm profile.out
+    fi
+done

--- a/vendor/github.com/mattn/go-shellwords/shellwords.go
+++ b/vendor/github.com/mattn/go-shellwords/shellwords.go
@@ -1,0 +1,317 @@
+package shellwords
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"strings"
+	"unicode"
+)
+
+var (
+	ParseEnv      bool = false
+	ParseBacktick bool = false
+)
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\r', '\n':
+		return true
+	}
+	return false
+}
+
+func replaceEnv(getenv func(string) string, s string) string {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+
+	var buf bytes.Buffer
+	rs := []rune(s)
+	for i := 0; i < len(rs); i++ {
+		r := rs[i]
+		if r == '\\' {
+			i++
+			if i == len(rs) {
+				break
+			}
+			buf.WriteRune(rs[i])
+			continue
+		} else if r == '$' {
+			i++
+			if i == len(rs) {
+				buf.WriteRune(r)
+				break
+			}
+			if rs[i] == 0x7b {
+				i++
+				p := i
+				for ; i < len(rs); i++ {
+					r = rs[i]
+					if r == '\\' {
+						i++
+						if i == len(rs) {
+							return s
+						}
+						continue
+					}
+					if r == 0x7d || (!unicode.IsLetter(r) && r != '_' && !unicode.IsDigit(r)) {
+						break
+					}
+				}
+				if r != 0x7d {
+					return s
+				}
+				if i > p {
+					buf.WriteString(getenv(s[p:i]))
+				}
+			} else {
+				p := i
+				for ; i < len(rs); i++ {
+					r := rs[i]
+					if r == '\\' {
+						i++
+						if i == len(rs) {
+							return s
+						}
+						continue
+					}
+					if !unicode.IsLetter(r) && r != '_' && !unicode.IsDigit(r) {
+						break
+					}
+				}
+				if i > p {
+					buf.WriteString(getenv(s[p:i]))
+					i--
+				} else {
+					buf.WriteString(s[p:])
+				}
+			}
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
+}
+
+type Parser struct {
+	ParseEnv      bool
+	ParseBacktick bool
+	Position      int
+	Dir           string
+
+	// If ParseEnv is true, use this for getenv.
+	// If nil, use os.Getenv.
+	Getenv func(string) string
+}
+
+func NewParser() *Parser {
+	return &Parser{
+		ParseEnv:      ParseEnv,
+		ParseBacktick: ParseBacktick,
+		Position:      0,
+		Dir:           "",
+	}
+}
+
+type argType int
+
+const (
+	argNo argType = iota
+	argSingle
+	argQuoted
+)
+
+func (p *Parser) Parse(line string) ([]string, error) {
+	args := []string{}
+	buf := ""
+	var escaped, doubleQuoted, singleQuoted, backQuote, dollarQuote bool
+	backtick := ""
+
+	pos := -1
+	got := argNo
+
+	i := -1
+loop:
+	for _, r := range line {
+		i++
+		if escaped {
+			buf += string(r)
+			escaped = false
+			got = argSingle
+			continue
+		}
+
+		if r == '\\' {
+			if singleQuoted {
+				buf += string(r)
+			} else {
+				escaped = true
+			}
+			continue
+		}
+
+		if isSpace(r) {
+			if singleQuoted || doubleQuoted || backQuote || dollarQuote {
+				buf += string(r)
+				backtick += string(r)
+			} else if got != argNo {
+				if p.ParseEnv {
+					if got == argSingle {
+						parser := &Parser{ParseEnv: false, ParseBacktick: false, Position: 0, Dir: p.Dir}
+						strs, err := parser.Parse(replaceEnv(p.Getenv, buf))
+						if err != nil {
+							return nil, err
+						}
+						args = append(args, strs...)
+					} else {
+						args = append(args, replaceEnv(p.Getenv, buf))
+					}
+				} else {
+					args = append(args, buf)
+				}
+				buf = ""
+				got = argNo
+			}
+			continue
+		}
+
+		switch r {
+		case '`':
+			if !singleQuoted && !doubleQuoted && !dollarQuote {
+				if p.ParseBacktick {
+					if backQuote {
+						out, err := shellRun(backtick, p.Dir)
+						if err != nil {
+							return nil, err
+						}
+						buf = buf[:len(buf)-len(backtick)] + out
+					}
+					backtick = ""
+					backQuote = !backQuote
+					continue
+				}
+				backtick = ""
+				backQuote = !backQuote
+			}
+		case ')':
+			if !singleQuoted && !doubleQuoted && !backQuote {
+				if p.ParseBacktick {
+					if dollarQuote {
+						out, err := shellRun(backtick, p.Dir)
+						if err != nil {
+							return nil, err
+						}
+						buf = buf[:len(buf)-len(backtick)-2] + out
+					}
+					backtick = ""
+					dollarQuote = !dollarQuote
+					continue
+				}
+				backtick = ""
+				dollarQuote = !dollarQuote
+			}
+		case '(':
+			if !singleQuoted && !doubleQuoted && !backQuote {
+				if !dollarQuote && strings.HasSuffix(buf, "$") {
+					dollarQuote = true
+					buf += "("
+					continue
+				} else {
+					return nil, errors.New("invalid command line string")
+				}
+			}
+		case '"':
+			if !singleQuoted && !dollarQuote {
+				if doubleQuoted {
+					got = argQuoted
+				}
+				doubleQuoted = !doubleQuoted
+				continue
+			}
+		case '\'':
+			if !doubleQuoted && !dollarQuote {
+				if singleQuoted {
+					got = argQuoted
+				}
+				singleQuoted = !singleQuoted
+				continue
+			}
+		case ';', '&', '|', '<', '>':
+			if !(escaped || singleQuoted || doubleQuoted || backQuote || dollarQuote) {
+				if r == '>' && len(buf) > 0 {
+					if c := buf[0]; '0' <= c && c <= '9' {
+						i -= 1
+						got = argNo
+					}
+				}
+				pos = i
+				break loop
+			}
+		}
+
+		got = argSingle
+		buf += string(r)
+		if backQuote || dollarQuote {
+			backtick += string(r)
+		}
+	}
+
+	if got != argNo {
+		if p.ParseEnv {
+			if got == argSingle {
+				parser := &Parser{ParseEnv: false, ParseBacktick: false, Position: 0, Dir: p.Dir}
+				strs, err := parser.Parse(replaceEnv(p.Getenv, buf))
+				if err != nil {
+					return nil, err
+				}
+				args = append(args, strs...)
+			} else {
+				args = append(args, replaceEnv(p.Getenv, buf))
+			}
+		} else {
+			args = append(args, buf)
+		}
+	}
+
+	if escaped || singleQuoted || doubleQuoted || backQuote || dollarQuote {
+		return nil, errors.New("invalid command line string")
+	}
+
+	p.Position = pos
+
+	return args, nil
+}
+
+func (p *Parser) ParseWithEnvs(line string) (envs []string, args []string, err error) {
+	_args, err := p.Parse(line)
+	if err != nil {
+		return nil, nil, err
+	}
+	envs = []string{}
+	args = []string{}
+	parsingEnv := true
+	for _, arg := range _args {
+		if parsingEnv && isEnv(arg) {
+			envs = append(envs, arg)
+		} else {
+			if parsingEnv {
+				parsingEnv = false
+			}
+			args = append(args, arg)
+		}
+	}
+	return envs, args, nil
+}
+
+func isEnv(arg string) bool {
+	return len(strings.Split(arg, "=")) == 2
+}
+
+func Parse(line string) ([]string, error) {
+	return NewParser().Parse(line)
+}
+
+func ParseWithEnvs(line string) (envs []string, args []string, err error) {
+	return NewParser().ParseWithEnvs(line)
+}

--- a/vendor/github.com/mattn/go-shellwords/util_posix.go
+++ b/vendor/github.com/mattn/go-shellwords/util_posix.go
@@ -1,0 +1,29 @@
+// +build !windows
+
+package shellwords
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line, dir string) (string, error) {
+	var shell string
+	if shell = os.Getenv("SHELL"); shell == "" {
+		shell = "/bin/sh"
+	}
+	cmd := exec.Command(shell, "-c", line)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	b, err := cmd.Output()
+	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			b = eerr.Stderr
+		}
+		return "", fmt.Errorf("%s: %w", string(b), err)
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/github.com/mattn/go-shellwords/util_windows.go
+++ b/vendor/github.com/mattn/go-shellwords/util_windows.go
@@ -1,0 +1,29 @@
+// +build windows
+
+package shellwords
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func shellRun(line, dir string) (string, error) {
+	var shell string
+	if shell = os.Getenv("COMSPEC"); shell == "" {
+		shell = "cmd"
+	}
+	cmd := exec.Command(shell, "/c", line)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	b, err := cmd.Output()
+	if err != nil {
+		if eerr, ok := err.(*exec.ExitError); ok {
+			b = eerr.Stderr
+		}
+		return "", fmt.Errorf("%s: %w", string(b), err)
+	}
+	return strings.TrimSpace(string(b)), nil
+}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/environment.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/environment.go
@@ -27,28 +27,34 @@ type EnvironmentViewStatus struct {
 	Details string           `json:"details,omitempty"`
 }
 
+/*
+Currently not supported AWS regions
+
+EnvironmentRegionAfSouth      EnvironmentRegion = "af-south-1"
+EnvironmentRegionApEast       EnvironmentRegion = "ap-east-1"
+EnvironmentRegionApNortheast2 EnvironmentRegion = "ap-northeast-2"
+EnvironmentRegionApNortheast3 EnvironmentRegion = "ap-northeast-3"
+EnvironmentRegionApSouth      EnvironmentRegion = "ap-south-1"
+EnvironmentRegionApSoutheast1 EnvironmentRegion = "ap-southeast-1"
+EnvironmentRegionApSoutheast2 EnvironmentRegion = "ap-southeast-2"
+EnvironmentRegionCaCentral    EnvironmentRegion = "ca-central-1"
+EnvironmentRegionEuNorth      EnvironmentRegion = "eu-north-1"
+EnvironmentRegionEuSouth      EnvironmentRegion = "eu-south-1"
+EnvironmentRegionEuWest1      EnvironmentRegion = "eu-west-1"
+EnvironmentRegionEuWest2      EnvironmentRegion = "eu-west-2"
+EnvironmentRegionEuWest3      EnvironmentRegion = "eu-west-3"
+EnvironmentRegionMeSouth      EnvironmentRegion = "me-south-1"
+EnvironmentRegionSaEast1      EnvironmentRegion = "sa-east-1"
+EnvironmentRegionSaEast1      EnvironmentRegion = "sa-east-1"
+
+*/
+
 type EnvironmentRegion string
 
 const (
-	EnvironmentRegionAfSouth      EnvironmentRegion = "af-south-1"
-	EnvironmentRegionApEast       EnvironmentRegion = "ap-east-1"
 	EnvironmentRegionApNortheast1 EnvironmentRegion = "ap-northeast-1"
-	EnvironmentRegionApNortheast2 EnvironmentRegion = "ap-northeast-2"
-	EnvironmentRegionApNortheast3 EnvironmentRegion = "ap-northeast-3"
-	EnvironmentRegionApSouth      EnvironmentRegion = "ap-south-1"
-	EnvironmentRegionApSoutheast1 EnvironmentRegion = "ap-southeast-1"
-	EnvironmentRegionApSoutheast2 EnvironmentRegion = "ap-southeast-2"
-	EnvironmentRegionCaCentral    EnvironmentRegion = "ca-central-1"
 	EnvironmentRegionEuCentral    EnvironmentRegion = "eu-central-1"
-	EnvironmentRegionEuNorth      EnvironmentRegion = "eu-north-1"
-	EnvironmentRegionEuSouth      EnvironmentRegion = "eu-south-1"
-	EnvironmentRegionEuWest1      EnvironmentRegion = "eu-west-1"
-	EnvironmentRegionEuWest2      EnvironmentRegion = "eu-west-2"
-	EnvironmentRegionEuWest3      EnvironmentRegion = "eu-west-3"
-	EnvironmentRegionMeSouth      EnvironmentRegion = "me-south-1"
-	EnvironmentRegionSaEast1      EnvironmentRegion = "sa-east-1"
 	EnvironmentRegionUsEast1      EnvironmentRegion = "us-east-1"
-	EnvironmentRegionUsEast2      EnvironmentRegion = "us-east-2"
 	EnvironmentRegionUsWest2      EnvironmentRegion = "us-west-2"
 )
 

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/function.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/function.go
@@ -78,7 +78,7 @@ func (c *client) GetFunction(ctx context.Context, nameOrUUID string) (*Function,
 	return &fun, nil
 }
 
-func (c *client) ListFunctions(ctx context.Context) ([]Function, error) {
+func (c *client) ListFunctions(ctx context.Context) ([]*Function, error) {
 	resp, err := c.MakeRequest(ctx, http.MethodGet, functionsBasePath, nil, nil)
 	if err != nil {
 		return nil, err
@@ -89,7 +89,7 @@ func (c *client) ListFunctions(ctx context.Context) ([]Function, error) {
 		return nil, err
 	}
 
-	var funs []Function
+	var funs []*Function
 	err = json.NewDecoder(resp.Body).Decode(&funs)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/function.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/function.go
@@ -1,0 +1,121 @@
+package meroxa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+const functionsBasePath = "/v1/functions"
+
+type Function struct {
+	UUID         string             `json:"uuid"`
+	Name         string             `json:"name"`
+	InputStream  string             `json:"input_stream"`
+	OutputStream string             `json:"output_stream"`
+	Image        string             `json:"image"`
+	Command      []string           `json:"command"`
+	Args         []string           `json:"args"`
+	EnvVars      map[string]string  `json:"env_vars"`
+	Status       FunctionStatus     `json:"status"`
+	Pipeline     PipelineIdentifier `json:"pipeline"`
+}
+
+type FunctionStatus struct {
+	State   string `json:"state"`
+	Details string `json:"details"`
+}
+
+type CreateFunctionInput struct {
+	Name         string             `json:"name"`
+	InputStream  string             `json:"input_stream"`
+	OutputStream string             `json:"output_stream"`
+	Pipeline     PipelineIdentifier `json:"pipeline"`
+	Image        string             `json:"image"`
+	Command      []string           `json:"command"`
+	Args         []string           `json:"args"`
+	EnvVars      map[string]string  `json:"env_vars"`
+}
+
+func (c *client) CreateFunction(ctx context.Context, input *CreateFunctionInput) (*Function, error) {
+	resp, err := c.MakeRequest(ctx, http.MethodPost, functionsBasePath, input, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := handleAPIErrors(resp); err != nil {
+		return nil, err
+	}
+
+	var fun Function
+	if err := json.NewDecoder(resp.Body).Decode(&fun); err != nil {
+		return nil, err
+	}
+
+	return &fun, nil
+}
+
+func (c *client) GetFunction(ctx context.Context, nameOrUUID string) (*Function, error) {
+	path := fmt.Sprintf("%s/%s", functionsBasePath, nameOrUUID)
+
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = handleAPIErrors(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var fun Function
+	err = json.NewDecoder(resp.Body).Decode(&fun)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fun, nil
+}
+
+func (c *client) ListFunctions(ctx context.Context) ([]Function, error) {
+	resp, err := c.MakeRequest(ctx, http.MethodGet, functionsBasePath, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = handleAPIErrors(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var funs []Function
+	err = json.NewDecoder(resp.Body).Decode(&funs)
+	if err != nil {
+		return nil, err
+	}
+
+	return funs, nil
+}
+
+func (c *client) DeleteFunction(ctx context.Context, nameOrUUID string) (*Function, error) {
+	path := fmt.Sprintf("%s/%s", functionsBasePath, nameOrUUID)
+
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = handleAPIErrors(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var fun Function
+	err = json.NewDecoder(resp.Body).Decode(&fun)
+	if err != nil {
+		return nil, err
+	}
+
+	return &fun, nil
+}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
@@ -41,6 +41,11 @@ type Client interface {
 	UpdateConnector(ctx context.Context, nameOrID string, input *UpdateConnectorInput) (*Connector, error)
 	UpdateConnectorStatus(ctx context.Context, nameOrID string, state Action) (*Connector, error)
 
+	CreateFunction(ctx context.Context, input *CreateFunctionInput) (*Function, error)
+	GetFunction(ctx context.Context, nameOrUUID string) (*Function, error)
+	ListFunctions(ctx context.Context) ([]Function, error)
+	DeleteFunction(ctx context.Context, nameOrUUID string) (*Function, error)
+
 	CreateEndpoint(ctx context.Context, input *CreateEndpointInput) error
 	DeleteEndpoint(ctx context.Context, name string) error
 	GetEndpoint(ctx context.Context, name string) (*Endpoint, error)

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
@@ -43,7 +43,7 @@ type Client interface {
 
 	CreateFunction(ctx context.Context, input *CreateFunctionInput) (*Function, error)
 	GetFunction(ctx context.Context, nameOrUUID string) (*Function, error)
-	ListFunctions(ctx context.Context) ([]Function, error)
+	ListFunctions(ctx context.Context) ([]*Function, error)
 	DeleteFunction(ctx context.Context, nameOrUUID string) (*Function, error)
 
 	CreateEndpoint(ctx context.Context, input *CreateEndpointInput) error

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/pipeline.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/pipeline.go
@@ -17,6 +17,11 @@ const (
 	PipelineStateDegraded PipelineState = "degraded"
 )
 
+type PipelineIdentifier struct {
+	UUID string `json:"uuid"`
+	Name string `json:"name"`
+}
+
 // Pipeline represents the Meroxa Pipeline type within the Meroxa API
 type Pipeline struct {
 	CreatedAt   time.Time              `json:"created_at"`

--- a/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
@@ -483,18 +483,18 @@ func (mr *MockClientMockRecorder) UpdateConnectorStatus(ctx, nameOrID, state int
 }
 
 // UpdateEnvironment mocks base method.
-func (m *MockClient) UpdateEnvironment(ctx context.Context, ameOrUUID string, input *meroxa.UpdateEnvironmentInput) (*meroxa.Environment, error) {
+func (m *MockClient) UpdateEnvironment(ctx context.Context, nameOrUUID string, input *meroxa.UpdateEnvironmentInput) (*meroxa.Environment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateEnvironment", ctx, ameOrUUID, input)
+	ret := m.ctrl.Call(m, "UpdateEnvironment", ctx, nameOrUUID, input)
 	ret0, _ := ret[0].(*meroxa.Environment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateEnvironment indicates an expected call of UpdateEnvironment.
-func (mr *MockClientMockRecorder) UpdateEnvironment(ctx, ameOrUUID, input interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) UpdateEnvironment(ctx, nameOrUUID, input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEnvironment", reflect.TypeOf((*MockClient)(nil).UpdateEnvironment), ctx, ameOrUUID, input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEnvironment", reflect.TypeOf((*MockClient)(nil).UpdateEnvironment), ctx, nameOrUUID, input)
 }
 
 // UpdatePipeline mocks base method.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,7 +84,10 @@ github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.10
 ## explicit; go 1.9
 github.com/mattn/go-runewidth
-# github.com/meroxa/meroxa-go v0.0.0-20220106054005-172177555369
+# github.com/mattn/go-shellwords v1.0.12
+## explicit; go 1.13
+github.com/mattn/go-shellwords
+# github.com/meroxa/meroxa-go v0.0.0-20220125232355-5ae5e80c0f00
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -87,7 +87,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20220125232355-5ae5e80c0f00
+# github.com/meroxa/meroxa-go v0.0.0-20220126011704-43e4ed19207c
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock


### PR DESCRIPTION
# Description of change

Add `meroxa functions`. This depends on https://github.com/meroxa/meroxa-go/pull/90.

# Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

# How was this tested?

- [x]  Unit Tests
- [x]  Tested in staging

# Demo

```
$ m function create o-func --input-stream resource-4497-028165-users --image meroxa/funtime-example-jq --pipeline default --env JQ_QUERY=.
Function "o-func" successfully created!

$ m function list
                 UUID                    NAME            INPUT STREAM                    OUTPUT STREAM               STATE    PIPELINE
====================================== ========= ============================ ==================================== ========= ==========
 85e18535-1505-4fe4-97cb-da209687b597   o-func    resource-4497-028165-users   resource-4497-028165-users-o-func    running   default

$ m function describe o-func
          UUID:   85e18535-1505-4fe4-97cb-da209687b597
          Name:   o-func
  Input Stream:   resource-4497-028165-users
 Output Stream:   resource-4497-028165-users-o-func
         Image:   meroxa/funtime-example-jq
       Command:
     Arguments:
      Env Vars:   JQ_QUERY=.
      Pipeline:   default
         State:   Running

$ m function delete o-func
To proceed, type "o-func" or re-run this command with --force
▸ o-func
Function "o-func" is being removed...
Function "o-func" successfully removed
```