### PR TITLE
Support turbine-js package build, remove temp dir build

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -194,9 +194,17 @@ func (d *Deploy) Logger(logger log.Logger) {
 func (d *Deploy) uploadSource(ctx context.Context, appPath, url string) error {
 	var err error
 
-	if d.lang == GoLang {
+	if d.lang == GoLang || d.lang == JavaScript {
 		d.logger.StartSpinner("\t", fmt.Sprintf("Creating Dockerfile before uploading source in %s", appPath))
-		err = turbine.CreateDockerfile("", appPath)
+
+		if d.lang == GoLang {
+			err = turbine.CreateDockerfile("", appPath)
+		}
+
+		if d.lang == JavaScript {
+			err = turbineJS.CreateDockerfile(ctx, d.logger, appPath)
+		}
+
 		if err != nil {
 			return err
 		}
@@ -217,7 +225,7 @@ func (d *Deploy) uploadSource(ctx context.Context, appPath, url string) error {
 
 	var buf bytes.Buffer
 
-	if d.lang == JavaScript || d.lang == Python {
+	if d.lang == Python {
 		appPath = d.tempPath
 	}
 
@@ -401,8 +409,6 @@ func (d *Deploy) buildApp(ctx context.Context) error {
 	switch d.lang {
 	case GoLang:
 		err = turbineGo.BuildBinary(ctx, d.logger, d.path, d.appName, true)
-	case JavaScript:
-		d.tempPath, err = turbineJS.BuildApp(d.path)
 	case Python:
 		// Dockerfile will already exist
 		d.tempPath, err = turbinePY.BuildApp(d.path)

--- a/cmd/meroxa/turbine_cli/javascript/deploy.go
+++ b/cmd/meroxa/turbine_cli/javascript/deploy.go
@@ -38,19 +38,14 @@ func NeedsToBuild(path string) (bool, error) {
 	return strconv.ParseBool(match[1])
 }
 
-func BuildApp(path string) (string, error) {
+func CreateDockerfile(ctx context.Context, l log.Logger, path string) error {
 	cmd := turbinecli.RunTurbineJS("clibuild", path)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("unable to build Meroxa Application at %s; %s", path, string(output))
+		return fmt.Errorf("unable to create Dockerfile at %s; %s", path, string(output))
 	}
 
-	r := regexp.MustCompile("\nturbine-response: (.*)\n")
-	match := r.FindStringSubmatch(string(output))
-	if match == nil || len(match) < 2 {
-		return "", fmt.Errorf("unable to build Meroxa Application at %s; %s", path, string(output))
-	}
-	return match[1], err
+	return err
 }
 
 func RunDeployApp(ctx context.Context, l log.Logger, path, imageName, appName, gitSha string) error {

--- a/cmd/meroxa/turbine_cli/utils.go
+++ b/cmd/meroxa/turbine_cli/utils.go
@@ -20,7 +20,7 @@ import (
 	"github.com/meroxa/cli/log"
 )
 
-const turbineJSVersion = "0.5.0"
+const turbineJSVersion = "1.0.0"
 
 type AppConfig struct {
 	Name        string            `json:"name"`
@@ -381,7 +381,7 @@ func CreateTarAndZipFile(src string, buf io.Writer) error {
 	tarWriter := tar.NewWriter(zipWriter)
 
 	err = filepath.Walk(appDir, func(file string, fi os.FileInfo, err error) error {
-		if fi.IsDir() && ((fi.Name() == ".git") || (fi.Name() == "fixtures")) {
+		if fi.IsDir() && ((fi.Name() == ".git") || (fi.Name() == "fixtures") || (fi.Name() == "node_modules")) {
 			return filepath.SkipDir
 		}
 		header, err := tar.FileInfoHeader(fi, file)
@@ -435,9 +435,9 @@ func RunTurbineJS(params ...string) (cmd *exec.Cmd) {
 
 func getTurbineJSBinary(params []string) []string {
 	shouldUseLocalTurbineJS := global.GetLocalTurbineJSSetting()
-	turbineJSBinary := fmt.Sprintf("@meroxa/turbine-js@%s", turbineJSVersion)
+	turbineJSBinary := fmt.Sprintf("@meroxa/turbine-js-cli@%s", turbineJSVersion)
 	if shouldUseLocalTurbineJS == isTrue {
-		turbineJSBinary = "turbine-js"
+		turbineJSBinary = "turbine-js-cli"
 	}
 	args := []string{"npx", "--yes", turbineJSBinary}
 	args = append(args, params...)

--- a/cmd/meroxa/turbine_cli/utils.go
+++ b/cmd/meroxa/turbine_cli/utils.go
@@ -381,7 +381,7 @@ func CreateTarAndZipFile(src string, buf io.Writer) error {
 	tarWriter := tar.NewWriter(zipWriter)
 
 	err = filepath.Walk(appDir, func(file string, fi os.FileInfo, err error) error {
-		if fi.IsDir() && ((fi.Name() == ".git") || (fi.Name() == "fixtures") || (fi.Name() == "node_modules")) {
+		if shouldSkipDir(fi) {
 			return filepath.SkipDir
 		}
 		header, err := tar.FileInfoHeader(fi, file)
@@ -446,4 +446,17 @@ func getTurbineJSBinary(params []string) []string {
 
 func executeTurbineJSCommand(params []string) *exec.Cmd {
 	return exec.Command(params[0], params[1:]...) //nolint:gosec
+}
+
+func shouldSkipDir(fi os.FileInfo) bool {
+	if !fi.IsDir() {
+		return false
+	}
+
+	switch fi.Name() {
+	case ".git", "fixtures", "node_modules":
+		return true
+	}
+
+	return false
 }

--- a/cmd/meroxa/turbine_cli/utils_test.go
+++ b/cmd/meroxa/turbine_cli/utils_test.go
@@ -17,22 +17,22 @@ func TestGetTurbineJSBinary(t *testing.T) {
 		{
 			name:    "MEROXA_USE_LOCAL_TURBINE_JS is unset",
 			envVar:  "",
-			wantCmd: fmt.Sprintf("@meroxa/turbine-js@%s", turbineJSVersion),
+			wantCmd: fmt.Sprintf("@meroxa/turbine-js-cli@%s", turbineJSVersion),
 		},
 		{
 			name:    "MEROXA_USE_LOCAL_TURBINE_JS is true",
 			envVar:  "true",
-			wantCmd: "turbine-js",
+			wantCmd: "turbine-js-cli",
 		},
 		{
 			name:    "MEROXA_USE_LOCAL_TURBINE_JS is false",
 			envVar:  "false",
-			wantCmd: fmt.Sprintf("@meroxa/turbine-js@%s", turbineJSVersion),
+			wantCmd: fmt.Sprintf("@meroxa/turbine-js-cli@%s", turbineJSVersion),
 		},
 		{
 			name:    "MEROXA_USE_LOCAL_TURBINE_JS is set to a value that is neither true nor false",
 			envVar:  "jam",
-			wantCmd: fmt.Sprintf("@meroxa/turbine-js@%s", turbineJSVersion),
+			wantCmd: fmt.Sprintf("@meroxa/turbine-js-cli@%s", turbineJSVersion),
 		},
 	}
 


### PR DESCRIPTION
## Description of change

+ Support separated packages from https://github.com/meroxa/turbine-js/pull/115 
  + `meroxa-js-cli`
  + `meroxa-js-framework`
+ Remove temporary directory building from turbine-js apps. Turbine-js apps now build just like turbine-go minus creating a binary
  + Meroxa cli calls turbine-js-cli to copy dockerfile from package to app directory
  + Meroxa cli tar/uploads app directory
  + Meroxa cli cleans up dockerfile



## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo
<img width="888" alt="Screen Shot 2022-08-17 at 12 22 13 PM" src="https://user-images.githubusercontent.com/4818826/185192456-c55fd7c9-bccd-4885-b460-c1d174639449.png">

## Additional references
https://github.com/meroxa/turbine-js/pull/115 

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
