### PR TITLE
doc: add `py` value in apps init example

### DIFF
--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -110,6 +110,9 @@ type Docs struct {
 	Long string
 	// Example is examples of how to use the command.
 	Example string
+
+	// Beta enabled will add (Beta) to the end of the short doc description
+	Beta bool
 }
 
 type CommandWithDeprecated interface {
@@ -430,7 +433,13 @@ func buildCommandWithDocs(cmd *cobra.Command, c Command) {
 
 	docs := v.Docs()
 	cmd.Long = docs.Long
-	cmd.Short = docs.Short
+
+	if docs.Beta {
+		cmd.Short = fmt.Sprintf("%s (Beta)", docs.Short)
+	} else {
+		cmd.Short = docs.Short
+	}
+
 	cmd.Example = docs.Example
 }
 

--- a/cmd/meroxa/root/apps/apps.go
+++ b/cmd/meroxa/root/apps/apps.go
@@ -49,6 +49,7 @@ func (*Apps) Usage() string {
 func (*Apps) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Manage Turbine Data Applications",
+		Beta:  true,
 	}
 }
 

--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -97,6 +97,7 @@ If deployment was successful, you should expect an application you'll be able to
 		Example: `meroxa apps deploy # assumes you run it from the app directory
 meroxa apps deploy --path ./my-app
 `,
+		Beta: true,
 	}
 }
 

--- a/cmd/meroxa/root/apps/describe.go
+++ b/cmd/meroxa/root/apps/describe.go
@@ -69,6 +69,7 @@ func (d *Describe) Usage() string {
 func (d *Describe) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Describe a Turbine Data Application",
+		Beta:  true,
 	}
 }
 

--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -54,6 +54,7 @@ meroxa apps init my-app --lang go --skip-mod-init 	# will not initialize the new
 meroxa apps init my-app --lang go --mod-vendor 		# will initialize the new go module and download dependencies to the vendor directory
 meroxa apps init my-app --lang go --path $GOPATH/src/github.com/my.org
 `,
+		Beta: true,
 	}
 }
 

--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -25,7 +25,7 @@ type Init struct {
 	}
 
 	flags struct {
-		Lang        string `long:"lang" short:"l" usage:"language to use (js|go)" required:"true"`
+		Lang        string `long:"lang" short:"l" usage:"language to use (js|go|py)" required:"true"`
 		Path        string `long:"path" usage:"path where application will be initialized (current directory as default)"`
 		ModVendor   bool   `long:"mod-vendor" usage:"whether to download modules to vendor or globally while initializing a Go application"`
 		SkipModInit bool   `long:"skip-mod-init" usage:"whether to run 'go mod init' while initializing a Go application"`
@@ -41,13 +41,14 @@ var (
 )
 
 func (*Init) Usage() string {
-	return "init [APP_NAME] [--path pwd] --lang js|go"
+	return "init [APP_NAME] [--path pwd] --lang js|go|py"
 }
 
 func (*Init) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Initialize a Turbine Data Application",
 		Example: `meroxa apps init my-app --path ~/code --lang js
+meroxa apps init my-app --lang py
 meroxa apps init my-app --lang go 			# will be initialized in a dir called my-app in the current directory
 meroxa apps init my-app --lang go --skip-mod-init 	# will not initialize the new go module
 meroxa apps init my-app --lang go --mod-vendor 		# will initialize the new go module and download dependencies to the vendor directory

--- a/cmd/meroxa/root/apps/list.go
+++ b/cmd/meroxa/root/apps/list.go
@@ -51,6 +51,7 @@ func (l *List) Usage() string {
 func (l *List) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "List Turbine Data Applications",
+		Beta:  true,
 	}
 }
 

--- a/cmd/meroxa/root/apps/remove.go
+++ b/cmd/meroxa/root/apps/remove.go
@@ -46,6 +46,7 @@ func (r *Remove) Usage() string {
 func (r *Remove) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Removes a Turbine Data Application",
+		Beta:  true,
 	}
 }
 

