### PR TITLE
Update init command and its tests to use the turbine CLI interface

### DIFF
--- a/cmd/meroxa/turbine/golang/init.go
+++ b/cmd/meroxa/turbine/golang/init.go
@@ -1,0 +1,113 @@
+package turbinego
+
+import (
+	"context"
+	"fmt"
+	"go/build"
+	"os"
+	"os/exec"
+	"strings"
+
+	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
+	"github.com/meroxa/cli/log"
+	turbinego "github.com/meroxa/turbine-go/init"
+)
+
+func (t *turbineGoCLI) Init(ctx context.Context, name string) error {
+	err := turbinego.Init(name, t.appPath)
+	if err != nil {
+		t.logger.StopSpinnerWithStatus("\t", log.Failed)
+		return err
+	}
+	return err
+}
+
+func (t *turbineGoCLI) GitInit(ctx context.Context, name string) error {
+	return utils.GitInit(ctx, name)
+}
+
+func GoInit(l log.Logger, appPath string, skipInit, vendor bool) error {
+	l.StartSpinner("\t", " Running golang module initializing...")
+	skipLog := "skipping go module initialization\n\tFor guidance, visit " +
+		"https://docs.meroxa.com/beta-overview#go-mod-init-for-a-new-golang-turbine-data-application"
+	goPath := os.Getenv("GOPATH")
+	if goPath == "" {
+		goPath = build.Default.GOPATH
+	}
+	if goPath == "" {
+		l.StopSpinnerWithStatus("$GOPATH not set up; "+skipLog, log.Warning)
+		return nil
+	}
+	i := strings.Index(appPath, goPath+"/src")
+	if i == -1 || i != 0 {
+		l.StopSpinnerWithStatus(fmt.Sprintf("%s is not under $GOPATH/src; %s", appPath, skipLog), log.Warning)
+		return nil
+	}
+
+	// temporarily switching to the app's directory
+	pwd, err := utils.SwitchToAppDirectory(appPath)
+	if err != nil {
+		l.StopSpinnerWithStatus("\t", log.Failed)
+		return err
+	}
+
+	// initialize the user's module
+	err = utils.SetModuleInitInAppJSON(appPath, skipInit)
+	if err != nil {
+		l.StopSpinnerWithStatus("\t", log.Failed)
+		return err
+	}
+
+	err = modulesInit(l, appPath, skipInit, vendor)
+	if err != nil {
+		l.StopSpinnerWithStatus("\t", log.Failed)
+		return err
+	}
+
+	return os.Chdir(pwd)
+}
+
+func modulesInit(l log.Logger, appPath string, skipInit, vendor bool) error {
+	if skipInit {
+		return nil
+	}
+
+	cmd := exec.Command("go", "mod", "init")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		l.StopSpinnerWithStatus(fmt.Sprintf("%s", string(output)), log.Failed)
+		return err
+	}
+	successLog := "go mod init succeeded"
+	goPath := os.Getenv("GOPATH")
+	if goPath == "" {
+		successLog += fmt.Sprintf(" (while assuming GOPATH is %s)", build.Default.GOPATH)
+	}
+	l.StopSpinnerWithStatus(successLog+"!", log.Successful)
+
+	err = GoGetDeps(l)
+	if err != nil {
+		return err
+	}
+
+	// download dependencies
+	err = utils.SetVendorInAppJSON(appPath, vendor)
+	if err != nil {
+		return err
+	}
+	depsLog := "Downloading dependencies"
+	cmd = exec.Command("go", "mod", "download")
+	if vendor {
+		depsLog += " to vendor"
+		cmd = exec.Command("go", "mod", "vendor")
+	}
+	depsLog += "..."
+	l.StartSpinner("\t", depsLog)
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		l.StopSpinnerWithStatus(fmt.Sprintf("%s", string(output)), log.Failed)
+		return err
+	}
+	l.StopSpinnerWithStatus("Downloaded all other dependencies successfully!", log.Successful)
+	return nil
+}

--- a/cmd/meroxa/turbine/golang/utils.go
+++ b/cmd/meroxa/turbine/golang/utils.go
@@ -2,100 +2,10 @@ package turbinego
 
 import (
 	"fmt"
-	"go/build"
-	"os"
 	"os/exec"
-	"strings"
 
-	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
 	"github.com/meroxa/cli/log"
 )
