### PR TITLE
Ignore capitalization when initializing an app

### DIFF
--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -96,7 +96,7 @@ func validateAppName(name string) (string, error) {
 
 func (i *Init) Execute(ctx context.Context) error {
 	name := i.args.appName
-	lang := i.flags.Lang
+	lang := strings.ToLower(i.flags.Lang)
 
 	name, err := validateAppName(name)
 	if err != nil {


### PR DESCRIPTION
## Description of change

any combination of capital letters in the language name should be acceptable

Fixes https://github.com/meroxa/product/issues/541

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo


BEFORE
$ m apps init --lang GoLang capitalization
	x 	
Error: language "GoLang" not supported. Currently, we support "javascript", "golang", and "python"


AFTER
$ m apps init --lang GoLang capitalization
	✔ Application directory created!
	✔ go mod init succeeded!
	✔ Downloaded latest turbine-go and turbine-go/running dependencies successfully!
	✔ Downloaded all other dependencies successfully!
	✔ Git initialized successfully!
Turbine Data Application successfully initialized!
You can start interacting with Meroxa in your app located at "/home/janelle/go/src/github.com/meroxa/demos/capitalization".
Your Application will not be visible in the Meroxa Dashboard until after deployment.


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
