### PR TITLE
fix(readme): directly link to installation docs from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For a complete guide to contributing to the Meroxa CLI, see the [Contribution Gu
 
 ## Installation Guide
 
-Please follow the installation instructions in the [Meroxa Documentation](http://docs.meroxa.com/).
+Please follow the [installation instructions in the Meroxa Documentation](https://docs.meroxa.com/cli/installation-guide).
 
 ### Build and Install the Binaries from Source (Advanced Install)
 


### PR DESCRIPTION
## Description of change

<!-- Provide a brief description of the change, what it is and why it was made below.* -->

With this change, the Readme section about installation instructions will directly link to the respective guide in the docs:

https://docs.meroxa.com/cli/installation-guide

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube
- [ ]  Tested manually

## Demo

[Rendered]()

