### PR TITLE
fix: version formatting

### DIFF
--- a/cmd/meroxa/main.go
+++ b/cmd/meroxa/main.go
@@ -29,7 +29,25 @@ var (
 	GitLatestTag string
 )
 
+func gitInfoNotEmpty() bool {
+	return GitCommit != "" || GitLatestTag != "" || GitUntracked != ""
+}
+
 func main() {
-	global.Version = fmt.Sprintf("%s:%s %s %s", version, GitCommit, GitLatestTag, GitUntracked)
+	if gitInfoNotEmpty() {
+		if GitCommit != "" {
+			version += fmt.Sprintf(":%s", GitCommit)
+		}
+
+		if GitLatestTag != "" {
+			version += fmt.Sprintf(" %s", GitLatestTag)
+		}
+
+		if GitUntracked != "" {
+			version += fmt.Sprintf(" %s", GitUntracked)
+		}
+	}
+
+	global.Version = version
 	root.Run()
 }


### PR DESCRIPTION
## Description of change

Fixes wrong formatting of version when using a CLI distributed. Brought by https://github.com/meroxa/cli/pull/341

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## Demo

**Before**

```
$ meroxa version
meroxa/2.0.1:   darwin/amd64
```

**After**

```
$ meroxa version
meroxa/2.0.1  darwin/amd64
```
