### PR TITLE
feat(repair): allow users to repair environments

### DIFF
--- a/cmd/meroxa/root/environments/environments.go
+++ b/cmd/meroxa/root/environments/environments.go
@@ -66,5 +66,6 @@ func (*Environments) SubCommands() []*cobra.Command {
 		builder.BuildCobraCommand(&List{}),
 		builder.BuildCobraCommand(&Remove{}),
 		builder.BuildCobraCommand(&Update{}),
+		builder.BuildCobraCommand(&Repair{}),
 	}
 }

--- a/cmd/meroxa/root/environments/repair.go
+++ b/cmd/meroxa/root/environments/repair.go
@@ -54,7 +54,7 @@ func (r *Repair) Usage() string {
 func (r *Repair) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Repair environment",
-		Long:  "Repair any environment that is in one of the following states: provisioning_error, deprovisioning_error, repairing_error.",
+		Long:  `Repair any environment that is in one of the following states: provisioning_error, deprovisioning_error, repairing_error.`,
 	}
 }
 
@@ -74,13 +74,13 @@ func (r *Repair) ParseArgs(args []string) error {
 }
 
 func (r *Repair) Execute(ctx context.Context) error {
-	rr, err := r.client.PerformActionOnEnvironment(ctx, r.args.NameOrUUID, &meroxa.RepairEnvironmentInput{Action: "repair"}) /* OPENQ: How do I pass a struct here? */
+	rr, err := r.client.PerformActionOnEnvironment(ctx, r.args.NameOrUUID, &meroxa.RepairEnvironmentInput{Action: "repair"})
 	if err != nil {
 		return err
 	}
 
-	r.logger.Infof(ctx, "The repairment of your environment %q is now in progress. Run `meroxa env describe %s` for status", r.args.NameOrUUID)
-	r.logger.Info(ctx, "Meroxa will try to resolve the error and your environment should be up and running soon.")
+	r.logger.Infof(ctx, `The repairment of your environment %q is now in progress and your environment will be up and running soon.`, r.args.NameOrUUID) // nolint:lll
+	r.logger.Infof(ctx, `Run "meroxa env describe %s" for status.`, r.args.NameOrUUID)
 	r.logger.JSON(ctx, rr)
 
 	return nil

--- a/cmd/meroxa/root/environments/repair.go
+++ b/cmd/meroxa/root/environments/repair.go
@@ -68,7 +68,7 @@ func (r *Repair) Client(client meroxa.Client) {
 }
 
 func (r *Repair) ParseArgs(args []string) error {
-         if len(args) < 1 {
+	if len(args) < 1 {
 		return errors.New("requires environment name or uuid")
 	}
 	r.args.NameOrUUID = args[0]
@@ -76,7 +76,7 @@ func (r *Repair) ParseArgs(args []string) error {
 }
 
 func (r *Repair) Execute(ctx context.Context) error {
-	rr, err := r.client.PerformActionOnEnvironment(ctx, r.args.NameOrUUID, &meroxa.RepairEnvironmentInput{Action: "repair"})
+	rr, err := r.client.PerformActionOnEnvironment(ctx, r.args.NameOrUUID, &meroxa.RepairEnvironmentInput{Action: meroxa.EnvironmentActionRepair}) // nolint:lll
 	if err != nil {
 		return err
 	}

--- a/cmd/meroxa/root/environments/repair.go
+++ b/cmd/meroxa/root/environments/repair.go
@@ -15,6 +15,7 @@ package environments
 
 import (
 	"context"
+	"errors"
 
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 	"github.com/meroxa/cli/log"
@@ -67,9 +68,10 @@ func (r *Repair) Client(client meroxa.Client) {
 }
 
 func (r *Repair) ParseArgs(args []string) error {
-	if len(args) > 0 {
-		r.args.NameOrUUID = args[0]
+         if len(args) < 1 {
+		return errors.New("requires environment name or uuid")
 	}
+	r.args.NameOrUUID = args[0]
 	return nil
 }
 

--- a/cmd/meroxa/root/environments/repair.go
+++ b/cmd/meroxa/root/environments/repair.go
@@ -1,0 +1,82 @@
+/*
+Copyright © 2021 Meroxa Inc
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package environments
+
+import (
+	"context"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+var (
+	_ builder.CommandWithDocs    = (*Repair)(nil)
+	_ builder.CommandWithArgs    = (*Repair)(nil)
+	_ builder.CommandWithClient  = (*Repair)(nil)
+	_ builder.CommandWithLogger  = (*Repair)(nil)
+	_ builder.CommandWithExecute = (*Repair)(nil)
+)
+
+type repairEnvironmentClient interface {
+  PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, body *meroxa.RepairEnvironmentInput) (*meroxa.Environment, error)
+}
+
+type Repair struct {
+	client repairEnvironmentClient
+	logger log.Logger
+
+  args struct {
+		NameOrUUID string
+	}
+}
+
+func (u *Repair) Usage() string {
+	return "repair NAMEorUUID"
+}
+
+func (r *Repair) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Repair environment",
+    Long: "Repair any environment that is in one of the following states: provisioning_error, deprovisioning_error, repairing_error.",
+	}
+}
+
+func (c *Repair) Logger(logger log.Logger) {
+	c.logger = logger
+}
+
+func (c *Repair) Client(client meroxa.Client) {
+	c.client = client
+}
+
+func (c *Repair) ParseArgs(args []string) error {
+	if len(args) > 0 {
+		c.args.NameOrUUID = args[0]
+	}
+	return nil
+}
+
+func (u *Repair) Execute(ctx context.Context) error {
+	r, err := u.client.PerformActionOnEnvironment(ctx, u.args.NameOrUUID, &meroxa.RepairEnvironmentInput{Action: "repair"}) /* OPENQ: How do I pass a struct here? */
+	if err != nil {
+		return err
+	}
+
+	u.logger.Infof(ctx, "The repairment of your environment %q is now in progress", u.args.NameOrUUID)
+	u.logger.Info(ctx, "Meroxa will try to resolve the error and your environment should be up and running soon.") //nolint
+	u.logger.JSON(ctx, r)
+
+	return nil
+}

--- a/cmd/meroxa/root/environments/repair_test.go
+++ b/cmd/meroxa/root/environments/repair_test.go
@@ -85,7 +85,7 @@ func TestRepairEnvironmentExecution(t *testing.T) {
 
 	gotLeveledOutput := logger.LeveledOutput()
 	wantLeveledOutput := fmt.Sprintf(
-		"Repairing environment...\nEnvironment %q has been updated. Run `meroxa env describe %s` for status",
+		"Repairing environment...\nThe repairment of your environment  %q is now in progress. Run `meroxa env describe %s` for status",
 		e.Name,
 		e.Name)
 

--- a/cmd/meroxa/root/environments/repair_test.go
+++ b/cmd/meroxa/root/environments/repair_test.go
@@ -85,7 +85,8 @@ func TestRepairEnvironmentExecution(t *testing.T) {
 
 	gotLeveledOutput := logger.LeveledOutput()
 	wantLeveledOutput := fmt.Sprintf(
-		"Repairing environment...\nThe repairment of your environment  %q is now in progress. Run `meroxa env describe %s` for status",
+		`The repairment of your environment %q is now in progress and your environment will be up and running soon.
+Run "meroxa env describe %s" for status.`,
 		e.Name,
 		e.Name)
 

--- a/cmd/meroxa/root/environments/repair_test.go
+++ b/cmd/meroxa/root/environments/repair_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright © 2021 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package environments
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+	"github.com/meroxa/meroxa-go/pkg/mock"
+)
+
+func TestRepairEnvironmentArgs(t *testing.T) {
+	tests := []struct {
+		args []string
+		err  error
+		name string
+		uuid string
+	}{
+		{args: nil, err: errors.New("requires environment name or uuid"), name: "", uuid: ""},
+		{args: []string{"environment-name"}, err: nil, name: "environment-name", uuid: ""},
+	}
+
+	for _, tt := range tests {
+		cc := &Repair{}
+		err := cc.ParseArgs(tt.args)
+
+		if err != nil && tt.err.Error() != err.Error() {
+			t.Fatalf("expected \"%s\" got \"%s\"", tt.err, err)
+		}
+
+		if tt.name != cc.args.NameOrUUID {
+			t.Fatalf("expected \"%s\" got \"%s\"", tt.name, cc.args.NameOrUUID)
+		}
+	}
+}
+
+func TestRepairEnvironmentExecution(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockClient(ctrl)
+	logger := log.NewTestLogger()
+
+	r := &Repair{
+		client: client,
+		logger: logger,
+	}
+
+	e := utils.GenerateEnvironment("")
+	r.args.NameOrUUID = e.Name
+
+	client.
+		EXPECT().
+		PerformActionOnEnvironment(ctx, e.Name, &meroxa.RepairEnvironmentInput{Action: "repair"}).
+		Return(&e, nil)
+
+	err := r.Execute(ctx)
+
+	if err != nil {
+		t.Fatalf("not expected error, got \"%s\"", err.Error())
+	}
+
+	gotLeveledOutput := logger.LeveledOutput()
+	wantLeveledOutput := fmt.Sprintf(
+		"Repairing environment...\nEnvironment %q has been updated. Run `meroxa env describe %s` for status",
+		e.Name,
+		e.Name)
+
+	if !strings.Contains(gotLeveledOutput, wantLeveledOutput) {
+		t.Fatalf("expected output:\n%s\ngot:\n%s", wantLeveledOutput, gotLeveledOutput)
+	}
+
+	gotJSONOutput := logger.JSONOutput()
+	var gotEnvironment meroxa.Environment
+	err = json.Unmarshal([]byte(gotJSONOutput), &gotEnvironment)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	if !reflect.DeepEqual(gotEnvironment, e) {
+		t.Fatalf("expected \"%v\", got \"%v\"", e, gotEnvironment)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900
+	github.com/meroxa/meroxa-go v0.0.0-20220202200635-942cf1c778a4
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect
@@ -57,5 +57,3 @@ require (
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
-
-replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.mod
+++ b/go.mod
@@ -57,3 +57,5 @@ require (
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20220126011704-43e4ed19207c
+	github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,6 @@ github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRR
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
-github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900 h1:gKQFFBHqRS0+9DX1Yv1vP8u5OqzGf+R5Vjc7rgHbfmI=
-github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRR
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/meroxa/meroxa-go v0.0.0-20220202200635-942cf1c778a4 h1:NlyG9imqx9fLuqNFtSSpUajILE45Ms/pAkK/f1AaFw0=
+github.com/meroxa/meroxa-go v0.0.0-20220202200635-942cf1c778a4/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRR
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
-github.com/meroxa/meroxa-go v0.0.0-20220126011704-43e4ed19207c h1:7L85L+/TmBp8eQHfgxjQ78ydC/+WFukuKi3od9pLMl8=
-github.com/meroxa/meroxa-go v0.0.0-20220126011704-43e4ed19207c/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
+github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900 h1:gKQFFBHqRS0+9DX1Yv1vP8u5OqzGf+R5Vjc7rgHbfmI=
+github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/environment.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/environment.go
@@ -99,6 +99,16 @@ type UpdateEnvironmentInput struct {
 	Configuration map[string]interface{} `json:"config,omitempty"`
 }
 
+type EnvironmentAction string
+
+const (
+	EnvironmentActionRepair EnvironmentAction = "repair"
+)
+
+type RepairEnvironmentInput struct {
+	Action        EnvironmentAction       `json:"action"`
+}
+
 // ListEnvironments returns an array of Environments (scoped to the calling user)
 func (c *client) ListEnvironments(ctx context.Context) ([]*Environment, error) {
 	resp, err := c.MakeRequest(ctx, http.MethodGet, environmentsBasePath, nil, nil)
@@ -183,6 +193,24 @@ func (c *client) DeleteEnvironment(ctx context.Context, nameOrUUID string) (*Env
 func (c *client) UpdateEnvironment(ctx context.Context, nameOrUUID string, input *UpdateEnvironmentInput) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s", environmentsBasePath, nameOrUUID)
 	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = handleAPIErrors(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var e *Environment
+	err = json.NewDecoder(resp.Body).Decode(&e)
+
+	return e, nil
+}
+
+func (c *client) PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, input *RepairEnvironmentInput) (*Environment, error) {
+	path := fmt.Sprintf("%s/%s/%s", environmentsBasePath, nameOrUUID, "actions")
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, input, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
@@ -56,6 +56,7 @@ type Client interface {
 	GetEnvironment(ctx context.Context, nameOrUUID string) (*Environment, error)
 	UpdateEnvironment(ctx context.Context, nameOrUUID string, input *UpdateEnvironmentInput) (*Environment, error)
 	ListEnvironments(ctx context.Context) ([]*Environment, error)
+	PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, input *RepairEnvironmentInput) (*Environment, error)
 
 	CreatePipeline(ctx context.Context, input *CreatePipelineInput) (*Pipeline, error)
 	DeletePipeline(ctx context.Context, id int) error

--- a/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
@@ -81,6 +81,21 @@ func (mr *MockClientMockRecorder) CreateEnvironment(ctx, input interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateEnvironment", reflect.TypeOf((*MockClient)(nil).CreateEnvironment), ctx, input)
 }
 
+// CreateFunction mocks base method.
+func (m *MockClient) CreateFunction(ctx context.Context, input *meroxa.CreateFunctionInput) (*meroxa.Function, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateFunction", ctx, input)
+	ret0, _ := ret[0].(*meroxa.Function)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateFunction indicates an expected call of CreateFunction.
+func (mr *MockClientMockRecorder) CreateFunction(ctx, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFunction", reflect.TypeOf((*MockClient)(nil).CreateFunction), ctx, input)
+}
+
 // CreatePipeline mocks base method.
 func (m *MockClient) CreatePipeline(ctx context.Context, input *meroxa.CreatePipelineInput) (*meroxa.Pipeline, error) {
 	m.ctrl.T.Helper()
@@ -152,6 +167,21 @@ func (m *MockClient) DeleteEnvironment(ctx context.Context, nameOrUUID string) (
 func (mr *MockClientMockRecorder) DeleteEnvironment(ctx, nameOrUUID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEnvironment", reflect.TypeOf((*MockClient)(nil).DeleteEnvironment), ctx, nameOrUUID)
+}
+
+// DeleteFunction mocks base method.
+func (m *MockClient) DeleteFunction(ctx context.Context, nameOrUUID string) (*meroxa.Function, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteFunction", ctx, nameOrUUID)
+	ret0, _ := ret[0].(*meroxa.Function)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteFunction indicates an expected call of DeleteFunction.
+func (mr *MockClientMockRecorder) DeleteFunction(ctx, nameOrUUID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFunction", reflect.TypeOf((*MockClient)(nil).DeleteFunction), ctx, nameOrUUID)
 }
 
 // DeletePipeline mocks base method.
@@ -240,6 +270,21 @@ func (m *MockClient) GetEnvironment(ctx context.Context, nameOrUUID string) (*me
 func (mr *MockClientMockRecorder) GetEnvironment(ctx, nameOrUUID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvironment", reflect.TypeOf((*MockClient)(nil).GetEnvironment), ctx, nameOrUUID)
+}
+
+// GetFunction mocks base method.
+func (m *MockClient) GetFunction(ctx context.Context, nameOrUUID string) (*meroxa.Function, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFunction", ctx, nameOrUUID)
+	ret0, _ := ret[0].(*meroxa.Function)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFunction indicates an expected call of GetFunction.
+func (mr *MockClientMockRecorder) GetFunction(ctx, nameOrUUID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFunction", reflect.TypeOf((*MockClient)(nil).GetFunction), ctx, nameOrUUID)
 }
 
 // GetPipeline mocks base method.
@@ -347,6 +392,21 @@ func (mr *MockClientMockRecorder) ListEnvironments(ctx interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironments", reflect.TypeOf((*MockClient)(nil).ListEnvironments), ctx)
 }
 
+// ListFunctions mocks base method.
+func (m *MockClient) ListFunctions(ctx context.Context) ([]*meroxa.Function, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListFunctions", ctx)
+	ret0, _ := ret[0].([]*meroxa.Function)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListFunctions indicates an expected call of ListFunctions.
+func (mr *MockClientMockRecorder) ListFunctions(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFunctions", reflect.TypeOf((*MockClient)(nil).ListFunctions), ctx)
+}
+
 // ListPipelineConnectors mocks base method.
 func (m *MockClient) ListPipelineConnectors(ctx context.Context, pipelineID int) ([]*meroxa.Connector, error) {
 	m.ctrl.T.Helper()
@@ -437,6 +497,21 @@ func (mr *MockClientMockRecorder) MakeRequest(ctx, method, path, body, params in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRequest", reflect.TypeOf((*MockClient)(nil).MakeRequest), ctx, method, path, body, params)
 }
 
+// PerformActionOnEnvironment mocks base method.
+func (m *MockClient) PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, input *meroxa.RepairEnvironmentInput) (*meroxa.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PerformActionOnEnvironment", ctx, nameOrUUID, input)
+	ret0, _ := ret[0].(*meroxa.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PerformActionOnEnvironment indicates an expected call of PerformActionOnEnvironment.
+func (mr *MockClientMockRecorder) PerformActionOnEnvironment(ctx, nameOrUUID, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PerformActionOnEnvironment", reflect.TypeOf((*MockClient)(nil).PerformActionOnEnvironment), ctx, nameOrUUID, input)
+}
+
 // RotateTunnelKeyForResource mocks base method.
 func (m *MockClient) RotateTunnelKeyForResource(ctx context.Context, nameOrID string) (*meroxa.Resource, error) {
 	m.ctrl.T.Helper()
@@ -495,15 +570,6 @@ func (m *MockClient) UpdateEnvironment(ctx context.Context, nameOrUUID string, i
 func (mr *MockClientMockRecorder) UpdateEnvironment(ctx, nameOrUUID, input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEnvironment", reflect.TypeOf((*MockClient)(nil).UpdateEnvironment), ctx, nameOrUUID, input)
-}
-
-// PerformActionOnEnvironment default mock method
-func (m *MockClient) PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, input *meroxa.RepairEnvironmentInput) (*meroxa.Environment, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PerformActionOnEnvironment", ctx, nameOrUUID, input)
-	ret0, _ := ret[0].(*meroxa.Environment)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
 }
 
 // UpdatePipeline mocks base method.

--- a/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
@@ -497,6 +497,15 @@ func (mr *MockClientMockRecorder) UpdateEnvironment(ctx, nameOrUUID, input inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateEnvironment", reflect.TypeOf((*MockClient)(nil).UpdateEnvironment), ctx, nameOrUUID, input)
 }
 
+// PerformActionOnEnvironment default mock method
+func (m *MockClient) PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, input *meroxa.RepairEnvironmentInput) (*meroxa.Environment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PerformActionOnEnvironment", ctx, nameOrUUID, input)
+	ret0, _ := ret[0].(*meroxa.Environment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // UpdatePipeline mocks base method.
 func (m *MockClient) UpdatePipeline(ctx context.Context, pipelineID int, input *meroxa.UpdatePipelineInput) (*meroxa.Pipeline, error) {
 	m.ctrl.T.Helper()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -87,7 +87,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900 => ../meroxa-go
+# github.com/meroxa/meroxa-go v0.0.0-20220202200635-942cf1c778a4
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
@@ -203,4 +203,3 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
-# github.com/meroxa/meroxa-go => ../meroxa-go

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -87,7 +87,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900
+# github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900 => ../meroxa-go
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
@@ -203,3 +203,4 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.4.0
 ## explicit; go 1.15
 gopkg.in/yaml.v2
+# github.com/meroxa/meroxa-go => ../meroxa-go

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -87,7 +87,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20220126011704-43e4ed19207c
+# github.com/meroxa/meroxa-go v0.0.0-20220131162708-20eac1635900
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock


### PR DESCRIPTION
### Description of change

Closes https://github.com/meroxa/cli/issues/184

This adds the `meroxa environment repair` command to the CLI.

### Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

### How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

### Demo

**Staging**

|![meroxa-repair-error](https://user-images.githubusercontent.com/8811742/151976493-d3106820-b364-4414-9c50-0f936c79dc1d.gif)
![meroxa-repair-success](https://user-images.githubusercontent.com/8811742/151976792-b8452fa3-3afa-4008-803b-e6867e021873.gif)|

**Locally**

![meroxa-repair-locally](https://user-images.githubusercontent.com/8811742/152228871-d89fa5ed-9798-423a-90e3-4523b1b8dc47.gif)


### Blockers

- [x] wrap up unit tests until CI passes
- [x] add a follow-up PR for documentation updates
- [x] integration test the feature locally
- [x] merge https://github.com/meroxa/meroxa-go/pull/92
- [x] test the feature branch in staging
- [x] vendor in latest meroxa-go and remove mod link to local repository

### Additional references

Related to https://github.com/meroxa/platform-api/pull/811
Related to https://github.com/meroxa/meroxa-go/pull/92

Environment Implementation Plan (CLI): https://www.notion.so/meroxa/Environment-Implementation-Plan-Stage-2-60970cbce0a44c2b9095c0fea4172a69#7bc7dded7ae44b4e9fcd6e27ad189bba
Environment Implementation Plan (Client-API): https://www.notion.so/meroxa/Environment-Implementation-Plan-Stage-2-60970cbce0a44c2b9095c0fea4172a69#261d954133834d088323bfa6867375c1

### Documentation updated

Since the feature is still hidden, this change does not include any doc updates.
