### PR TITLE
Use `turbine-js` for local bin name

### DIFF
--- a/cmd/meroxa/turbine_cli/utils.go
+++ b/cmd/meroxa/turbine_cli/utils.go
@@ -433,7 +433,7 @@ func getTurbineJSBinary(params []string) []string {
 	shouldUseLocalTurbineJS := global.GetLocalTurbineJSSetting()
 	turbineJSBinary := fmt.Sprintf("@meroxa/turbine-js@%s", turbineJSVersion)
 	if shouldUseLocalTurbineJS == isTrue {
-		turbineJSBinary = "turbine"
+		turbineJSBinary = "turbine-js"
 	}
 	args := []string{"npx", "--yes", turbineJSBinary}
 	args = append(args, params...)

--- a/cmd/meroxa/turbine_cli/utils_test.go
+++ b/cmd/meroxa/turbine_cli/utils_test.go
@@ -22,7 +22,7 @@ func TestGetTurbineJSBinary(t *testing.T) {
 		{
 			name:    "MEROXA_USE_LOCAL_TURBINE_JS is true",
 			envVar:  "true",
-			wantCmd: "turbine",
+			wantCmd: "turbine-js",
 		},
 		{
 			name:    "MEROXA_USE_LOCAL_TURBINE_JS is false",


### PR DESCRIPTION
## Description of change
See 
https://meroxa.slack.com/archives/C02L14X6TA9/p1658353954803519

Eric was running into an issue with local dev setup which led me down an interesting path of discovering some odd behavior with bin naming. I believe this is due to something specific about the way that asdf installs global packages wrt bin filenames. 

This updates us to always use `turbine-js` as the name for the local executable, instead of `turbine`, which is the most correct name according to https://docs.npmjs.com/cli/v7/configuring-npm/package-json#bin and should work for everyone regardless of version manager (or lack of).  

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube
- [x] @ericcheatham verifies this branch locally
