### PR TITLE
Meroxa go upgrade headers

### DIFF
--- a/cmd/meroxa/root/api/api.go
+++ b/cmd/meroxa/root/api/api.go
@@ -41,7 +41,7 @@ var (
 )
 
 type apiClient interface {
-	MakeRequest(ctx context.Context, method, path string, body interface{}, params url.Values) (*http.Response, error)
+	MakeRequest(ctx context.Context, method, path string, body interface{}, params url.Values, headers http.Header) (*http.Response, error)
 }
 
 type API struct {
@@ -92,7 +92,7 @@ func (a *API) ParseArgs(args []string) error {
 }
 
 func (a *API) Execute(ctx context.Context) error {
-	resp, err := a.client.MakeRequest(ctx, a.args.Method, a.args.Path, a.args.Body, nil)
+	resp, err := a.client.MakeRequest(ctx, a.args.Method, a.args.Path, a.args.Body, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/meroxa/root/api/api_test.go
+++ b/cmd/meroxa/root/api/api_test.go
@@ -118,6 +118,7 @@ func TestAPIExecution(t *testing.T) {
 			a.args.Path,
 			"",
 			nil,
+			nil,
 		).
 		Return(httpResponse, nil)
 

--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -135,7 +135,7 @@ func (i *Init) Execute(ctx context.Context) error {
 			return err
 		}
 		i.logger.StopSpinnerWithStatus("Application directory created!", log.Successful)
-		err = turbineCLI.GoInit(i.logger, i.path+"/"+name, i.flags.SkipModInit, i.flags.ModVendor)
+		err = turbineCLI.GoInit(ctx, i.logger, i.path+"/"+name, i.flags.SkipModInit, i.flags.ModVendor)
 	case "js", JavaScript, NodeJs:
 		err = turbinejs.Init(ctx, i.logger, name, i.path)
 	case "py", Python3, Python:

--- a/cmd/meroxa/root/apps/init_test.go
+++ b/cmd/meroxa/root/apps/init_test.go
@@ -112,6 +112,10 @@ func TestGitInit(t *testing.T) {
 
 func TestGoInit(t *testing.T) {
 	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		t.Fatal("GOPATH is not defined")
+	}
+
 	tests := []struct {
 		desc                 string
 		path                 string

--- a/cmd/meroxa/root/apps/init_test.go
+++ b/cmd/meroxa/root/apps/init_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
-
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 	"github.com/meroxa/cli/log"
 	"github.com/meroxa/cli/utils"
@@ -110,8 +110,12 @@ func TestGitInit(t *testing.T) {
 	os.RemoveAll(testDir)
 }
 
+//nolint:funlen
 func TestGoInit(t *testing.T) {
 	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		gopath = build.Default.GOPATH
+	}
 	if gopath == "" {
 		t.Fatal("GOPATH is not defined")
 	}

--- a/cmd/meroxa/turbine_cli/utils.go
+++ b/cmd/meroxa/turbine_cli/utils.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/build"
 	"io"
 	"os"
 	"os/exec"
@@ -237,11 +238,15 @@ func GetGitSha(appPath string) (string, error) {
 	return string(output), nil
 }
 
-func GoInit(l log.Logger, appPath string, skipInit, vendor bool) error {
+func GoInit(ctx context.Context, l log.Logger, appPath string, skipInit, vendor bool) error {
 	l.StartSpinner("\t", "Running golang module initializing...")
 	skipLog := "skipping go module initialization\n\tFor guidance, visit " +
 		"https://docs.meroxa.com/beta-overview#go-mod-init-for-a-new-golang-turbine-data-application"
 	goPath := os.Getenv("GOPATH")
+	if goPath == "" {
+		goPath = build.Default.GOPATH
+		l.Infof(ctx, "using default GOPATH: %s", goPath)
+	}
 	if goPath == "" {
 		l.StopSpinnerWithStatus("$GOPATH not set up; "+skipLog, log.Warning)
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20220802095537-beb01d916646
+	github.com/meroxa/meroxa-go v0.0.0-20220810182408-f05df5bf6f6e
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -564,8 +564,8 @@ github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
-github.com/meroxa/meroxa-go v0.0.0-20220802095537-beb01d916646 h1:HG42GPLNMo8dwkiRaqU9WtAQbxn1gcWMGl4RnqQRIso=
-github.com/meroxa/meroxa-go v0.0.0-20220802095537-beb01d916646/go.mod h1:qczCsZeXwn2R+JeEVjPkgtIMGROQ1Si8ox+OC2nfOYg=
+github.com/meroxa/meroxa-go v0.0.0-20220810182408-f05df5bf6f6e h1:342YniWwgpSnG3afpXwI+yer2peDX6MSw3yjl3O6dSs=
+github.com/meroxa/meroxa-go v0.0.0-20220810182408-f05df5bf6f6e/go.mod h1:qczCsZeXwn2R+JeEVjPkgtIMGROQ1Si8ox+OC2nfOYg=
 github.com/meroxa/turbine-go v0.0.0-20220805164010-1a9d67a2378f h1:buMv3c+got1ZaabJdzmvKMMhurkT/wu/EUcerCm2/po=
 github.com/meroxa/turbine-go v0.0.0-20220805164010-1a9d67a2378f/go.mod h1:x6qIhTUBt8961KrUUioSTd1sCsRKMBvZ3LSS2BDUhJo=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/application.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/application.go
@@ -60,7 +60,7 @@ type ApplicationStatus struct {
 }
 
 func (c *client) CreateApplication(ctx context.Context, input *CreateApplicationInput) (*Application, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, applicationsBasePath, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, applicationsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *client) CreateApplication(ctx context.Context, input *CreateApplication
 }
 
 func (c *client) DeleteApplication(ctx context.Context, name string) error {
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func (c *client) DeleteApplication(ctx context.Context, name string) error {
 // DeleteApplicationEntities does a bit more than DeleteApplication. Its main purpose is to remove underneath's app resources
 // even in the event the application didn't exist.
 func (c *client) DeleteApplicationEntities(ctx context.Context, name string) (*http.Response, error) {
-	respAppDelete, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil)
+	respAppDelete, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, nil)
 	if err != nil {
 		return respAppDelete, err
 	}
@@ -145,7 +145,7 @@ func (c *client) DeleteApplicationEntities(ctx context.Context, name string) (*h
 }
 
 func (c *client) GetApplication(ctx context.Context, name string) (*Application, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", applicationsBasePath, name), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (c *client) GetApplication(ctx context.Context, name string) (*Application,
 }
 
 func (c *client) ListApplications(ctx context.Context) ([]*Application, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, applicationsBasePath, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, applicationsBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/build.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/build.go
@@ -28,7 +28,7 @@ type Build struct {
 }
 
 func (c *client) GetBuild(ctx context.Context, uuid string) (*Build, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", buildsBasePath, uuid), nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", buildsBasePath, uuid), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -48,7 +48,7 @@ func (c *client) GetBuild(ctx context.Context, uuid string) (*Build, error) {
 }
 
 func (c *client) CreateBuild(ctx context.Context, input *CreateBuildInput) (*Build, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, buildsBasePath, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, buildsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/connector.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/connector.go
@@ -80,7 +80,7 @@ func (c *client) CreateConnector(ctx context.Context, input *CreateConnectorInpu
 		input.Configuration = map[string]interface{}{"input": input.Input}
 	}
 	input.Metadata = map[string]interface{}{"mx:connectorType": string(input.Type)}
-	resp, err := c.MakeRequest(ctx, http.MethodPost, connectorsBasePath, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, connectorsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +110,7 @@ func (c *client) UpdateConnectorStatus(ctx context.Context, nameOrID string, sta
 		State: state,
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, path, cr, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, cr, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (c *client) UpdateConnectorStatus(ctx context.Context, nameOrID string, sta
 func (c *client) UpdateConnector(ctx context.Context, nameOrID string, input *UpdateConnectorInput) (*Connector, error) {
 	path := fmt.Sprintf("%s/%s", connectorsBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +156,7 @@ func (c *client) UpdateConnector(ctx context.Context, nameOrID string, input *Up
 func (c *client) ListPipelineConnectors(ctx context.Context, pipelineNameOrID string) ([]*Connector, error) {
 	path := fmt.Sprintf("%s/%s/connectors", pipelinesBasePath, pipelineNameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func (c *client) ListPipelineConnectors(ctx context.Context, pipelineNameOrID st
 
 // ListConnectors returns an array of Connectors (scoped to the calling user)
 func (c *client) ListConnectors(ctx context.Context) ([]*Connector, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, connectorsBasePath, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, connectorsBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +200,7 @@ func (c *client) ListConnectors(ctx context.Context) ([]*Connector, error) {
 func (c *client) GetConnectorByNameOrID(ctx context.Context, nameOrID string) (*Connector, error) {
 	path := fmt.Sprintf("%s/%s", connectorsBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +223,7 @@ func (c *client) GetConnectorByNameOrID(ctx context.Context, nameOrID string) (*
 func (c *client) DeleteConnector(ctx context.Context, nameOrID string) error {
 	path := fmt.Sprintf("%s/%s", connectorsBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/endpoint.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/endpoint.go
@@ -33,7 +33,7 @@ type Endpoint struct {
 }
 
 func (c *client) CreateEndpoint(ctx context.Context, input *CreateEndpointInput) error {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, endpointBasePath, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, endpointBasePath, input, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -43,7 +43,7 @@ func (c *client) CreateEndpoint(ctx context.Context, input *CreateEndpointInput)
 
 func (c *client) GetEndpoint(ctx context.Context, name string) (*Endpoint, error) {
 	path := fmt.Sprintf("%s/%s", endpointBasePath, name)
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (c *client) GetEndpoint(ctx context.Context, name string) (*Endpoint, error
 
 func (c *client) DeleteEndpoint(ctx context.Context, name string) error {
 	path := fmt.Sprintf("%s/%s", endpointBasePath, name)
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (c *client) DeleteEndpoint(ctx context.Context, name string) error {
 }
 
 func (c *client) ListEndpoints(ctx context.Context) ([]Endpoint, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, endpointBasePath, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, endpointBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/environment.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/environment.go
@@ -141,7 +141,7 @@ type RepairEnvironmentInput struct {
 
 // ListEnvironments returns an array of Environments (scoped to the calling user)
 func (c *client) ListEnvironments(ctx context.Context) ([]*Environment, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, environmentsBasePath, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, environmentsBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (c *client) ListEnvironments(ctx context.Context) ([]*Environment, error) {
 
 // CreateEnvironment creates a new Environment based on a CreateEnvironmentInput
 func (c *client) CreateEnvironment(ctx context.Context, input *CreateEnvironmentInput) (*Environment, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, environmentsBasePath, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, environmentsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (c *client) CreateEnvironment(ctx context.Context, input *CreateEnvironment
 
 func (c *client) GetEnvironment(ctx context.Context, nameOrUUID string) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s", environmentsBasePath, nameOrUUID)
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (c *client) GetEnvironment(ctx context.Context, nameOrUUID string) (*Enviro
 
 func (c *client) DeleteEnvironment(ctx context.Context, nameOrUUID string) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s", environmentsBasePath, nameOrUUID)
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func (c *client) DeleteEnvironment(ctx context.Context, nameOrUUID string) (*Env
 
 func (c *client) UpdateEnvironment(ctx context.Context, nameOrUUID string, input *UpdateEnvironmentInput) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s", environmentsBasePath, nameOrUUID)
-	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (c *client) UpdateEnvironment(ctx context.Context, nameOrUUID string, input
 
 func (c *client) PerformActionOnEnvironment(ctx context.Context, nameOrUUID string, input *RepairEnvironmentInput) (*Environment, error) {
 	path := fmt.Sprintf("%s/%s/%s", environmentsBasePath, nameOrUUID, "actions")
-	resp, err := c.MakeRequest(ctx, http.MethodPost, path, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/function.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/function.go
@@ -40,7 +40,7 @@ type CreateFunctionInput struct {
 }
 
 func (c *client) CreateFunction(ctx context.Context, input *CreateFunctionInput) (*Function, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, functionsBasePath, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, functionsBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (c *client) CreateFunction(ctx context.Context, input *CreateFunctionInput)
 func (c *client) GetFunction(ctx context.Context, nameOrUUID string) (*Function, error) {
 	path := fmt.Sprintf("%s/%s", functionsBasePath, nameOrUUID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +80,7 @@ func (c *client) GetFunction(ctx context.Context, nameOrUUID string) (*Function,
 }
 
 func (c *client) ListFunctions(ctx context.Context) ([]*Function, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, functionsBasePath, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, functionsBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (c *client) ListFunctions(ctx context.Context) ([]*Function, error) {
 func (c *client) DeleteFunction(ctx context.Context, nameOrUUID string) (*Function, error) {
 	path := fmt.Sprintf("%s/%s", functionsBasePath, nameOrUUID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/log.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/log.go
@@ -15,7 +15,7 @@ const (
 func (c *client) GetConnectorLogs(ctx context.Context, nameOrID string) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s/logs", connectorLogsBasePath, nameOrID)
 
-	req, err := c.newRequest(ctx, http.MethodGet, path, nil, nil)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (c *client) GetConnectorLogs(ctx context.Context, nameOrID string) (*http.R
 func (c *client) GetFunctionLogs(ctx context.Context, nameOrUUID string) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s/logs", functionLogsBasePath, nameOrUUID)
 
-	req, err := c.newRequest(ctx, http.MethodGet, path, nil, nil)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (c *client) GetFunctionLogs(ctx context.Context, nameOrUUID string) (*http.
 func (c *client) GetBuildLogs(ctx context.Context, uuid string) (*http.Response, error) {
 	path := fmt.Sprintf("%s/%s/logs", buildLogsBasePath, uuid)
 
-	req, err := c.newRequest(ctx, http.MethodGet, path, nil, nil)
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/volatiletech/null/v8"
@@ -112,7 +113,7 @@ type Client interface {
 
 	GetUser(ctx context.Context) (*User, error)
 
-	MakeRequest(ctx context.Context, method string, path string, body interface{}, params url.Values) (*http.Response, error)
+	MakeRequest(ctx context.Context, method string, path string, body interface{}, params url.Values, headers http.Header) (*http.Response, error)
 }
 
 // New returns a Meroxa API client. To configure it provide a list of Options.
@@ -149,8 +150,8 @@ func New(options ...Option) (Client, error) {
 	return c, nil
 }
 
-func (c *client) MakeRequest(ctx context.Context, method, path string, body interface{}, params url.Values) (*http.Response, error) {
-	req, err := c.newRequest(ctx, method, path, body, params)
+func (c *client) MakeRequest(ctx context.Context, method, path string, body interface{}, params url.Values, headers http.Header) (*http.Response, error) {
+	req, err := c.newRequest(ctx, method, path, body, params, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +166,7 @@ func (c *client) MakeRequest(ctx context.Context, method, path string, body inte
 	return resp, nil
 }
 
-func (c *client) newRequest(ctx context.Context, method, path string, body interface{}, params url.Values) (*http.Request, error) {
+func (c *client) newRequest(ctx context.Context, method, path string, body interface{}, params url.Values, headers http.Header) (*http.Request, error) {
 	u, err := c.baseURL.Parse(path)
 	if err != nil {
 		return nil, err
@@ -187,6 +188,9 @@ func (c *client) newRequest(ctx context.Context, method, path string, body inter
 	req.Header.Add("Content-Type", jsonContentType)
 	req.Header.Add("Accept", jsonContentType)
 	req.Header.Add("User-Agent", c.userAgent)
+	for key, value := range headers {
+		req.Header.Add(key, strings.Join(value, ","))
+	}
 
 	// add params
 	if params != nil {

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/pipeline.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/pipeline.go
@@ -48,7 +48,7 @@ type UpdatePipelineInput struct {
 
 // CreatePipeline provisions a new Pipeline
 func (c *client) CreatePipeline(ctx context.Context, input *CreatePipelineInput) (*Pipeline, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, pipelinesBasePath, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, pipelinesBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func (c *client) CreatePipeline(ctx context.Context, input *CreatePipelineInput)
 func (c *client) UpdatePipeline(ctx context.Context, pipelineNameOrID string, input *UpdatePipelineInput) (*Pipeline, error) {
 	path := fmt.Sprintf("%s/%s", pipelinesBasePath, pipelineNameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPatch, path, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +101,7 @@ func (c *client) UpdatePipelineStatus(ctx context.Context, pipelineNameOrID stri
 		State: action,
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, path, cr, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, cr, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (c *client) UpdatePipelineStatus(ctx context.Context, pipelineNameOrID stri
 
 // ListPipelines returns an array of Pipelines (scoped to the calling user)
 func (c *client) ListPipelines(ctx context.Context) ([]*Pipeline, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, pipelinesBasePath, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, pipelinesBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +147,7 @@ func (c *client) GetPipelineByName(ctx context.Context, name string) (*Pipeline,
 		"name": {name},
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, pipelinesBasePath, nil, params)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, pipelinesBasePath, nil, params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (c *client) GetPipelineByName(ctx context.Context, name string) (*Pipeline,
 // GetPipeline returns a Pipeline with the given id
 func (c *client) GetPipeline(ctx context.Context, pipelineID int) (*Pipeline, error) {
 	path := fmt.Sprintf("%s/%d", pipelinesBasePath, pipelineID)
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +192,7 @@ func (c *client) GetPipeline(ctx context.Context, pipelineID int) (*Pipeline, er
 func (c *client) DeletePipeline(ctx context.Context, nameOrID string) error {
 	path := fmt.Sprintf("%s/%s", pipelinesBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/resource.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/resource.go
@@ -95,7 +95,7 @@ func (c *client) CreateResource(ctx context.Context, input *CreateResourceInput)
 		return nil, err
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, ResourcesBasePath, input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, ResourcesBasePath, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,7 @@ func (c *client) UpdateResource(ctx context.Context, nameOrID string, input *Upd
 		}
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPatch, fmt.Sprintf("%s/%s", ResourcesBasePath, nameOrID), input, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPatch, fmt.Sprintf("%s/%s", ResourcesBasePath, nameOrID), input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func (c *client) performResourceAction(ctx context.Context, nameOrID string, act
 		Action: action,
 	}
 
-	resp, err := c.MakeRequest(ctx, http.MethodPost, path, body, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, path, body, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +182,7 @@ func (c *client) performResourceAction(ctx context.Context, nameOrID string, act
 
 // ListResources returns an array of Resources (scoped to the calling user)
 func (c *client) ListResources(ctx context.Context) ([]*Resource, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, ResourcesBasePath, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, ResourcesBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +205,7 @@ func (c *client) ListResources(ctx context.Context) ([]*Resource, error) {
 func (c *client) GetResourceByNameOrID(ctx context.Context, nameOrID string) (*Resource, error) {
 	path := fmt.Sprintf("%s/%s", ResourcesBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (c *client) GetResourceByNameOrID(ctx context.Context, nameOrID string) (*R
 func (c *client) DeleteResource(ctx context.Context, nameOrID string) error {
 	path := fmt.Sprintf("%s/%s", ResourcesBasePath, nameOrID)
 
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, path, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/resource_types.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/resource_types.go
@@ -27,7 +27,7 @@ const (
 func (c *client) ListResourceTypes(ctx context.Context) ([]string, error) {
 	path := fmt.Sprintf("/v1/resource-types")
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/source.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/source.go
@@ -18,7 +18,7 @@ type SourceBlob struct {
 }
 
 func (c *client) CreateSource(ctx context.Context) (*Source, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, sourcesBasePath, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, sourcesBasePath, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/transform.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/transform.go
@@ -27,7 +27,7 @@ type Transform struct {
 func (c *client) ListTransforms(ctx context.Context) ([]*Transform, error) {
 	path := fmt.Sprintf("/v1/transforms")
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/user.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/user.go
@@ -25,7 +25,7 @@ type User struct {
 func (c *client) GetUser(ctx context.Context) (*User, error) {
 	path := fmt.Sprintf("%s/me", usersPath)
 
-	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
@@ -632,18 +632,18 @@ func (mr *MockClientMockRecorder) ListTransforms(ctx interface{}) *gomock.Call {
 }
 
 // MakeRequest mocks base method.
-func (m *MockClient) MakeRequest(ctx context.Context, method, path string, body interface{}, params url.Values) (*http.Response, error) {
+func (m *MockClient) MakeRequest(ctx context.Context, method, path string, body interface{}, params url.Values, headers http.Header) (*http.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeRequest", ctx, method, path, body, params)
+	ret := m.ctrl.Call(m, "MakeRequest", ctx, method, path, body, params, headers)
 	ret0, _ := ret[0].(*http.Response)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeRequest indicates an expected call of MakeRequest.
-func (mr *MockClientMockRecorder) MakeRequest(ctx, method, path, body, params interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) MakeRequest(ctx, method, path, body, params, headers interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRequest", reflect.TypeOf((*MockClient)(nil).MakeRequest), ctx, method, path, body, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeRequest", reflect.TypeOf((*MockClient)(nil).MakeRequest), ctx, method, path, body, params, headers)
 }
 
 // PerformActionOnEnvironment mocks base method.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20220802095537-beb01d916646
+# github.com/meroxa/meroxa-go v0.0.0-20220810182408-f05df5bf6f6e
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock


### PR DESCRIPTION
## Description of change

Updating `meroxa-go` package to be able to inject headers in the `apiClient.MakeRequest` calls.

_Extra: GOPATH was required for the app's initialization, and `build.Default.GOPATH` was added as a fallback._

## Type of change

- [X] New feature
- [X] Bugfix

## How was this tested?

- [X]  Unit Tests
