### PR TITLE
upd(templates): move PR instructions into comments

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,41 +1,41 @@
-# Description of change
+## Description of change
 
-*A brief description of the change, what it is and why it was made.*
+<!-- Provide a brief description of the change, what it is and why it was made below.* -->
 
 Fixes <GitHub Issue>
 
-# Type of change
+## Type of change
+
+<!-- Please tick off the correct checkbox after saving the PR description. -->
 
 - [ ]  New feature
 - [ ]  Bug fix
 - [ ]  Refactor
 - [ ]  Documentation
 
-# How was this tested?
+## How was this tested?
 
 - [ ]  Unit Tests
 - [ ]  Tested in staging
 
-# Demo
+## Demo
 
-**Before this pull-request**
+<!-- Provide examples of how the feature looked before and after this change in the table below -->
+| before | after |
+|--------|-------|
+|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|
 
-_Include how it looked before_
 
-**After this pull-request**
+## Additional references
 
-_Include how it looks now_
+<!-- Post any additional links (if appropriate) below -->
 
-# Additional references
+## Documentation updated
 
-*Any additional links (if appropriate)*
-
-# Documentation updated
-
-*Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.*
+<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.
 
 You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.
 
-✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨
+✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->
 
-*Provide PR link:* 
+<!-- Provide a PR link below -->


### PR DESCRIPTION
## Description of change

This updates the PR templates to reflect the PR instructions as comments in the template instead of plain text. This way, the PR creator doesn't need to delete the instructions anymore before saving the description.

## Type of change

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [x]  Documentation

## How was this tested?

Tested manually on Github

## Demo

| before | after |
|--|--|
|![Screen Shot 2022-02-01 at 11 30 42 AM](https://user-images.githubusercontent.com/8811742/151952710-d35a6457-ddc1-44e8-87fa-96b444b8de5a.png)|![pr-after](https://user-images.githubusercontent.com/8811742/151952551-70119a0c-27f6-46f4-8621-85e63b466e61.gif)|


