### PR TITLE
fix: breaking tests

### DIFF
--- a/cmd/meroxa/root/pipelines/create_test.go
+++ b/cmd/meroxa/root/pipelines/create_test.go
@@ -169,6 +169,7 @@ func TestCreatePipelineWithEnvironmentExecution(t *testing.T) {
 		client: client,
 		logger: logger,
 	}
+
 	// Set up feature flags
 	if global.Config == nil {
 		build := builder.BuildCobraCommand(c)
@@ -241,7 +242,6 @@ Pipeline %q successfully created!
 		t.Fatalf("expected \"%v\", got \"%v\"", *p, gotPipeline)
 	}
 
-	// Clear environments feature flags
 	global.Config.Set(global.UserFeatureFlagsEnv, startingFlags)
 }
 
@@ -257,6 +257,13 @@ func TestCreatePipelineWithEnvironmentExecutionWithoutFeatureFlag(t *testing.T) 
 		client: client,
 		logger: logger,
 	}
+
+	if global.Config == nil {
+		build := builder.BuildCobraCommand(c)
+		_ = global.PersistentPreRunE(build)
+	}
+
+	global.Config.Set(global.UserFeatureFlagsEnv, "")
 
 	pi := &meroxa.CreatePipelineInput{
 		Name:        pName,

--- a/cmd/meroxa/root/resources/create_test.go
+++ b/cmd/meroxa/root/resources/create_test.go
@@ -320,6 +320,12 @@ func TestCreateResourceExecutionWithEnvironmentUUIDWithoutFeatureFlag(t *testing
 		logger: logger,
 	}
 
+	if global.Config == nil {
+		build := builder.BuildCobraCommand(c)
+		_ = global.PersistentPreRunE(build)
+	}
+	global.Config.Set(global.UserFeatureFlagsEnv, "")
+
 	cr := utils.GenerateResourceWithEnvironment()
 
 	r := meroxa.CreateResourceInput{


### PR DESCRIPTION
## Description of change

Noticed these two tests breaking locally since they were relying on the existence of feature flags. 

This change ensure they are testing what they should.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

**Before**

```
=== RUN   TestCreatePipelineWithEnvironmentExecutionWithoutFeatureFlag
    create.go:103: Unexpected call to *mock.MockClient.CreatePipeline([context.Background 0xc000292160]) at /Users/rb/code/meroxa/cli/cmd/meroxa/root/pipelines/create.go:103 because: there are no expected calls of the method "CreatePipeline" for that receiver
--- FAIL: TestCreatePipelineWithEnvironmentExecutionWithoutFeatureFlag (0.00s)
=== RUN   TestCreateResourceExecutionWithEnvironmentUUIDWithoutFeatureFlag
    create.go:176: Unexpected call to *mock.MockClient.CreateResource([context.Background 0xc000252cd0]) at /Users/rb/code/meroxa/cli/cmd/meroxa/root/resources/create.go:176 because: there are no expected calls of the method "CreateResource" for that receiver
--- FAIL: TestCreateResourceExecutionWithEnvironmentUUIDWithoutFeatureFlag (0.00s)
```

**After**

```
=== RUN   TestCreatePipelineWithEnvironmentExecutionWithoutFeatureFlag
--- PASS: TestCreatePipelineWithEnvironmentExecutionWithoutFeatureFlag (0.00s)
=== RUN   TestCreateResourceExecutionWithEnvironmentUUIDWithoutFeatureFlag
--- PASS: TestCreateResourceExecutionWithEnvironmentUUIDWithoutFeatureFlag (0.00s)
```
