### PR TITLE
upd(turbine-go): upgrade turbine-go and meroxa-go to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/briandowns/spinner v1.18.1
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2
+	github.com/meroxa/turbine-go v0.0.0-20220419083802-4f83d9343ce6
 	github.com/volatiletech/null/v8 v8.1.2
 )
 
@@ -73,6 +73,10 @@ require (
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tidwall/gjson v1.14.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
+	github.com/tidwall/sjson v1.2.4 // indirect
 	github.com/volatiletech/inflect v0.0.1 // indirect
 	github.com/volatiletech/randomize v0.0.1 // indirect
 	github.com/volatiletech/strmangle v0.0.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20220415221139-f31436f83dca
+	github.com/meroxa/meroxa-go v0.0.0-20220419000706-05a93c79cc6e
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/briandowns/spinner v1.18.1
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-go v0.0.0-20220418141359-a37ec2862d9a
+	github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2
 	github.com/volatiletech/null/v8 v8.1.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -578,6 +578,8 @@ github.com/meroxa/meroxa-go v0.0.0-20220415221139-f31436f83dca h1:HTg9REXt9NqbX2
 github.com/meroxa/meroxa-go v0.0.0-20220415221139-f31436f83dca/go.mod h1:BsqYa9jqfyGOAgfkggfK567b2Ahkb+RCH3lXDQGgrh8=
 github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2 h1:scBLDEdMynk5T9O6EcEMxewOTUsjgb5UcbOKx3SkT48=
 github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2/go.mod h1:F4ODyjX+tn5dYFRc1bQlHLUnTtlJIxs09AKHqfCD5Cg=
+github.com/meroxa/turbine-go v0.0.0-20220419083802-4f83d9343ce6 h1:vMXfEM3/9+Q4wOKMoYYFbCe0d3bOW3iCiLRhW5blmgo=
+github.com/meroxa/turbine-go v0.0.0-20220419083802-4f83d9343ce6/go.mod h1:F4ODyjX+tn5dYFRc1bQlHLUnTtlJIxs09AKHqfCD5Cg=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
@@ -793,8 +795,13 @@ github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tidwall/gjson v1.12.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.13.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.0 h1:6aeJ0bzojgWLa82gDQHcx3S0Lr/O51I9bJ5nv6JFx5w=
+github.com/tidwall/gjson v1.14.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.4 h1:cuiLzLnaMeBhRmEv00Lpk3tkYrcxpmbU81tAY4Dw0tc=
 github.com/tidwall/sjson v1.2.4/go.mod h1:098SZ494YoMWPmMO6ct4dcFnqxwj9r/gF0Etp19pSNM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,8 @@ github.com/meroxa/funtime v0.0.0-20220113012133-85e6e898fc73/go.mod h1:K2y2GvcA4
 github.com/meroxa/meroxa-go v0.0.0-20220208195203-71ddc3133fab/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/meroxa/meroxa-go v0.0.0-20220415221139-f31436f83dca h1:HTg9REXt9NqbX2syACtpUEwF/unzwWRjG9AkSaqcnLc=
 github.com/meroxa/meroxa-go v0.0.0-20220415221139-f31436f83dca/go.mod h1:BsqYa9jqfyGOAgfkggfK567b2Ahkb+RCH3lXDQGgrh8=
-github.com/meroxa/turbine-go v0.0.0-20220418141359-a37ec2862d9a h1:wcfOhNkl719CrPe8OmgiZInm448enMDrOwr/pBy5/7w=
-github.com/meroxa/turbine-go v0.0.0-20220418141359-a37ec2862d9a/go.mod h1:F4ODyjX+tn5dYFRc1bQlHLUnTtlJIxs09AKHqfCD5Cg=
+github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2 h1:scBLDEdMynk5T9O6EcEMxewOTUsjgb5UcbOKx3SkT48=
+github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2/go.mod h1:F4ODyjX+tn5dYFRc1bQlHLUnTtlJIxs09AKHqfCD5Cg=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=

--- a/go.sum
+++ b/go.sum
@@ -576,6 +576,8 @@ github.com/meroxa/funtime v0.0.0-20220113012133-85e6e898fc73/go.mod h1:K2y2GvcA4
 github.com/meroxa/meroxa-go v0.0.0-20220208195203-71ddc3133fab/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/meroxa/meroxa-go v0.0.0-20220415221139-f31436f83dca h1:HTg9REXt9NqbX2syACtpUEwF/unzwWRjG9AkSaqcnLc=
 github.com/meroxa/meroxa-go v0.0.0-20220415221139-f31436f83dca/go.mod h1:BsqYa9jqfyGOAgfkggfK567b2Ahkb+RCH3lXDQGgrh8=
+github.com/meroxa/meroxa-go v0.0.0-20220419000706-05a93c79cc6e h1:z5wOdhit1nuDyevydXW4/c2dwQW2BbAamBar1vJ4nhw=
+github.com/meroxa/meroxa-go v0.0.0-20220419000706-05a93c79cc6e/go.mod h1:BsqYa9jqfyGOAgfkggfK567b2Ahkb+RCH3lXDQGgrh8=
 github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2 h1:scBLDEdMynk5T9O6EcEMxewOTUsjgb5UcbOKx3SkT48=
 github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2/go.mod h1:F4ODyjX+tn5dYFRc1bQlHLUnTtlJIxs09AKHqfCD5Cg=
 github.com/meroxa/turbine-go v0.0.0-20220419083802-4f83d9343ce6 h1:vMXfEM3/9+Q4wOKMoYYFbCe0d3bOW3iCiLRhW5blmgo=

--- a/vendor/github.com/meroxa/meroxa-go/LICENSE.md
+++ b/vendor/github.com/meroxa/meroxa-go/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Meroxa Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/meroxa/turbine-go/LICENSE.md
+++ b/vendor/github.com/meroxa/turbine-go/LICENSE.md
@@ -1,0 +1,4 @@
+Copyright Ⓒ 2022 Meroxa Inc.
+
+All code in this repository is copyrighted and proprietary. It is not
+licensed for usage, distribution and/or modification of any kind.

--- a/vendor/github.com/meroxa/turbine-go/init/template/app.go
+++ b/vendor/github.com/meroxa/turbine-go/init/template/app.go
@@ -73,13 +73,13 @@ type Anonymize struct{}
 
 func (f Anonymize) Process(stream []turbine.Record) ([]turbine.Record, []turbine.RecordWithError) {
 	for i, r := range stream {
-		e := fmt.Sprintf("%s", r.Payload.Get("customer_email"))
+		e := fmt.Sprintf("%s", r.Payload.Get("after.customer_email"))
 		if e == "" {
 			log.Printf("unable to find customer_email value in %d record\n", i)
 			break
 		}
 		hashedEmail := consistentHash(e)
-		err := r.Payload.Set("customer_email", hashedEmail)
+		err := r.Payload.Set("after.customer_email", hashedEmail)
 		if err != nil {
 			log.Println("error setting value: ", err)
 			break

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-go v0.0.0-20220418141359-a37ec2862d9a
+# github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2
 ## explicit; go 1.17
 github.com/meroxa/turbine-go/deploy
 github.com/meroxa/turbine-go/init

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,11 +186,11 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20220415221139-f31436f83dca
+# github.com/meroxa/meroxa-go v0.0.0-20220419000706-05a93c79cc6e
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-go v0.0.0-20220418221103-f56d64003db2
+# github.com/meroxa/turbine-go v0.0.0-20220419083802-4f83d9343ce6
 ## explicit; go 1.17
 github.com/meroxa/turbine-go/deploy
 github.com/meroxa/turbine-go/init
@@ -263,6 +263,14 @@ github.com/spf13/viper
 # github.com/subosito/gotenv v1.2.0
 ## explicit
 github.com/subosito/gotenv
+# github.com/tidwall/gjson v1.14.0
+## explicit; go 1.12
+# github.com/tidwall/match v1.1.1
+## explicit; go 1.15
+# github.com/tidwall/pretty v1.2.0
+## explicit; go 1.16
+# github.com/tidwall/sjson v1.2.4
+## explicit; go 1.14
 # github.com/volatiletech/inflect v0.0.1
 ## explicit; go 1.14
 github.com/volatiletech/inflect


### PR DESCRIPTION
## Description of change

This upgrades to the latest version of turbine-go, including https://github.com/meroxa/turbine-go/pull/36

## Blockers

- [x] merge https://github.com/meroxa/turbine-go/pull/36
- [x] run `go get -u github.com/meroxa/turbine-go && make gomod`

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

