### PR TITLE
UX improvements for go app init and path flag

### DIFF
--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -46,9 +46,10 @@ func (*Init) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Initialize a Meroxa Data Application",
 		Example: "meroxa apps init my-app --path ~/code --lang js" +
-			"meroxa apps init my-app --lang go # will be initialized in current directory" +
+			"meroxa apps init my-app --lang go # will be initialized in a dir called my-app in the current directory" +
+			"meroxa apps init my-app --lang go --path $GOPATH/src/github.com/my.org" +
 			"meroxa apps init my-app --lang go --skip-mod-init # will not initialize the new go module" +
-			"meroxa apps init my-app --lang go --mod-vendor # will initialize the new go module and download dependendies to the vendor directory",
+			"meroxa apps init my-app --lang go --mod-vendor # will initialize the new go module and download dependencies to the vendor directory",
 	}
 }
 
@@ -111,8 +112,14 @@ func (i *Init) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	err = i.GitInit(ctx, i.path+"/"+name)
+	if err != nil {
+		return err
+	}
+
 	i.logger.Infof(ctx, "Application successfully initialized!\n"+
 		"You can start interacting with Meroxa in your app located at \"%s/%s\"", i.path, name)
 
-	return i.GitInit(ctx, i.path+"/"+name)
+	return nil
 }


### PR DESCRIPTION
## Description of change
print the success log after git init
warn and skip go mod init if the given path is not within $GOPATH
update init go app example to include $GOPATH in the --path value

bonus:
make it clearer when the given path for app run or app deploy is not an app dir ... can't find name doesn't help the user fix the error quickly

Fixes https://github.com/meroxa/turbine-project/issues/128

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging

## Demo
![Screenshot from 2022-04-01 18-23-10](https://user-images.githubusercontent.com/12731615/161360064-1c1e4c58-a126-47be-9f6c-cadf1e9dcc3a.png)
![Screenshot from 2022-04-01 18-21-25](https://user-images.githubusercontent.com/12731615/161360067-c50146cd-befd-4f83-95cb-3f3e00930991.png)
![Screenshot from 2022-04-01 18-20-34](https://user-images.githubusercontent.com/12731615/161360069-db81018c-e177-452e-9f2b-2a356aea9d7d.png)



## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
