### PR TITLE
fix(apps:init): re-enable language "go" shorthand on apps init

### DIFF
--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -86,7 +86,7 @@ func (i *Init) Execute(ctx context.Context) error {
 
 	i.logger.Infof(ctx, "Initializing application %q in %q...", name, i.path)
 	switch lang {
-	case GoLang:
+	case "go", GoLang:
 		err := turbine.Init(name, i.path)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description of change

<!-- Provide a brief description of the change, what it is and why it was made below.* -->

Fixes https://github.com/meroxa/cli/issues/278

This re-enables the "go" shorthand parameter for initializing Turbine apps on the CLI.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|![appinitgo](https://user-images.githubusercontent.com/8811742/158659941-ce107fed-63a3-454c-bfae-0ec29eaf85b5.gif)|tbd|


