### PR TITLE
Remove JS build process

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -235,6 +235,13 @@ func (d *Deploy) uploadSource(ctx context.Context, appPath, url string) error {
 		}
 	}
 
+	if d.lang == JavaScript {
+		err = turbineJS.CreateDockerfile(appPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	dFile := fmt.Sprintf("turbine-%s.tar.gz", d.appName)
 
 	var buf bytes.Buffer
@@ -263,7 +270,7 @@ func (d *Deploy) uploadSource(ctx context.Context, appPath, url string) error {
 		return err
 	}
 
-	if d.lang == GoLang {
+	if d.lang == GoLang || d.lang == JavaScript {
 		// We clean up Dockerfile as last step
 		err = os.Remove(filepath.Join(appPath, "Dockerfile"))
 		if err != nil {
@@ -414,8 +421,6 @@ func (d *Deploy) buildApp(ctx context.Context) error {
 	switch d.lang {
 	case GoLang:
 		err = turbineGo.BuildBinary(ctx, d.logger, d.path, d.appName, true)
-	case JavaScript:
-		d.tempPath, err = turbineJS.BuildApp(d.path)
 	case Python:
 		// Dockerfile will already exist
 		d.tempPath, err = turbinePY.BuildApp(d.path)

--- a/cmd/meroxa/turbine_cli/javascript/deploy.go
+++ b/cmd/meroxa/turbine_cli/javascript/deploy.go
@@ -14,7 +14,7 @@ import (
 )
 
 func NeedsToBuild(path string) (bool, error) {
-	cmd := exec.Command("npx", "--yes", "@meroxa/turbine-js@0.1.6", "hasfunctions", path)
+	cmd := exec.Command("npx", "--yes", "@meroxa/turbine-js@0.2.0", "hasfunctions", path)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		err := fmt.Errorf(
@@ -36,23 +36,8 @@ func NeedsToBuild(path string) (bool, error) {
 	return strconv.ParseBool(match[1])
 }
 
-func BuildApp(path string) (string, error) {
-	cmd := exec.Command("npx", "--yes", "@meroxa/turbine-js@0.1.6", "clibuild", path)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("unable to build Meroxa Application at %s; %s", path, string(output))
-	}
-
-	r := regexp.MustCompile("\nturbine-response: (.*)\n")
-	match := r.FindStringSubmatch(string(output))
-	if match == nil || len(match) < 2 {
-		return "", fmt.Errorf("unable to build Meroxa Application at %s; %s", path, string(output))
-	}
-	return match[1], err
-}
-
 func RunDeployApp(ctx context.Context, l log.Logger, path, imageName string) (string, error) {
-	cmd := exec.Command("npx", "--yes", "@meroxa/turbine-js@0.1.6", "clideploy", imageName, path)
+	cmd := exec.Command("npx", "--yes", "@meroxa/turbine-js@0.2.0", "deploy", imageName, path)
 
 	accessToken, _, err := global.GetUserToken()
 	if err != nil {
@@ -62,4 +47,14 @@ func RunDeployApp(ctx context.Context, l log.Logger, path, imageName string) (st
 	cmd.Env = append(cmd.Env, fmt.Sprintf("MEROXA_ACCESS_TOKEN=%s", accessToken))
 
 	return turbinecli.RunCmdWithErrorDetection(ctx, cmd, l)
+}
+
+func CreateDockerfile(path string) error {
+	cmd := exec.Command("npx", "--yes", "@meroxa/turbine-js@0.2.0", "generatedockerfile", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("unable to build Meroxa Application at %s; %s", path, string(output))
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description of change
Removes the JS build process and offload only Dockerfile injection to turbine-js

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Blockers
+ [ ] Merge and NPM publish https://github.com/meroxa/turbine-js/pull/83