-
-func GoInit(l log.Logger, appPath string, skipInit, vendor bool) error {
-	l.StartSpinner("\t", " Running golang module initializing...")
-	skipLog := "skipping go module initialization\n\tFor guidance, visit " +
-		"https://docs.meroxa.com/beta-overview#go-mod-init-for-a-new-golang-turbine-data-application"
-	goPath := os.Getenv("GOPATH")
-	if goPath == "" {
-		goPath = build.Default.GOPATH
-	}
-	if goPath == "" {
-		l.StopSpinnerWithStatus("$GOPATH not set up; "+skipLog, log.Warning)
-		return nil
-	}
-	i := strings.Index(appPath, goPath+"/src")
-	if i == -1 || i != 0 {
-		l.StopSpinnerWithStatus(fmt.Sprintf("%s is not under $GOPATH/src; %s", appPath, skipLog), log.Warning)
-		return nil
-	}
-
-	// temporarily switching to the app's directory
-	pwd, err := utils.SwitchToAppDirectory(appPath)
-	if err != nil {
-		l.StopSpinnerWithStatus("\t", log.Failed)
-		return err
-	}
-
-	// initialize the user's module
-	err = utils.SetModuleInitInAppJSON(appPath, skipInit)
-	if err != nil {
-		l.StopSpinnerWithStatus("\t", log.Failed)
-		return err
-	}
-
-	err = modulesInit(l, appPath, skipInit, vendor)
-	if err != nil {
-		l.StopSpinnerWithStatus("\t", log.Failed)
-		return err
-	}
-
-	return os.Chdir(pwd)
-}
-
-func modulesInit(l log.Logger, appPath string, skipInit, vendor bool) error {
-	if skipInit {
-		return nil
-	}
-
-	cmd := exec.Command("go", "mod", "init")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		l.StopSpinnerWithStatus(fmt.Sprintf("%s", string(output)), log.Failed)
-		return err
-	}
-	successLog := "go mod init succeeded"
-	goPath := os.Getenv("GOPATH")
-	if goPath == "" {
-		successLog += fmt.Sprintf(" (while assuming GOPATH is %s)", build.Default.GOPATH)
-	}
-	l.StopSpinnerWithStatus(successLog+"!", log.Successful)
-
-	err = GoGetDeps(l)
-	if err != nil {
-		return err
-	}
-
-	// download dependencies
-	err = utils.SetVendorInAppJSON(appPath, vendor)
-	if err != nil {
-		return err
-	}
-	depsLog := "Downloading dependencies"
-	cmd = exec.Command("go", "mod", "download")
-	if vendor {
-		depsLog += " to vendor"
-		cmd = exec.Command("go", "mod", "vendor")
-	}
-	depsLog += "..."
-	l.StartSpinner("\t", depsLog)
-	output, err = cmd.CombinedOutput()
-	if err != nil {
-		l.StopSpinnerWithStatus(fmt.Sprintf("%s", string(output)), log.Failed)
-		return err
-	}
-	l.StopSpinnerWithStatus("Downloaded all other dependencies successfully!", log.Successful)
-	return nil
-}
 
 // GoGetDeps updates the latest Meroxa mods.
 func GoGetDeps(l log.Logger) error {

--- a/cmd/meroxa/turbine/interface.go
+++ b/cmd/meroxa/turbine/interface.go
@@ -7,4 +7,6 @@ import (
 type CLI interface {
 	Upgrade(vendor bool) error
 	Run(ctx context.Context) error
+	Init(ctx context.Context, name string) error
+	GitInit(ctx context.Context, appPath string) error
 }

--- a/cmd/meroxa/turbine/javascript/init.go
+++ b/cmd/meroxa/turbine/javascript/init.go
@@ -4,11 +4,14 @@ import (
 	"context"
 
 	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
-	"github.com/meroxa/cli/log"
 )
 
-func Init(ctx context.Context, l log.Logger, name, path string) error {
-	cmd := RunTurbineJS("generate", name, path)
-	_, err := utils.RunCmdWithErrorDetection(ctx, cmd, l)
+func (t *turbineJsCLI) Init(ctx context.Context, name string) error {
+	cmd := RunTurbineJS("generate", name, t.appPath)
+	_, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
 	return err
+}
+
+func (t *turbineJsCLI) GitInit(ctx context.Context, name string) error {
+	return utils.GitInit(ctx, name)
 }

--- a/cmd/meroxa/turbine/mock/cli.go
+++ b/cmd/meroxa/turbine/mock/cli.go
@@ -34,6 +34,34 @@ func (m *MockCLI) EXPECT() *MockCLIMockRecorder {
 	return m.recorder
 }
 
+// GitInit mocks base method.
+func (m *MockCLI) GitInit(ctx context.Context, appPath string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GitInit", ctx, appPath)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GitInit indicates an expected call of GitInit.
+func (mr *MockCLIMockRecorder) GitInit(ctx, appPath interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GitInit", reflect.TypeOf((*MockCLI)(nil).GitInit), ctx, appPath)
+}
+
+// Init mocks base method.
+func (m *MockCLI) Init(ctx context.Context, name string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Init", ctx, name)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Init indicates an expected call of Init.
+func (mr *MockCLIMockRecorder) Init(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockCLI)(nil).Init), ctx, name)
+}
+
 // Run mocks base method.
 func (m *MockCLI) Run(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/cmd/meroxa/turbine/python/init.go
+++ b/cmd/meroxa/turbine/python/init.go
@@ -5,11 +5,14 @@ import (
 	"os/exec"
 
 	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
-	"github.com/meroxa/cli/log"
 )
 
-func Init(ctx context.Context, l log.Logger, name, path string) error {
-	cmd := exec.Command("turbine-py", "generate", name, path)
-	_, err := utils.RunCmdWithErrorDetection(ctx, cmd, l)
+func (t *turbinePyCLI) Init(ctx context.Context, name string) error {
+	cmd := exec.Command("turbine-py", "generate", name, t.appPath)
+	_, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
 	return err
+}
+
+func (t *turbinePyCLI) GitInit(ctx context.Context, name string) error {
+	return utils.GitInit(ctx, name)
 }

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -164,6 +164,23 @@ func WriteConfigFile(appPath string, cfg AppConfig) error {
 	return nil
 }
 
+func GitInit(ctx context.Context, appPath string) error {
+	if appPath == "" {
+		return errors.New("path is required")
+	}
+
+	cmd := exec.Command("git", "config", "--global", "init.defaultBranch", "main")
+	cmd.Path = appPath
+	_ = cmd.Run()
+
+	cmd = exec.Command("git", "init", appPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf(string(output))
+	}
+	return nil
+}
+
 // GitChecks prints warnings about uncommitted tracked and untracked files.
 func GitChecks(ctx context.Context, l log.Logger, appPath string) error {
 	cmd := exec.Command("git", "status", "--porcelain=v2")

--- a/cmd/meroxa/turbine/utils_test.go
+++ b/cmd/meroxa/turbine/utils_test.go
@@ -1,0 +1,41 @@
+package turbine
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestGitInit(t *testing.T) {
+	testDir := os.TempDir() + "/tests" + uuid.New().String()
+
+	tests := []struct {
+		path string
+		err  error
+	}{
+		{path: "", err: errors.New("path is required")},
+		{path: testDir, err: nil},
+	}
+
+	for _, tt := range tests {
+		err := GitInit(context.Background(), tt.path)
+		if err != nil {
+			if tt.err == nil {
+				t.Fatalf("unexpected error \"%s\"", err)
+			} else if tt.err.Error() != err.Error() {
+				t.Fatalf("expected \"%s\" got \"%s\"", tt.err, err)
+			}
+		}
+
+		if tt.err == nil {
+			if _, err := os.Stat(testDir + "/.git"); os.IsNotExist(err) {
+				t.Fatalf("expected directory \"%s\" to be created", testDir)
+			}
+		}
+	}
+
+	os.RemoveAll(testDir)
+}


### PR DESCRIPTION
## Description of change

Use the turbine CLI interface in the init command so as to test the command without accessing the filesystem or calling other binaries as much as possible
the existing test for Go init is pretty thorough and tests a number of functions, so leaving it there for now and may move it around in a PR that is coming soon

Related to meroxa/turbine-project#251

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
