### PR TITLE
Allow to skip all collection validations

### DIFF
--- a/cmd/meroxa/root/apps/deploy_test.go
+++ b/cmd/meroxa/root/apps/deploy_test.go
@@ -30,7 +30,7 @@ func TestDeployAppFlags(t *testing.T) {
 		{name: "docker-hub-username", required: false, hidden: true},
 		{name: "docker-hub-access-token", required: false, hidden: true},
 		{name: "spec", required: false, hidden: true},
-		{name: "skip-unique-collection", required: false, hidden: true},
+		{name: "skip-collection-validation", required: false, hidden: true},
 	}
 
 	c := builder.BuildCobraCommand(&Deploy{})
@@ -438,10 +438,9 @@ func TestGetResourceCheckErrorMessage(t *testing.T) {
 //nolint:funlen // this is a test function, splitting it would duplicate code
 func TestValidateCollections(t *testing.T) {
 	testCases := []struct {
-		name               string
-		resources          []turbine.ApplicationResource
-		skipUniquenessFlag bool
-		err                string
+		name      string
+		resources []turbine.ApplicationResource
+		err       string
 	}{
 		{
 			name: "Different source and destination resources reference different collections",
@@ -508,7 +507,8 @@ func TestValidateCollections(t *testing.T) {
 				},
 			},
 			err: "⚠️\n\tApplication resource \"pg\" with collection \"sequences\" cannot be used as a destination. It is also the source." +
-				"\nPlease modify your Turbine data application code. Then run `meroxa app deploy` again. ",
+				"\nPlease modify your Turbine data application code. Then run `meroxa app deploy` again. " +
+				"To skip collection validation, run `meroxa app deploy --skip-collection-validation`.",
 		},
 		{
 			name: "One resource is both source and destination",
@@ -521,7 +521,8 @@ func TestValidateCollections(t *testing.T) {
 				},
 			},
 			err: "⚠️\n\tApplication resource cannot be used as both a source and destination." +
-				"\nPlease modify your Turbine data application code. Then run `meroxa app deploy` again. ",
+				"\nPlease modify your Turbine data application code. Then run `meroxa app deploy` again. " +
+				"To skip collection validation, run `meroxa app deploy --skip-collection-validation`.",
 		},
 		{
 			name: "Destination resource used in another app",
@@ -540,7 +541,7 @@ func TestValidateCollections(t *testing.T) {
 			err: "⚠️\n\tApplication resource \"pg\" with collection \"anonymous\" cannot be used as a destination. " +
 				"It is also being used as a destination by another application \"application-name\"." +
 				"\nPlease modify your Turbine data application code. Then run `meroxa app deploy` again. " +
-				"To skip unique destination collection validation, run `meroxa app deploy --skip-unique-collection`.",
+				"To skip collection validation, run `meroxa app deploy --skip-collection-validation`.",
 		},
 		{
 			name: "Two same destination resources",
@@ -562,7 +563,8 @@ func TestValidateCollections(t *testing.T) {
 				},
 			},
 			err: "⚠️\n\tApplication resource \"pg\" with collection \"test-destination\" cannot be used as a destination more than once." +
-				"\nPlease modify your Turbine data application code. Then run `meroxa app deploy` again. ",
+				"\nPlease modify your Turbine data application code. Then run `meroxa app deploy` again. " +
+				"To skip collection validation, run `meroxa app deploy --skip-collection-validation`.",
 		},
 		{
 			name: "Ignore resources without collection info",
@@ -577,22 +579,6 @@ func TestValidateCollections(t *testing.T) {
 					Name: "pg",
 				},
 			},
-		},
-		{
-			name: "Destination resource used in another app",
-			resources: []turbine.ApplicationResource{
-				{
-					Name:       "source",
-					Source:     true,
-					Collection: "sequences",
-				},
-				{
-					Name:        "pg",
-					Destination: true,
-					Collection:  "anonymous",
-				},
-			},
-			skipUniquenessFlag: true,
 		},
 	}
 
@@ -638,7 +624,6 @@ func TestValidateCollections(t *testing.T) {
 				ListApplications(ctx).
 				Return(apps, nil)
 
-			d.flags.SkipUniqueCollection = tc.skipUniquenessFlag
 			err := d.validateCollections(ctx, tc.resources)
 			if tc.err == "" {
 				assert.NoError(t, err)


### PR DESCRIPTION
## Description of change

Ali brought up a case that would require skipping looping validation https://meroxa.slack.com/archives/C02ECHVCHSA/p1661444080066859?thread_ts=1661440392.621599&cid=C02ECHVCHSA

So we want to modify the old skip flag to also skip all collection validation 

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

Before:
```
➜  test-go git:(feature-branch) meroxa apps deploy --skip-unique-collection
Validating your app.json...
	✔ Checked your language is "python"
	✔ Checked your application name is "test-py"
Checking for uncommitted changes...
	✔ No uncommitted changes!
Deploying application "test-py"...
	✔ Application built
	x Resource availability check failed
Error: ⚠️
	Application resource "pg" with collection "sequences" cannot be used as a destination. It is also the source.
Please modify your Turbine data application code. Then run `meroxa app deploy` again. ```

```


After
```
➜  test-go git:(feature-branch) meroxa apps deploy --skip-collection-validation
Validating your app.json...
	✔ Checked your language is "golang"
	✔ Checked your application name is "test-go"
	✔ Feature branch (feature-branch) detected, setting app name to test-go-feature-branch...
Checking for uncommitted changes...
	✔ No uncommitted changes!
Deploying application "test-go-feature-branch"...
	✔ Application built
	✔ Can access your Turbine resources
	✔ Application processes found. Creating application image...
	✔ Platform source fetched
	✔ Dockerfile created
	✔ "turbine-test-go-feature-branch.tar.gz" successfully created in "/Users/dianadoherty/go/src/meroxa/test-go"
	✔ Source uploaded
	✔ Removed "turbine-test-go-feature-branch.tar.gz"
	✔ Dockerfile removed
	✔ Successfully built process image ("83db1b4a-20a7-4fa0-8d65-9e08f344d1f7")
	✔ Deploy complete
	✔ Application "test-go-feature-branch" successfully created!

  ✨ To visualize your application visit https://dashboard.meroxa.io/apps/94d4b739-cf74-4bd8-871e-cd444af92a39/detail
```