--- a/cmd/meroxa/root/apps/run.go
+++ b/cmd/meroxa/root/apps/run.go
@@ -57,6 +57,7 @@ func (*Run) Docs() builder.Docs {
 		Example: `meroxa apps run 			# assumes you run it from the app directory
 meroxa apps run --path ../go-demo 	# it'll use lang defined in your app.json
 `,
+		Beta: true,
 	}
 }
 

--- a/cmd/meroxa/root/builds/builds.go
+++ b/cmd/meroxa/root/builds/builds.go
@@ -41,6 +41,7 @@ func (*Builds) Aliases() []string {
 func (*Builds) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Inspect Process Builds on Meroxa",
+		Beta:  true,
 	}
 }
 

--- a/cmd/meroxa/root/builds/describe.go
+++ b/cmd/meroxa/root/builds/describe.go
@@ -54,6 +54,7 @@ func (d *Describe) Usage() string {
 func (d *Describe) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "Describe a Meroxa Process Build",
+		Beta:  true,
 	}
 }
 

--- a/cmd/meroxa/root/builds/logs.go
+++ b/cmd/meroxa/root/builds/logs.go
@@ -60,6 +60,7 @@ func (*Logs) Aliases() []string {
 func (l *Logs) Docs() builder.Docs {
 	return builder.Docs{
 		Short: "List a Meroxa Process Build's Logs",
+		Beta:  true,
 	}
 }
 

--- a/docs/cmd/md/meroxa.md
+++ b/docs/cmd/md/meroxa.md
@@ -26,10 +26,10 @@ meroxa resources list --types
 ### SEE ALSO
 
 * [meroxa api](meroxa_api.md)	 - Invoke Meroxa API
-* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications
+* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications (Beta)
 * [meroxa auth](meroxa_auth.md)	 - Authentication commands for Meroxa
 * [meroxa billing](meroxa_billing.md)	 - Open your billing page in a web browser
-* [meroxa builds](meroxa_builds.md)	 - Inspect Process Builds on Meroxa
+* [meroxa builds](meroxa_builds.md)	 - Inspect Process Builds on Meroxa (Beta)
 * [meroxa completion](meroxa_completion.md)	 - Generate completion script
 * [meroxa config](meroxa_config.md)	 - Manage your Meroxa CLI configuration
 * [meroxa endpoints](meroxa_endpoints.md)	 - Manage endpoints on Meroxa

--- a/docs/cmd/md/meroxa_apps.md
+++ b/docs/cmd/md/meroxa_apps.md
@@ -1,6 +1,6 @@
 ## meroxa apps
 
-Manage Turbine Data Applications
+Manage Turbine Data Applications (Beta)
 
 ### Options
 
@@ -20,10 +20,10 @@ Manage Turbine Data Applications
 ### SEE ALSO
 
 * [meroxa](meroxa.md)	 - The Meroxa CLI
-* [meroxa apps deploy](meroxa_apps_deploy.md)	 - Deploy a Turbine Data Application
-* [meroxa apps describe](meroxa_apps_describe.md)	 - Describe a Turbine Data Application
-* [meroxa apps init](meroxa_apps_init.md)	 - Initialize a Turbine Data Application
-* [meroxa apps list](meroxa_apps_list.md)	 - List Turbine Data Applications
-* [meroxa apps remove](meroxa_apps_remove.md)	 - Removes a Turbine Data Application
-* [meroxa apps run](meroxa_apps_run.md)	 - Execute a Turbine Data Application locally
+* [meroxa apps deploy](meroxa_apps_deploy.md)	 - Deploy a Turbine Data Application (Beta)
+* [meroxa apps describe](meroxa_apps_describe.md)	 - Describe a Turbine Data Application (Beta)
+* [meroxa apps init](meroxa_apps_init.md)	 - Initialize a Turbine Data Application (Beta)
+* [meroxa apps list](meroxa_apps_list.md)	 - List Turbine Data Applications (Beta)
+* [meroxa apps remove](meroxa_apps_remove.md)	 - Removes a Turbine Data Application (Beta)
+* [meroxa apps run](meroxa_apps_run.md)	 - Execute a Turbine Data Application locally (Beta)
 

--- a/docs/cmd/md/meroxa_apps_deploy.md
+++ b/docs/cmd/md/meroxa_apps_deploy.md
@@ -1,6 +1,6 @@
 ## meroxa apps deploy
 
-Deploy a Turbine Data Application
+Deploy a Turbine Data Application (Beta)
 
 ### Synopsis
 
@@ -39,5 +39,5 @@ meroxa apps deploy --path ./my-app
 
 ### SEE ALSO
 
-* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications
+* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/md/meroxa_apps_describe.md
+++ b/docs/cmd/md/meroxa_apps_describe.md
@@ -1,6 +1,6 @@
 ## meroxa apps describe
 
-Describe a Turbine Data Application
+Describe a Turbine Data Application (Beta)
 
 ```
 meroxa apps describe [NAMEorUUID] [flags]
@@ -24,5 +24,5 @@ meroxa apps describe [NAMEorUUID] [flags]
 
 ### SEE ALSO
 
-* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications
+* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/md/meroxa_apps_init.md
+++ b/docs/cmd/md/meroxa_apps_init.md
@@ -1,6 +1,6 @@
 ## meroxa apps init
 
-Initialize a Turbine Data Application
+Initialize a Turbine Data Application (Beta)
 
 ```
 meroxa apps init [APP_NAME] [--path pwd] --lang js|go|py [flags]
@@ -39,5 +39,5 @@ meroxa apps init my-app --lang go --path $GOPATH/src/github.com/my.org
 
 ### SEE ALSO
 
-* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications
+* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/md/meroxa_apps_init.md
+++ b/docs/cmd/md/meroxa_apps_init.md
@@ -3,13 +3,14 @@
 Initialize a Turbine Data Application
 
 ```
-meroxa apps init [APP_NAME] [--path pwd] --lang js|go [flags]
+meroxa apps init [APP_NAME] [--path pwd] --lang js|go|py [flags]
 ```
 
 ### Examples
 
 ```
 meroxa apps init my-app --path ~/code --lang js
+meroxa apps init my-app --lang py
 meroxa apps init my-app --lang go 			# will be initialized in a dir called my-app in the current directory
 meroxa apps init my-app --lang go --skip-mod-init 	# will not initialize the new go module
 meroxa apps init my-app --lang go --mod-vendor 		# will initialize the new go module and download dependencies to the vendor directory
@@ -21,7 +22,7 @@ meroxa apps init my-app --lang go --path $GOPATH/src/github.com/my.org
 
 ```
   -h, --help            help for init
-  -l, --lang string     language to use (js|go) (required)
+  -l, --lang string     language to use (js|go|py) (required)
       --mod-vendor      whether to download modules to vendor or globally while initializing a Go application
       --path string     path where application will be initialized (current directory as default)
       --skip-mod-init   whether to run 'go mod init' while initializing a Go application

--- a/docs/cmd/md/meroxa_apps_list.md
+++ b/docs/cmd/md/meroxa_apps_list.md
@@ -1,6 +1,6 @@
 ## meroxa apps list
 
-List Turbine Data Applications
+List Turbine Data Applications (Beta)
 
 ```
 meroxa apps list [flags]
@@ -24,5 +24,5 @@ meroxa apps list [flags]
 
 ### SEE ALSO
 
-* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications
+* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/md/meroxa_apps_remove.md
+++ b/docs/cmd/md/meroxa_apps_remove.md
@@ -1,6 +1,6 @@
 ## meroxa apps remove
 
-Removes a Turbine Data Application
+Removes a Turbine Data Application (Beta)
 
 ```
 meroxa apps remove NAME [flags]
@@ -24,5 +24,5 @@ meroxa apps remove NAME [flags]
 
 ### SEE ALSO
 
-* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications
+* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/md/meroxa_apps_run.md
+++ b/docs/cmd/md/meroxa_apps_run.md
@@ -1,6 +1,6 @@
 ## meroxa apps run
 
-Execute a Turbine Data Application locally
+Execute a Turbine Data Application locally (Beta)
 
 ### Synopsis
 
@@ -37,5 +37,5 @@ meroxa apps run --path ../go-demo 	# it'll use lang defined in your app.json
 
 ### SEE ALSO
 
-* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications
+* [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/md/meroxa_builds.md
+++ b/docs/cmd/md/meroxa_builds.md
@@ -1,6 +1,6 @@
 ## meroxa builds
 
-Inspect Process Builds on Meroxa
+Inspect Process Builds on Meroxa (Beta)
 
 ### Options
 
@@ -20,6 +20,6 @@ Inspect Process Builds on Meroxa
 ### SEE ALSO
 
 * [meroxa](meroxa.md)	 - The Meroxa CLI
-* [meroxa builds describe](meroxa_builds_describe.md)	 - Describe a Meroxa Process Build
-* [meroxa builds logs](meroxa_builds_logs.md)	 - List a Meroxa Process Build's Logs
+* [meroxa builds describe](meroxa_builds_describe.md)	 - Describe a Meroxa Process Build (Beta)
+* [meroxa builds logs](meroxa_builds_logs.md)	 - List a Meroxa Process Build's Logs (Beta)
 

--- a/docs/cmd/md/meroxa_builds_describe.md
+++ b/docs/cmd/md/meroxa_builds_describe.md
@@ -1,6 +1,6 @@
 ## meroxa builds describe
 
-Describe a Meroxa Process Build
+Describe a Meroxa Process Build (Beta)
 
 ```
 meroxa builds describe [UUID] [flags]
@@ -23,5 +23,5 @@ meroxa builds describe [UUID] [flags]
 
 ### SEE ALSO
 
-* [meroxa builds](meroxa_builds.md)	 - Inspect Process Builds on Meroxa
+* [meroxa builds](meroxa_builds.md)	 - Inspect Process Builds on Meroxa (Beta)
 

--- a/docs/cmd/md/meroxa_builds_logs.md
+++ b/docs/cmd/md/meroxa_builds_logs.md
@@ -1,6 +1,6 @@
 ## meroxa builds logs
 
-List a Meroxa Process Build's Logs
+List a Meroxa Process Build's Logs (Beta)
 
 ```
 meroxa builds logs [UUID] [flags]
@@ -23,5 +23,5 @@ meroxa builds logs [UUID] [flags]
 
 ### SEE ALSO
 
-* [meroxa builds](meroxa_builds.md)	 - Inspect Process Builds on Meroxa
+* [meroxa builds](meroxa_builds.md)	 - Inspect Process Builds on Meroxa (Beta)
 

--- a/docs/cmd/www/meroxa-apps-deploy.md
+++ b/docs/cmd/www/meroxa-apps-deploy.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-apps-deploy/
 ---
 ## meroxa apps deploy
 
-Deploy a Turbine Data Application
+Deploy a Turbine Data Application (Beta)
 
 ### Synopsis
 
@@ -46,5 +46,5 @@ meroxa apps deploy --path ./my-app
 
 ### SEE ALSO
 
-* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications
+* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/www/meroxa-apps-describe.md
+++ b/docs/cmd/www/meroxa-apps-describe.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-apps-describe/
 ---
 ## meroxa apps describe
 
-Describe a Turbine Data Application
+Describe a Turbine Data Application (Beta)
 
 ```
 meroxa apps describe [NAMEorUUID] [flags]
@@ -31,5 +31,5 @@ meroxa apps describe [NAMEorUUID] [flags]
 
 ### SEE ALSO
 
-* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications
+* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/www/meroxa-apps-init.md
+++ b/docs/cmd/www/meroxa-apps-init.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-apps-init/
 ---
 ## meroxa apps init
 
-Initialize a Turbine Data Application
+Initialize a Turbine Data Application (Beta)
 
 ```
 meroxa apps init [APP_NAME] [--path pwd] --lang js|go|py [flags]
@@ -46,5 +46,5 @@ meroxa apps init my-app --lang go --path $GOPATH/src/github.com/my.org
 
 ### SEE ALSO
 
-* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications
+* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/www/meroxa-apps-init.md
+++ b/docs/cmd/www/meroxa-apps-init.md
@@ -10,13 +10,14 @@ url: /cli/cmd/meroxa-apps-init/
 Initialize a Turbine Data Application
 
 ```
-meroxa apps init [APP_NAME] [--path pwd] --lang js|go [flags]
+meroxa apps init [APP_NAME] [--path pwd] --lang js|go|py [flags]
 ```
 
 ### Examples
 
 ```
 meroxa apps init my-app --path ~/code --lang js
+meroxa apps init my-app --lang py
 meroxa apps init my-app --lang go 			# will be initialized in a dir called my-app in the current directory
 meroxa apps init my-app --lang go --skip-mod-init 	# will not initialize the new go module
 meroxa apps init my-app --lang go --mod-vendor 		# will initialize the new go module and download dependencies to the vendor directory
@@ -28,7 +29,7 @@ meroxa apps init my-app --lang go --path $GOPATH/src/github.com/my.org
 
 ```
   -h, --help            help for init
-  -l, --lang string     language to use (js|go) (required)
+  -l, --lang string     language to use (js|go|py) (required)
       --mod-vendor      whether to download modules to vendor or globally while initializing a Go application
       --path string     path where application will be initialized (current directory as default)
       --skip-mod-init   whether to run 'go mod init' while initializing a Go application

--- a/docs/cmd/www/meroxa-apps-list.md
+++ b/docs/cmd/www/meroxa-apps-list.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-apps-list/
 ---
 ## meroxa apps list
 
-List Turbine Data Applications
+List Turbine Data Applications (Beta)
 
 ```
 meroxa apps list [flags]
@@ -31,5 +31,5 @@ meroxa apps list [flags]
 
 ### SEE ALSO
 
-* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications
+* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/www/meroxa-apps-remove.md
+++ b/docs/cmd/www/meroxa-apps-remove.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-apps-remove/
 ---
 ## meroxa apps remove
 
-Removes a Turbine Data Application
+Removes a Turbine Data Application (Beta)
 
 ```
 meroxa apps remove NAME [flags]
@@ -31,5 +31,5 @@ meroxa apps remove NAME [flags]
 
 ### SEE ALSO
 
-* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications
+* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/www/meroxa-apps-run.md
+++ b/docs/cmd/www/meroxa-apps-run.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-apps-run/
 ---
 ## meroxa apps run
 
-Execute a Turbine Data Application locally
+Execute a Turbine Data Application locally (Beta)
 
 ### Synopsis
 
@@ -44,5 +44,5 @@ meroxa apps run --path ../go-demo 	# it'll use lang defined in your app.json
 
 ### SEE ALSO
 
-* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications
+* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications (Beta)
 

--- a/docs/cmd/www/meroxa-apps.md
+++ b/docs/cmd/www/meroxa-apps.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-apps/
 ---
 ## meroxa apps
 
-Manage Turbine Data Applications
+Manage Turbine Data Applications (Beta)
 
 ### Options
 
@@ -27,10 +27,10 @@ Manage Turbine Data Applications
 ### SEE ALSO
 
 * [meroxa](/cli/cmd/meroxa/)	 - The Meroxa CLI
-* [meroxa apps deploy](/cli/cmd/meroxa-apps-deploy/)	 - Deploy a Turbine Data Application
-* [meroxa apps describe](/cli/cmd/meroxa-apps-describe/)	 - Describe a Turbine Data Application
-* [meroxa apps init](/cli/cmd/meroxa-apps-init/)	 - Initialize a Turbine Data Application
-* [meroxa apps list](/cli/cmd/meroxa-apps-list/)	 - List Turbine Data Applications
-* [meroxa apps remove](/cli/cmd/meroxa-apps-remove/)	 - Removes a Turbine Data Application
-* [meroxa apps run](/cli/cmd/meroxa-apps-run/)	 - Execute a Turbine Data Application locally
+* [meroxa apps deploy](/cli/cmd/meroxa-apps-deploy/)	 - Deploy a Turbine Data Application (Beta)
+* [meroxa apps describe](/cli/cmd/meroxa-apps-describe/)	 - Describe a Turbine Data Application (Beta)
+* [meroxa apps init](/cli/cmd/meroxa-apps-init/)	 - Initialize a Turbine Data Application (Beta)
+* [meroxa apps list](/cli/cmd/meroxa-apps-list/)	 - List Turbine Data Applications (Beta)
+* [meroxa apps remove](/cli/cmd/meroxa-apps-remove/)	 - Removes a Turbine Data Application (Beta)
+* [meroxa apps run](/cli/cmd/meroxa-apps-run/)	 - Execute a Turbine Data Application locally (Beta)
 

--- a/docs/cmd/www/meroxa-builds-describe.md
+++ b/docs/cmd/www/meroxa-builds-describe.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-builds-describe/
 ---
 ## meroxa builds describe
 
-Describe a Meroxa Process Build
+Describe a Meroxa Process Build (Beta)
 
 ```
 meroxa builds describe [UUID] [flags]
@@ -30,5 +30,5 @@ meroxa builds describe [UUID] [flags]
 
 ### SEE ALSO
 
-* [meroxa builds](/cli/cmd/meroxa-builds/)	 - Inspect Process Builds on Meroxa
+* [meroxa builds](/cli/cmd/meroxa-builds/)	 - Inspect Process Builds on Meroxa (Beta)
 

--- a/docs/cmd/www/meroxa-builds-logs.md
+++ b/docs/cmd/www/meroxa-builds-logs.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-builds-logs/
 ---
 ## meroxa builds logs
 
-List a Meroxa Process Build's Logs
+List a Meroxa Process Build's Logs (Beta)
 
 ```
 meroxa builds logs [UUID] [flags]
@@ -30,5 +30,5 @@ meroxa builds logs [UUID] [flags]
 
 ### SEE ALSO
 
-* [meroxa builds](/cli/cmd/meroxa-builds/)	 - Inspect Process Builds on Meroxa
+* [meroxa builds](/cli/cmd/meroxa-builds/)	 - Inspect Process Builds on Meroxa (Beta)
 

--- a/docs/cmd/www/meroxa-builds.md
+++ b/docs/cmd/www/meroxa-builds.md
@@ -7,7 +7,7 @@ url: /cli/cmd/meroxa-builds/
 ---
 ## meroxa builds
 
-Inspect Process Builds on Meroxa
+Inspect Process Builds on Meroxa (Beta)
 
 ### Options
 
@@ -27,6 +27,6 @@ Inspect Process Builds on Meroxa
 ### SEE ALSO
 
 * [meroxa](/cli/cmd/meroxa/)	 - The Meroxa CLI
-* [meroxa builds describe](/cli/cmd/meroxa-builds-describe/)	 - Describe a Meroxa Process Build
-* [meroxa builds logs](/cli/cmd/meroxa-builds-logs/)	 - List a Meroxa Process Build's Logs
+* [meroxa builds describe](/cli/cmd/meroxa-builds-describe/)	 - Describe a Meroxa Process Build (Beta)
+* [meroxa builds logs](/cli/cmd/meroxa-builds-logs/)	 - List a Meroxa Process Build's Logs (Beta)
 

--- a/docs/cmd/www/meroxa.md
+++ b/docs/cmd/www/meroxa.md
@@ -33,10 +33,10 @@ meroxa resources list --types
 ### SEE ALSO
 
 * [meroxa api](/cli/cmd/meroxa-api/)	 - Invoke Meroxa API
-* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications
+* [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications (Beta)
 * [meroxa auth](/cli/cmd/meroxa-auth/)	 - Authentication commands for Meroxa
 * [meroxa billing](/cli/cmd/meroxa-billing/)	 - Open your billing page in a web browser
-* [meroxa builds](/cli/cmd/meroxa-builds/)	 - Inspect Process Builds on Meroxa
+* [meroxa builds](/cli/cmd/meroxa-builds/)	 - Inspect Process Builds on Meroxa (Beta)
 * [meroxa completion](/cli/cmd/meroxa-completion/)	 - Generate completion script
 * [meroxa config](/cli/cmd/meroxa-config/)	 - Manage your Meroxa CLI configuration
 * [meroxa endpoints](/cli/cmd/meroxa-endpoints/)	 - Manage endpoints on Meroxa

--- a/etc/man/man1/meroxa-apps-deploy.1
+++ b/etc/man/man1/meroxa-apps-deploy.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-apps\-deploy \- Deploy a Turbine Data Application
+meroxa\-apps\-deploy \- Deploy a Turbine Data Application (Beta)
 
 
 .SH SYNOPSIS

--- a/etc/man/man1/meroxa-apps-describe.1
+++ b/etc/man/man1/meroxa-apps-describe.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-apps\-describe \- Describe a Turbine Data Application
+meroxa\-apps\-describe \- Describe a Turbine Data Application (Beta)
 
 
 .SH SYNOPSIS
@@ -13,7 +13,7 @@ meroxa\-apps\-describe \- Describe a Turbine Data Application
 
 .SH DESCRIPTION
 .PP
-Describe a Turbine Data Application
+Describe a Turbine Data Application (Beta)
 
 
 .SH OPTIONS

--- a/etc/man/man1/meroxa-apps-init.1
+++ b/etc/man/man1/meroxa-apps-init.1
@@ -8,7 +8,7 @@ meroxa\-apps\-init \- Initialize a Turbine Data Application
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa apps init [APP\_NAME] [\-\-path pwd] \-\-lang js|go [flags]\fP
+\fBmeroxa apps init [APP\_NAME] [\-\-path pwd] \-\-lang js|go|py [flags]\fP
 
 
 .SH DESCRIPTION
@@ -23,7 +23,7 @@ Initialize a Turbine Data Application
 
 .PP
 \fB\-l\fP, \fB\-\-lang\fP=""
-	language to use (js|go) (required)
+	language to use (js|go|py) (required)
 
 .PP
 \fB\-\-mod\-vendor\fP[=false]
@@ -62,6 +62,7 @@ Initialize a Turbine Data Application
 
 .nf
 meroxa apps init my\-app \-\-path \~/code \-\-lang js
+meroxa apps init my\-app \-\-lang py
 meroxa apps init my\-app \-\-lang go 			# will be initialized in a dir called my\-app in the current directory
 meroxa apps init my\-app \-\-lang go \-\-skip\-mod\-init 	# will not initialize the new go module
 meroxa apps init my\-app \-\-lang go \-\-mod\-vendor 		# will initialize the new go module and download dependencies to the vendor directory

--- a/etc/man/man1/meroxa-apps-init.1
+++ b/etc/man/man1/meroxa-apps-init.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-apps\-init \- Initialize a Turbine Data Application
+meroxa\-apps\-init \- Initialize a Turbine Data Application (Beta)
 
 
 .SH SYNOPSIS
@@ -13,7 +13,7 @@ meroxa\-apps\-init \- Initialize a Turbine Data Application
 
 .SH DESCRIPTION
 .PP
-Initialize a Turbine Data Application
+Initialize a Turbine Data Application (Beta)
 
 
 .SH OPTIONS

--- a/etc/man/man1/meroxa-apps-list.1
+++ b/etc/man/man1/meroxa-apps-list.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-apps\-list \- List Turbine Data Applications
+meroxa\-apps\-list \- List Turbine Data Applications (Beta)
 
 
 .SH SYNOPSIS
@@ -13,7 +13,7 @@ meroxa\-apps\-list \- List Turbine Data Applications
 
 .SH DESCRIPTION
 .PP
-List Turbine Data Applications
+List Turbine Data Applications (Beta)
 
 
 .SH OPTIONS

--- a/etc/man/man1/meroxa-apps-remove.1
+++ b/etc/man/man1/meroxa-apps-remove.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-apps\-remove \- Removes a Turbine Data Application
+meroxa\-apps\-remove \- Removes a Turbine Data Application (Beta)
 
 
 .SH SYNOPSIS
@@ -13,7 +13,7 @@ meroxa\-apps\-remove \- Removes a Turbine Data Application
 
 .SH DESCRIPTION
 .PP
-Removes a Turbine Data Application
+Removes a Turbine Data Application (Beta)
 
 
 .SH OPTIONS

--- a/etc/man/man1/meroxa-apps-run.1
+++ b/etc/man/man1/meroxa-apps-run.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-apps\-run \- Execute a Turbine Data Application locally
+meroxa\-apps\-run \- Execute a Turbine Data Application locally (Beta)
 
 
 .SH SYNOPSIS

--- a/etc/man/man1/meroxa-apps.1
+++ b/etc/man/man1/meroxa-apps.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-apps \- Manage Turbine Data Applications
+meroxa\-apps \- Manage Turbine Data Applications (Beta)
 
 
 .SH SYNOPSIS
@@ -13,7 +13,7 @@ meroxa\-apps \- Manage Turbine Data Applications
 
 .SH DESCRIPTION
 .PP
-Manage Turbine Data Applications
+Manage Turbine Data Applications (Beta)
 
 
 .SH OPTIONS

--- a/etc/man/man1/meroxa-builds-describe.1
+++ b/etc/man/man1/meroxa-builds-describe.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-builds\-describe \- Describe a Meroxa Process Build
+meroxa\-builds\-describe \- Describe a Meroxa Process Build (Beta)
 
 
 .SH SYNOPSIS
@@ -13,7 +13,7 @@ meroxa\-builds\-describe \- Describe a Meroxa Process Build
 
 .SH DESCRIPTION
 .PP
-Describe a Meroxa Process Build
+Describe a Meroxa Process Build (Beta)
 
 
 .SH OPTIONS

--- a/etc/man/man1/meroxa-builds-logs.1
+++ b/etc/man/man1/meroxa-builds-logs.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-builds\-logs \- List a Meroxa Process Build's Logs
+meroxa\-builds\-logs \- List a Meroxa Process Build's Logs (Beta)
 
 
 .SH SYNOPSIS
@@ -13,7 +13,7 @@ meroxa\-builds\-logs \- List a Meroxa Process Build's Logs
 
 .SH DESCRIPTION
 .PP
-List a Meroxa Process Build's Logs
+List a Meroxa Process Build's Logs (Beta)
 
 
 .SH OPTIONS

--- a/etc/man/man1/meroxa-builds.1
+++ b/etc/man/man1/meroxa-builds.1
@@ -3,7 +3,7 @@
 
 .SH NAME
 .PP
-meroxa\-builds \- Inspect Process Builds on Meroxa
+meroxa\-builds \- Inspect Process Builds on Meroxa (Beta)
 
 
 .SH SYNOPSIS
@@ -13,7 +13,7 @@ meroxa\-builds \- Inspect Process Builds on Meroxa
 
 .SH DESCRIPTION
 .PP
-Inspect Process Builds on Meroxa
+Inspect Process Builds on Meroxa (Beta)
 
 
 .SH OPTIONS


### PR DESCRIPTION
## Description of change

Includes `py` as a possible value in the documentation for `apps init`

Part of https://github.com/meroxa/turbine-project/issues/206

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [x]  Documentation

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

https://github.com/meroxa/meroxa-docs/pull/95
