### PR TITLE
fix: documentation for logical replication

### DIFF
--- a/cmd/meroxa/root/resources/create.go
+++ b/cmd/meroxa/root/resources/create.go
@@ -84,7 +84,7 @@ func (c *Create) Docs() builder.Docs {
 
 		// TODO: Provide example with `--env` once it's not behind a feature flag
 		Example: `
-meroxa resources create store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":true}'
+meroxa resources create store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":"true"}'
 meroxa resources create datalake --type s3 -u "s3://$AWS_ACCESS_KEY_ID:$AWS_ACCESS_KEY_SECRET@us-east-1/meroxa-demos"
 meroxa resources create warehouse --type redshift -u $REDSHIFT_URL
 meroxa resources create slack --type url -u $WEBHOOK_URL

--- a/docs/cmd/md/meroxa_resources_create.md
+++ b/docs/cmd/md/meroxa_resources_create.md
@@ -14,7 +14,7 @@ meroxa resources create [NAME] --type TYPE --url URL [flags]
 
 ```
 
-meroxa resources create store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":true}'
+meroxa resources create store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":"true"}'
 meroxa resources create datalake --type s3 -u "s3://$AWS_ACCESS_KEY_ID:$AWS_ACCESS_KEY_SECRET@us-east-1/meroxa-demos"
 meroxa resources create warehouse --type redshift -u $REDSHIFT_URL
 meroxa resources create slack --type url -u $WEBHOOK_URL

--- a/docs/cmd/www/meroxa-resources-create.md
+++ b/docs/cmd/www/meroxa-resources-create.md
@@ -21,7 +21,7 @@ meroxa resources create [NAME] --type TYPE --url URL [flags]
 
 ```
 
-meroxa resources create store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":true}'
+meroxa resources create store --type postgres -u $DATABASE_URL --metadata '{"logical_replication":"true"}'
 meroxa resources create datalake --type s3 -u "s3://$AWS_ACCESS_KEY_ID:$AWS_ACCESS_KEY_SECRET@us-east-1/meroxa-demos"
 meroxa resources create warehouse --type redshift -u $REDSHIFT_URL
 meroxa resources create slack --type url -u $WEBHOOK_URL

--- a/etc/man/man1/meroxa-resources-create.1
+++ b/etc/man/man1/meroxa-resources-create.1
@@ -94,7 +94,7 @@ Use the create command to add resources to your Meroxa resource catalog.
 
 .nf
 
-meroxa resources create store \-\-type postgres \-u $DATABASE\_URL \-\-metadata '{"logical\_replication":true}'
+meroxa resources create store \-\-type postgres \-u $DATABASE\_URL \-\-metadata '{"logical\_replication":"true"}'
 meroxa resources create datalake \-\-type s3 \-u "s3://$AWS\_ACCESS\_KEY\_ID:$AWS\_ACCESS\_KEY\_SECRET@us\-east\-1/meroxa\-demos"
 meroxa resources create warehouse \-\-type redshift \-u $REDSHIFT\_URL
 meroxa resources create slack \-\-type url \-u $WEBHOOK\_URL


### PR DESCRIPTION
## Description of change

If you do what was in the example, it actually doesn't add a Postgres DB with logical replication enabled.

In other words, connectors using this as a source until now they remained as `jdbc-source` and not `debezium-pg-source`.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [x]  Documentation

## How was this tested?

- Testing turbine go app with logical replication, I noticed this.

## Documents updated

https://github.com/meroxa/meroxa-docs/pull/101