### PR TITLE
Allow downloads of private repositories during Circle CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,5 +11,15 @@ jobs:
     steps:
       - checkout
 
+      - add_ssh_keys:
+          fingerprints:
+            - "16:26:c9:af:c0:c6:27:08:be:31:b5:36:40:71:63:44"
+
+      # lock in authentication for Github modules via ssh
+      - run: git config --global --add url."git@github.com:".insteadOf "https://github.com/"
+
+      # disable checksum checking via Go on private Meroxa repositories
+      - run: go env -w GOPRIVATE=github.com/meroxa/*
+
       # specify any bash command here prefixed with `run: `
       - run: go test -mod=vendor -v -race ./...


### PR DESCRIPTION
## Description of change

<!-- Provide a brief description of the change, what it is and why it was made below.* -->

Follow-up to https://github.com/meroxa/cli/pull/288

I followed [this guide](https://circleci.com/docs/2.0/gh-bb-integration/#enable-your-project-to-check-out-additional-private-repositories) to add a machine user key to our cli project on CircleCI.

Example run on Circle CI: https://app.circleci.com/pipelines/github/meroxa/cli/1434/workflows/3b9d64d1-c8ee-4336-a98f-8b240cc0483c/jobs/1393

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation
- [x] Improvement

## How was this tested?

Manually on CircleCI
