### PR TITLE
Initiate Python application via apps init 

### DIFF
--- a/cmd/meroxa/root/apps/apps.go
+++ b/cmd/meroxa/root/apps/apps.go
@@ -27,10 +27,11 @@ import (
 type Apps struct{}
 
 const (
+	Python                    = "python"
 	JavaScript                = "javascript"
 	GoLang                    = "golang"
 	NodeJs                    = "nodejs"
-	LanguageNotSupportedError = "Currently, we support \"javascript\" and \"golang\""
+	LanguageNotSupportedError = "Currently, we support \"javascript\", \"golang\", and \"python\""
 )
 
 var (

--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"os/exec"
 
-	turbinejs "github.com/meroxa/cli/cmd/meroxa/turbine_cli/javascript"
-
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 	turbineCLI "github.com/meroxa/cli/cmd/meroxa/turbine_cli"
+	turbinejs "github.com/meroxa/cli/cmd/meroxa/turbine_cli/javascript"
 	"github.com/meroxa/cli/log"
 	turbine "github.com/meroxa/turbine/init"
 )
@@ -96,6 +95,14 @@ func (i *Init) Execute(ctx context.Context) error {
 		err = turbine.Init(name, i.path)
 	case "js", JavaScript, NodeJs:
 		err = turbinejs.Init(ctx, i.logger, name, i.path)
+	case "py", Python:
+		cmd := exec.Command("turbine", "--generate", name, i.path)
+		stdout, err := cmd.CombinedOutput()
+		if err != nil {
+			i.logger.Error(ctx, string(stdout))
+			return err
+		}
+		i.logger.Info(ctx, string(stdout))
 	default:
 		return fmt.Errorf("language %q not supported. %s", lang, LanguageNotSupportedError)
 	}

--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -9,6 +9,7 @@ import (
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 	turbineCLI "github.com/meroxa/cli/cmd/meroxa/turbine_cli"
 	turbinejs "github.com/meroxa/cli/cmd/meroxa/turbine_cli/javascript"
+	turbinepy "github.com/meroxa/cli/cmd/meroxa/turbine_cli/python"
 	"github.com/meroxa/cli/log"
 	turbine "github.com/meroxa/turbine/init"
 )
@@ -96,13 +97,7 @@ func (i *Init) Execute(ctx context.Context) error {
 	case "js", JavaScript, NodeJs:
 		err = turbinejs.Init(ctx, i.logger, name, i.path)
 	case "py", Python:
-		cmd := exec.Command("turbine", "--generate", name, i.path)
-		stdout, err := cmd.CombinedOutput()
-		if err != nil {
-			i.logger.Error(ctx, string(stdout))
-			return err
-		}
-		i.logger.Info(ctx, string(stdout))
+		err = turbinepy.Init(ctx, i.logger, name, i.path)
 	default:
 		return fmt.Errorf("language %q not supported. %s", lang, LanguageNotSupportedError)
 	}

--- a/cmd/meroxa/turbine_cli/python/init.go
+++ b/cmd/meroxa/turbine_cli/python/init.go
@@ -1,0 +1,15 @@
+package turbinejs
+
+import (
+	"context"
+	"os/exec"
+
+	turbineCLI "github.com/meroxa/cli/cmd/meroxa/turbine_cli"
+	"github.com/meroxa/cli/log"
+)
+
+func Init(ctx context.Context, l log.Logger, name, path string) error {
+	cmd := exec.Command("turbine", "--generate", name, path)
+	_, err := turbineCLI.RunCmdWithErrorDetection(ctx, cmd, l)
+	return err
+}


### PR DESCRIPTION
## Description of change
Adds `python` to `meroxa apps init` 

Fixes https://github.com/meroxa/turbine-project/issues/96
## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging

Running `meroxa apps init` with the python flag
![Screen Shot 2022-03-28 at 6 11 43 PM](https://user-images.githubusercontent.com/1973524/160502352-81be19dc-834f-4252-94fe-d8729f96220b.png)

App directory created at specified location with expected files and directories 
![Screen Shot 2022-03-28 at 6 12 17 PM](https://user-images.githubusercontent.com/1973524/160502355-07905bd2-b524-42ac-961d-0561570fadd9.png)
