### PR TITLE
chore: Upgrade to latest turbine-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/briandowns/spinner v1.18.1
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-go v0.0.0-20220524134641-ccdb7c982741
+	github.com/meroxa/turbine-go v0.0.0-20220524142527-95d74b69888a
 	github.com/stretchr/testify v1.7.0
 	github.com/volatiletech/null/v8 v8.1.2
 )

--- a/go.sum
+++ b/go.sum
@@ -564,8 +564,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/meroxa/meroxa-go v0.0.0-20220419150435-19df16177640 h1:keSIQO3busIkUlHT/Q7p0ij3VcbjeOrXs1vvSJm33J0=
 github.com/meroxa/meroxa-go v0.0.0-20220419150435-19df16177640/go.mod h1:BsqYa9jqfyGOAgfkggfK567b2Ahkb+RCH3lXDQGgrh8=
-github.com/meroxa/turbine-go v0.0.0-20220524134641-ccdb7c982741 h1:kpmIjp6VV9eTzu8FGKgLp+wGwxTNw2LLhbW7cqnnrio=
-github.com/meroxa/turbine-go v0.0.0-20220524134641-ccdb7c982741/go.mod h1:1MRyltZ88DFkJd4PloKVoY1SagIMfF89rjoToMbnlvM=
+github.com/meroxa/turbine-go v0.0.0-20220524142527-95d74b69888a h1:NIQnKkvcrPIMNhYJjisweevGeBtSVDMBdjnhBhdNaPo=
+github.com/meroxa/turbine-go v0.0.0-20220524142527-95d74b69888a/go.mod h1:1MRyltZ88DFkJd4PloKVoY1SagIMfF89rjoToMbnlvM=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-go v0.0.0-20220524134641-ccdb7c982741
+# github.com/meroxa/turbine-go v0.0.0-20220524142527-95d74b69888a
 ## explicit; go 1.17
 github.com/meroxa/turbine-go
 github.com/meroxa/turbine-go/deploy


### PR DESCRIPTION
The following commands were run to generate changes: go get -u github.com/meroxa/turbine-go@latest and make gomod