### PR TITLE
feat: Add support to python3 as possible option

### DIFF
--- a/cmd/meroxa/root/apps/apps.go
+++ b/cmd/meroxa/root/apps/apps.go
@@ -26,6 +26,7 @@ type Apps struct{}
 
 const (
 	Python                    = "python"
+	Python3                   = "python3"
 	JavaScript                = "javascript"
 	GoLang                    = "golang"
 	NodeJs                    = "nodejs"

--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -483,7 +483,7 @@ func (d *Deploy) validateLanguage() error {
 		d.lang = GoLang
 	case "js", JavaScript, NodeJs:
 		d.lang = JavaScript
-	case "py", Python:
+	case "py", Python3, Python:
 		d.lang = Python
 	default:
 		return fmt.Errorf("language %q not supported. %s", d.lang, LanguageNotSupportedError)

--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -136,7 +136,7 @@ func (i *Init) Execute(ctx context.Context) error {
 		err = turbineCLI.GoInit(ctx, i.logger, i.path+"/"+name, i.flags.SkipModInit, i.flags.ModVendor)
 	case "js", JavaScript, NodeJs:
 		err = turbinejs.Init(ctx, i.logger, name, i.path)
-	case "py", Python:
+	case "py", Python3, Python:
 		err = turbinepy.Init(ctx, i.logger, name, i.path)
 	default:
 		return fmt.Errorf("language %q not supported. %s", lang, LanguageNotSupportedError)

--- a/cmd/meroxa/root/apps/run.go
+++ b/cmd/meroxa/root/apps/run.go
@@ -85,7 +85,7 @@ func (r *Run) Execute(ctx context.Context) error {
 		return turbineGo.Run(ctx, r.path, r.logger)
 	case "js", JavaScript, NodeJs:
 		return turbineJS.Build(ctx, r.logger, r.path)
-	case "py", Python:
+	case "py", Python3, Python:
 		return turbinepy.Run(ctx, r.logger, r.path)
 	default:
 		return fmt.Errorf("language %q not supported. %s", lang, LanguageNotSupportedError)


### PR DESCRIPTION
## Description of change

We have noticed some customer attempting to use `python3` as one of the languages. 

Adding "support" for this option is fairly trivial and we should do that since documentation uses `python` and `python3` interchangeably.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo


**Before**

```
$ meroxa apps init --lang python3
language "python3" not supported. Currently, we support "javascript", "golang", and "python"
```

**Now**


```
$ meroxa apps init --lang python3
Initializing application...
```

