### PR TITLE
[WIP] upd(deploy): reword predeployment user messaging to be more descriptive

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -408,7 +408,7 @@ func (d *Deploy) buildApp(ctx context.Context) error {
 	var err error
 
 	// Without the " " at the beginning of `suffix`, spinner looks next to word (only on this occurrence)
-	d.logger.StartSpinner("\t", " Building application...")
+	d.logger.StartSpinner("\t", " Building local binary...")
 
 	switch d.lang {
 	case GoLang:
@@ -423,7 +423,7 @@ func (d *Deploy) buildApp(ctx context.Context) error {
 		d.logger.StopSpinnerWithStatus("\t", log.Failed)
 		return err
 	}
-	d.logger.StopSpinnerWithStatus("Application built!", log.Successful)
+	d.logger.StopSpinnerWithStatus("Binary built! Let's double-check your app configuration before deploying it...", log.Successful)
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

This is just a quick pass on how the wording for the binary build step during app deployments could look like. Feedback and suggestions are welcome!

This is a follow-up [to this demo and discussion](https://meroxa.slack.com/archives/C02L14X6TA9/p1653672323863129)

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|![appdeploys-before](https://user-images.githubusercontent.com/8811742/171223246-f937f25b-c6b7-4dd6-83b6-05107d0245e0.gif)|![appdeploys-after](https://user-images.githubusercontent.com/8811742/171223371-11e341c9-343a-4e81-a803-10f47bee3c27.gif)|

