### PR TITLE
Turbine-js feature branch changes (--listresources and app name)

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -361,7 +361,7 @@ func (d *Deploy) deployApp(ctx context.Context, imageName, gitSha string) error 
 	case GoLang:
 		err = turbineGo.RunDeployApp(ctx, d.logger, d.path, imageName, d.appName, gitSha)
 	case JavaScript:
-		err = turbineJS.RunDeployApp(ctx, d.logger, d.path, imageName, gitSha)
+		err = turbineJS.RunDeployApp(ctx, d.logger, d.path, imageName, d.appName, gitSha)
 	case Python:
 		err = turbinePY.RunDeployApp(ctx, d.logger, d.path, imageName, gitSha)
 	}

--- a/cmd/meroxa/turbine_cli/javascript/deploy.go
+++ b/cmd/meroxa/turbine_cli/javascript/deploy.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"encoding/json"
+
 	"github.com/meroxa/cli/cmd/meroxa/global"
 	turbinecli "github.com/meroxa/cli/cmd/meroxa/turbine_cli"
 	"github.com/meroxa/cli/log"

--- a/cmd/meroxa/turbine_cli/javascript/deploy.go
+++ b/cmd/meroxa/turbine_cli/javascript/deploy.go
@@ -2,13 +2,13 @@ package turbinejs
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
-	"encoding/json"
 
 	"github.com/meroxa/cli/cmd/meroxa/global"
 	turbinecli "github.com/meroxa/cli/cmd/meroxa/turbine_cli"
@@ -77,15 +77,15 @@ func GetResourceNames(ctx context.Context, l log.Logger, appPath, appName string
 		return names, errors.New(string(output))
 	}
 
-	var parsed []map[string]interface{}
+	var parsed []turbinecli.ApplicationResource
 	if err := json.Unmarshal(output, &parsed); err != nil {
 		return getResourceNamesFromString(string(output)), nil
 	}
 
 	for i := range parsed {
 		kv := parsed[i]
-		if _, ok := kv["name"]; ok {
-			names = append(names, kv["name"].(string))
+		if kv.Name != "" {
+			names = append(names, kv.Name)
 		}
 	}
 


### PR DESCRIPTION
## Description of change

Changes as part of feature branch project for turbine-js. List resources on turbine-js now dumbs json similar to go, the code for parsing is now the same as for golang too. 

Deploy also now requires an app name, this will be using to override app.json app_name. 

Fixes (https://github.com/meroxa/product/issues/398)

Relevant PRs: 

https://github.com/meroxa/turbine-js/pull/121
https://github.com/meroxa/meroxa-js/pull/23

## Type of change

- [x]  Refactor

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|


## Additional references


## Documentation updated
