### PR TITLE
chore: Upgrade to latest turbine-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-go v0.0.0-20220808165302-ff929376e177
+	github.com/meroxa/turbine-go v0.0.0-20220826151950-0de76598d622
 	github.com/stretchr/testify v1.8.0
 	github.com/volatiletech/null/v8 v8.1.2
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
@@ -78,7 +78,7 @@ require (
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	github.com/tidwall/gjson v1.14.2 // indirect
+	github.com/tidwall/gjson v1.14.3 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/meroxa/meroxa-go v0.0.0-20220810182408-f05df5bf6f6e h1:342YniWwgpSnG3afpXwI+yer2peDX6MSw3yjl3O6dSs=
 github.com/meroxa/meroxa-go v0.0.0-20220810182408-f05df5bf6f6e/go.mod h1:qczCsZeXwn2R+JeEVjPkgtIMGROQ1Si8ox+OC2nfOYg=
-github.com/meroxa/turbine-go v0.0.0-20220808165302-ff929376e177 h1:IlAZCm/UlMnC+5V+OAYlKXa16yGzlLxO1+6EN6PcwxM=
-github.com/meroxa/turbine-go v0.0.0-20220808165302-ff929376e177/go.mod h1:x6qIhTUBt8961KrUUioSTd1sCsRKMBvZ3LSS2BDUhJo=
+github.com/meroxa/turbine-go v0.0.0-20220826151950-0de76598d622 h1:8K0K2j7LsKZH82L839ZeufacyoH8CeY7IGCjyh39quQ=
+github.com/meroxa/turbine-go v0.0.0-20220826151950-0de76598d622/go.mod h1:URu62BZTpLbQCfgVImK0lGf4tIHxJxZMpgIJQyq+0zY=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -722,8 +722,9 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
+github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=

--- a/vendor/github.com/tidwall/gjson/gjson.go
+++ b/vendor/github.com/tidwall/gjson/gjson.go
@@ -945,7 +945,7 @@ func isDotPiperChar(s string) bool {
 		// check that the next component is *not* a modifier.
 		i := 1
 		for ; i < len(s); i++ {
-			if s[i] == '.' || s[i] == '|' {
+			if s[i] == '.' || s[i] == '|' || s[i] == ':' {
 				break
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -200,7 +200,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-go v0.0.0-20220808165302-ff929376e177
+# github.com/meroxa/turbine-go v0.0.0-20220826151950-0de76598d622
 ## explicit; go 1.18
 github.com/meroxa/turbine-go
 github.com/meroxa/turbine-go/deploy
@@ -283,7 +283,7 @@ github.com/stretchr/testify/require
 # github.com/subosito/gotenv v1.2.0
 ## explicit
 github.com/subosito/gotenv
-# github.com/tidwall/gjson v1.14.2
+# github.com/tidwall/gjson v1.14.3
 ## explicit; go 1.12
 github.com/tidwall/gjson
 # github.com/tidwall/match v1.1.1


### PR DESCRIPTION
The following commands were run to generate changes: go get -u github.com/meroxa/turbine-go@latest and make gomod