### PR TITLE
bug(turbine): Path should always be converted to absolute

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -197,7 +197,10 @@ func (d *Deploy) Execute(ctx context.Context) error {
 		return err
 	}
 
-	d.path = turbineCLI.GetPath(d.flags.Path)
+	d.path, err = turbineCLI.GetPath(d.flags.Path)
+	if err != nil {
+		return err
+	}
 	d.lang, err = turbineCLI.GetLangFromAppJSON(d.path)
 	if err != nil {
 		return err

--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -91,7 +91,7 @@ func (i *Init) Execute(ctx context.Context) error {
 	i.logger.Infof(ctx, "Initializing application %q in %q...", name, i.path)
 	switch lang {
 	case "go", GoLang:
-		err := turbine.Init(name, i.path)
+		err = turbine.Init(name, i.path)
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func (i *Init) Execute(ctx context.Context) error {
 			"You can start interacting with Meroxa in your app located at \"%s/%s\"", i.path, name)
 	case "js", JavaScript, NodeJs:
 		cmd := exec.Command("npx", "turbine", "generate", name, i.path)
-		stdout, err := cmd.CombinedOutput()
+		stdout, err := cmd.CombinedOutput() //nolint:govet
 		if err != nil {
 			i.logger.Error(ctx, string(stdout))
 			return err

--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -82,7 +82,11 @@ func (i *Init) Execute(ctx context.Context) error {
 	name := i.args.appName
 	lang := i.flags.Lang
 
-	i.path = turbineCLI.GetPath(i.flags.Path)
+	var err error
+	i.path, err = turbineCLI.GetPath(i.flags.Path)
+	if err != nil {
+		return err
+	}
 
 	i.logger.Infof(ctx, "Initializing application %q in %q...", name, i.path)
 	switch lang {
@@ -105,7 +109,7 @@ func (i *Init) Execute(ctx context.Context) error {
 		return fmt.Errorf("language %q not supported. %s", lang, LanguageNotSupportedError)
 	}
 
-	err := i.GitInit(ctx, i.path+"/"+name)
+	err = i.GitInit(ctx, i.path+"/"+name)
 	if err != nil {
 		return err
 	}

--- a/cmd/meroxa/root/apps/run.go
+++ b/cmd/meroxa/root/apps/run.go
@@ -19,8 +19,6 @@ package apps
 import (
 	"context"
 	"fmt"
-	"path/filepath"
-
 	turbineGo "github.com/meroxa/cli/cmd/meroxa/turbine_cli/golang"
 
 	turbineJS "github.com/meroxa/cli/cmd/meroxa/turbine_cli/javascript"
@@ -72,13 +70,10 @@ func (r *Run) Flags() []builder.Flag {
 }
 
 func (r *Run) Execute(ctx context.Context) error {
-	r.path = turbineCLI.GetPath(r.flags.Path)
-	if r.path == "." || r.path == "" {
-		var err error
-		r.path, err = filepath.Abs(".")
-		if err != nil {
-			return err
-		}
+	var err error
+	r.path, err = turbineCLI.GetPath(r.flags.Path)
+	if err != nil {
+		return err
 	}
 	lang, err := turbineCLI.GetLang(r.flags.Lang, r.path)
 	if err != nil {

--- a/cmd/meroxa/root/apps/run.go
+++ b/cmd/meroxa/root/apps/run.go
@@ -19,12 +19,11 @@ package apps
 import (
 	"context"
 	"fmt"
-	turbineGo "github.com/meroxa/cli/cmd/meroxa/turbine_cli/golang"
-
-	turbineJS "github.com/meroxa/cli/cmd/meroxa/turbine_cli/javascript"
 
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 	turbineCLI "github.com/meroxa/cli/cmd/meroxa/turbine_cli"
+	turbineGo "github.com/meroxa/cli/cmd/meroxa/turbine_cli/golang"
+	turbineJS "github.com/meroxa/cli/cmd/meroxa/turbine_cli/javascript"
 	"github.com/meroxa/cli/log"
 )
 

--- a/cmd/meroxa/turbine_cli/utils.go
+++ b/cmd/meroxa/turbine_cli/utils.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -18,11 +19,15 @@ type AppConfig struct {
 	Language string `json:"language"`
 }
 
-func GetPath(pwd string) string {
-	if pwd != "" {
-		return pwd
+func GetPath(path string) (string, error) {
+	if path == "." || path == "" {
+		var err error
+		path, err = filepath.Abs(".")
+		if err != nil {
+			return "", err
+		}
 	}
-	return "."
+	return path, nil
 }
 
 // GetLang will return language defined either by `--lang` or the one defined by user in the app.json.

--- a/cmd/meroxa/turbine_cli/utils.go
+++ b/cmd/meroxa/turbine_cli/utils.go
@@ -19,15 +19,15 @@ type AppConfig struct {
 	Language string `json:"language"`
 }
 
-func GetPath(path string) (string, error) {
-	if path == "." || path == "" {
+func GetPath(flag string) (string, error) {
+	if flag == "." || flag == "" {
 		var err error
-		path, err = filepath.Abs(".")
+		flag, err = filepath.Abs(".")
 		if err != nil {
 			return "", err
 		}
 	}
-	return path, nil
+	return flag, nil
 }
 
 // GetLang will return language defined either by `--lang` or the one defined by user in the app.json.


### PR DESCRIPTION
## Description of change

Only the path flag on run was being interpreted as absolute, and not init or deploy. 

Fixes https://github.com/meroxa/turbine-project/issues/99

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [x] manual

## Demo
![Screenshot from 2022-03-22 14-07-33](https://user-images.githubusercontent.com/12731615/159576176-2479745b-f039-44a2-b7f7-238589023f61.png)


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
