### PR TITLE
fix(lint): update linting in metrics-test

### DIFF
--- a/cmd/meroxa/global/metrics_test.go
+++ b/cmd/meroxa/global/metrics_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package global
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"testing"
@@ -93,7 +94,7 @@ func TestAddError(t *testing.T) {
 	}
 
 	err := "unexpected error"
-	addError(event, fmt.Errorf("%s", err))
+	addError(event, errors.New(err))
 
 	if v, ok := event["error"]; !ok || v != err {
 		if !ok {

--- a/cmd/meroxa/global/metrics_test.go
+++ b/cmd/meroxa/global/metrics_test.go
@@ -93,7 +93,7 @@ func TestAddError(t *testing.T) {
 	}
 
 	err := "unexpected error"
-	addError(event, fmt.Errorf(err))
+	addError(event, fmt.Errorf("%s", err))
 
 	if v, ok := event["error"]; !ok || v != err {
 		if !ok {


### PR DESCRIPTION
## Description of change

<!-- Provide a brief description of the change, what it is and why it was made below.*  -->

This fixes up a small linter error on the CLI.


```bash
$ golangci-lint run

 cmd/meroxa/global/metrics_test.go:96:18: dynamicFmtString: use errors.New(err) or fmt.Errorf('%s', err) instead (gocritic)
addError(event, fmt.Errorf(err))
```



## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation
- [x]  Chore

## How was this tested?

- [x]  Run linter locally
- [ ]  Tested in staging

