### PR TITLE
chore: rename fig’s fork

### DIFF
--- a/.github/workflows/fig.yml
+++ b/.github/workflows/fig.yml
@@ -26,6 +26,7 @@ jobs:
         autocomplete-spec-name: meroxa
         spec-path: spec/meroxa.ts
         repo-org: meroxa
-        repo-name: cli-autocomplete
+        repo-name: cli-fig-autocomplete
         integration: cobra
         use-minor-base: true
+        


### PR DESCRIPTION
## Description of change

As we integrate with tools such as [Fig](https://fig.io/) and [Warp](https://www.warp.dev/), I want to name repositories a bit more explicitly. Example:

- https://github.com/meroxa/cli-fig-autocomplete
- https://github.com/meroxa/cli-warp-workflows

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation