### PR TITLE
Pass api url to turbine

### DIFF
--- a/cmd/meroxa/turbine_cli/golang/deploy.go
+++ b/cmd/meroxa/turbine_cli/golang/deploy.go
@@ -28,7 +28,12 @@ func RunDeployApp(ctx context.Context, l log.Logger, appPath, imageName, appName
 		return "", err
 	}
 	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("ACCESS_TOKEN=%s", accessToken), fmt.Sprintf("REFRESH_TOKEN=%s", refreshToken))
+	cmd.Env = append(
+		cmd.Env,
+		fmt.Sprintf("ACCESS_TOKEN=%s", accessToken),
+		fmt.Sprintf("REFRESH_TOKEN=%s", refreshToken),
+		fmt.Sprintf("API_URL=%s", global.GetMeroxaAPIURL()),
+	)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Description of change

We need to pass api url to turbine, otherwise, API url defaults to production 

Fixes https://github.com/meroxa/acceptance/issues/101

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
