### PR TITLE
bug(turbine): JS build and run were mixed up and caused an erroneous …

### DIFF
--- a/cmd/meroxa/turbine/javascript/build.go
+++ b/cmd/meroxa/turbine/javascript/build.go
@@ -2,18 +2,11 @@ package turbinejs
 
 import (
 	"context"
-
-	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
 )
 
-// Build calls turbine-js to build an application.
+// Build has nothing to do for turbine-js.
 func (t *turbineJsCLI) Build(ctx context.Context, appName string, platform bool) (string, error) {
-	// TODO: Handle the requirement of https://github.com/meroxa/turbine-js.git being installed
-	// cd into the path first
-	cmd := utils.RunTurbineJS(ctx, "test", t.appPath)
-	stdOut, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
-	t.logger.Info(ctx, stdOut)
-	return "", err
+	return "", nil
 }
 
 func (t *turbineJsCLI) CleanUpTempBuildLocation(ctx context.Context) error {

--- a/cmd/meroxa/turbine/javascript/run.go
+++ b/cmd/meroxa/turbine/javascript/run.go
@@ -1,8 +1,15 @@
 package turbinejs
 
-import "context"
+import (
+	"context"
 
+	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
+)
+
+// Run calls turbine-js to exercise the app.
 func (t *turbineJsCLI) Run(ctx context.Context) (err error) {
-	_, err = t.Build(ctx, "", false)
+	cmd := utils.RunTurbineJS(ctx, "test", t.appPath)
+	stdOut, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	t.logger.Info(ctx, stdOut)
 	return err
 }


### PR DESCRIPTION
…call during deploy

## Description of change

the Javascript Build() was never really doing a build, but a run. Caused some confusion with the deploy refactor. 

Fixes https://github.com/meroxa/product/issues/564

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
