### PR TITLE
Turbine-py feature branch changes (--listresources and app name)

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -364,7 +364,7 @@ func (d *Deploy) deployApp(ctx context.Context, imageName, gitSha string) error 
 	case JavaScript:
 		err = turbineJS.RunDeployApp(ctx, d.logger, d.path, imageName, gitSha)
 	case Python:
-		err = turbinePY.RunDeployApp(ctx, d.logger, d.path, imageName, gitSha)
+		err = turbinePY.RunDeployApp(ctx, d.logger, d.path, imageName, d.appName, gitSha)
 	}
 	if err != nil {
 		d.logger.StopSpinnerWithStatus("Deployment failed\n\n", log.Failed)

--- a/cmd/meroxa/turbine_cli/python/deploy.go
+++ b/cmd/meroxa/turbine_cli/python/deploy.go
@@ -57,7 +57,7 @@ func NeedsToBuild(path string) (bool, error) {
 // RunDeployApp creates Application entities.
 func RunDeployApp(ctx context.Context, l log.Logger, path, imageName, appName, gitSha string) error {
 	cmd := exec.Command("turbine-py", "clideploy", path, imageName, appName, gitSha)
-  
+
 	accessToken, _, err := global.GetUserToken()
 	if err != nil {
 		return err

--- a/cmd/meroxa/turbine_cli/python/deploy.go
+++ b/cmd/meroxa/turbine_cli/python/deploy.go
@@ -89,7 +89,7 @@ func GetResourceNames(ctx context.Context, l log.Logger, appPath, appName string
 		return names, errors.New(string(output))
 	}
 
-	var parsed []map[string]interface{}
+	var parsed []turbinecli.ApplicationResource
 	if err := json.Unmarshal(output, &parsed); err != nil {
 		// fall back if not json
 		return getResourceNamesFromString(string(output)), nil
@@ -97,8 +97,8 @@ func GetResourceNames(ctx context.Context, l log.Logger, appPath, appName string
 
 	for i := range parsed {
 		kv := parsed[i]
-		if _, ok := kv["name"]; ok {
-			names = append(names, kv["name"].(string))
+		if kv.Name != "" {
+			names = append(names, kv.Name)
 		}
 	}
 	return names, nil

--- a/cmd/meroxa/turbine_cli/python/deploy.go
+++ b/cmd/meroxa/turbine_cli/python/deploy.go
@@ -2,6 +2,7 @@ package turbinepy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -54,8 +55,8 @@ func NeedsToBuild(path string) (bool, error) {
 }
 
 // RunDeployApp creates Application entities.
-func RunDeployApp(ctx context.Context, l log.Logger, path, imageName, gitSha string) error {
-	cmd := exec.Command("turbine-py", "clideploy", path, imageName, gitSha)
+func RunDeployApp(ctx context.Context, l log.Logger, path, imageName, appName, gitSha string) error {
+	cmd := exec.Command("turbine-py", "clideploy", path, imageName, appName, gitSha)
 
 	accessToken, _, err := global.GetUserToken()
 	if err != nil {
@@ -87,16 +88,34 @@ func GetResourceNames(ctx context.Context, l log.Logger, appPath, appName string
 	if err != nil {
 		return names, errors.New(string(output))
 	}
-	r := regexp.MustCompile("^turbine-response: \\[(.*)\\]\n")
-	match := r.FindStringSubmatch(string(output))
-	if match == nil || len(match) < 2 {
-		return names, fmt.Errorf("unable to verify resource availability for Meroxa Application at %s; %s", appPath, string(output))
+
+	var parsed []map[string]interface{}
+	if err := json.Unmarshal(output, &parsed); err != nil {
+		// fall back if not json
+		l.Info(ctx, string(output))
+		return getResourceNamesFromString(string(output)), nil
 	}
-	text := match[1]
-	names = strings.Split(text, ",")
-	for i, name := range names {
-		name = strings.TrimSpace(name)
-		names[i] = strings.Trim(name, "'")
+
+	for i := range parsed {
+		kv := parsed[i]
+		if _, ok := kv["name"]; ok {
+			names = append(names, kv["name"].(string))
+		}
+
 	}
 	return names, nil
+}
+
+// getResourceNamesFromString provides backward compatibility with turbine-go
+// legacy resource listing format.
+func getResourceNamesFromString(s string) []string {
+	var names []string
+
+	r := regexp.MustCompile(`\[(.+?)\]`)
+	sliceString := r.FindStringSubmatch(s)
+	if len(sliceString) > 0 {
+		names = strings.Fields(sliceString[1])
+	}
+
+	return names
 }

--- a/cmd/meroxa/turbine_cli/python/deploy.go
+++ b/cmd/meroxa/turbine_cli/python/deploy.go
@@ -92,7 +92,6 @@ func GetResourceNames(ctx context.Context, l log.Logger, appPath, appName string
 	var parsed []map[string]interface{}
 	if err := json.Unmarshal(output, &parsed); err != nil {
 		// fall back if not json
-		l.Info(ctx, string(output))
 		return getResourceNamesFromString(string(output)), nil
 	}
 
@@ -101,7 +100,6 @@ func GetResourceNames(ctx context.Context, l log.Logger, appPath, appName string
 		if _, ok := kv["name"]; ok {
 			names = append(names, kv["name"].(string))
 		}
-
 	}
 	return names, nil
 }

--- a/cmd/meroxa/turbine_cli/utils.go
+++ b/cmd/meroxa/turbine_cli/utils.go
@@ -33,6 +33,12 @@ type AppConfig struct {
 var prefetched *AppConfig
 var isTrue = "true"
 
+type ApplicationResource struct {
+	Name        string `json:"name"`
+	Source      bool   `json:"source"`
+	Destination bool   `json:"destination"`
+}
+
 func GetPath(flag string) (string, error) {
 	if flag == "" {
 		flag = "."


### PR DESCRIPTION
## Description of change

Changes as part of feature branch project for turbine-py. List resources on turbine-py now dumbs json similar to go, the code for parsing is now the same as for golang too. 

Deploy also now requires an app name, this will be using to override app.json app_name. 

Fixes (https://github.com/meroxa/product/issues/398)

Relevant PRs: 

https://github.com/meroxa/turbine-py/pull/80
https://github.com/meroxa/meroxa-py/pull/34

## Type of change

- [x]  Refactor

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|


## Additional references


## Documentation updated
