### PR TITLE
fix: apps init (updates to latest turbine-go)

### DIFF
--- a/cmd/meroxa/turbine_cli/utils.go
+++ b/cmd/meroxa/turbine_cli/utils.go
@@ -288,7 +288,7 @@ func GoInit(ctx context.Context, l log.Logger, appPath string, skipInit, vendor 
 		if err != nil {
 			return err
 		}
-		depsLog := "Downloading dependencies "
+		depsLog := "Downloading dependencies"
 		cmd = exec.Command("go", "mod", "download")
 		if vendor {
 			depsLog += "to vendor"

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/briandowns/spinner v1.18.1
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-go v0.0.0-20220420192036-400dcc5f1248
+	github.com/meroxa/turbine-go v0.0.0-20220421203002-fbd388ede780
 	github.com/volatiletech/null/v8 v8.1.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -568,8 +568,8 @@ github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88J
 github.com/meroxa/meroxa-go v0.0.0-20220208195203-71ddc3133fab/go.mod h1:HDFszURCM1cOpKE699o5Hs0T2tEIXqY+vFcsur3RiwY=
 github.com/meroxa/meroxa-go v0.0.0-20220419150435-19df16177640 h1:keSIQO3busIkUlHT/Q7p0ij3VcbjeOrXs1vvSJm33J0=
 github.com/meroxa/meroxa-go v0.0.0-20220419150435-19df16177640/go.mod h1:BsqYa9jqfyGOAgfkggfK567b2Ahkb+RCH3lXDQGgrh8=
-github.com/meroxa/turbine-go v0.0.0-20220420192036-400dcc5f1248 h1:vkhTKpdjTprx2TxL+Ft2XH2TXbEqaWK5rl4WzeqrMj4=
-github.com/meroxa/turbine-go v0.0.0-20220420192036-400dcc5f1248/go.mod h1:1MRyltZ88DFkJd4PloKVoY1SagIMfF89rjoToMbnlvM=
+github.com/meroxa/turbine-go v0.0.0-20220421203002-fbd388ede780 h1:xn874Xe7nZO0Mme3YfCEFY4LUoV3OBkBQ1OjiCHk0Ls=
+github.com/meroxa/turbine-go v0.0.0-20220421203002-fbd388ede780/go.mod h1:1MRyltZ88DFkJd4PloKVoY1SagIMfF89rjoToMbnlvM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=

--- a/vendor/github.com/meroxa/turbine-go/init/template/README.md
+++ b/vendor/github.com/meroxa/turbine-go/init/template/README.md
@@ -90,7 +90,7 @@ func (a App) Run(v turbine.Turbine) error {
 		return err
 	}
 
-	err = dest.Write(res, "collection_archive", nil)
+	err = dest.Write(res, "collection_archive")
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ res, _ := v.Process(rr, Anonymize{})
 The `Process` function is Turbine's way of saying, for the records that are coming in, I want you to process these records against a function. Once your app is deployed on Meroxa, Meroxa will do the work to take each record or event that does get streamed to your app and then run your code against it. This allows Meroxa to scale out your processing relative to the velocity of the records streaming in.
 
 ```go
-err = dest.Write(res, "collection_archive", nil)
+err = dest.Write(res, "collection_archive")
 ```
 
 The `Write` function is optional. It takes any records given to it and streams them to the downstream system. In many cases, you might not need to stream data to another system, but this gives you an easy way to do so.

--- a/vendor/github.com/meroxa/turbine-go/init/template/app.go
+++ b/vendor/github.com/meroxa/turbine-go/init/template/app.go
@@ -61,7 +61,9 @@ func (a App) Run(v turbine.Turbine) error {
 	// using the `Write` function
 	// Replace `collection_archive` with a table, collection,
 	// or bucket name in your data store
-	err = dest.Write(res, "collection_archive", nil)
+	// if a configuration is needed you can also use
+	// dest.WriteWithConfig
+	err = dest.Write(res, "collection_archive")
 	if err != nil {
 		return err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -190,7 +190,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-go v0.0.0-20220420192036-400dcc5f1248
+# github.com/meroxa/turbine-go v0.0.0-20220421203002-fbd388ede780
 ## explicit; go 1.17
 github.com/meroxa/turbine-go/deploy
 github.com/meroxa/turbine-go/init


### PR DESCRIPTION
## Description of change

Fixes the following error by upgrading to latest turbine-go.

```
$ .m apps run
# order-go-app
./app.go:64:18: too many arguments in call to dest.Write
	have (turbine.Records, string, nil)
	want (turbine.Records, string)
Error: build failed
```

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## Demo

**Before**

Seen error above.

**After**

The following works just as expected:

`$ meroxa apps init;meroxa apps run`