### PR TITLE
feat: Only release to homebrew not nightly builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: release
 on:
   push:
     tags:
-      - '*'
-      - '!*-nightly.*'
+      - 'v*.*.*'
+      - '!v*.*.*-nightly.*'
 
 jobs:
   goreleaser:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '*'
+      - '!*-nightly.*'
 
 jobs:
   goreleaser:
@@ -12,14 +13,16 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 1.18.x
       -
         name: Import GPG key
         id: import_gpg
@@ -29,7 +32,7 @@ jobs:
           passphrase: ${{ secrets.MEROXA_MACHINE_GPG_PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
## Description of change

Fixes the following experience:

```
$ brew upgrade meroxa
/.../
==> Upgrading meroxa/taps/meroxa
  1.6.3-alpha.1 -> 2.1.0-nightly.20220514
```

## Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation
