### PR TITLE
docs: update discord server ID on README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We believe that anyone should be empowered to leverage real-time data. Using the
 [Contribution Guide](CONTRIBUTING.md) |
 [Twitter](https://twitter.com/meroxadata)  
 
-[![Support Server](https://img.shields.io/discord/591914197219016707.svg?label=Meroxa%20Community&logo=Discord&colorB=7289da&style=for-the-badge)](https://discord.meroxa.com)
+[![Support Server](https://img.shields.io/discord/828680256877363200.svg?label=Meroxa%20Community&logo=Discord&colorB=7289da&style=for-the-badge)](https://discord.meroxa.com)
 
 
 ## Documentation


### PR DESCRIPTION
## Description of change

Fixes the Discord badge in the README by updating the server ID to the correct one.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [x]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
