### PR TITLE
Make sure `hasfunctions` via turbine-js uses app path

### DIFF
--- a/cmd/meroxa/turbine/javascript/deploy.go
+++ b/cmd/meroxa/turbine/javascript/deploy.go
@@ -13,13 +13,13 @@ import (
 	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
 )
 
-func (t *turbineJsCLI) NeedsToBuild(ctx context.Context, path string) (bool, error) {
-	cmd := utils.RunTurbineJS(ctx, "hasfunctions", path)
+func (t *turbineJsCLI) NeedsToBuild(ctx context.Context, appName string) (bool, error) {
+	cmd := utils.RunTurbineJS(ctx, "hasfunctions", t.appPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		err := fmt.Errorf(
 			"unable to determine if the Meroxa Application at %s has a Process; %s",
-			path,
+			t.appPath,
 			string(output))
 		return false, err
 	}
@@ -29,7 +29,7 @@ func (t *turbineJsCLI) NeedsToBuild(ctx context.Context, path string) (bool, err
 	if match == nil || len(match) < 2 {
 		err := fmt.Errorf(
 			"unable to determine if the Meroxa Application at %s has a Process; %s",
-			path,
+			t.appPath,
 			string(output))
 		return false, err
 	}


### PR DESCRIPTION
## Description of change
Fixes the hasfunctions command to use the app path and not the app name. 

<!-- Provide a brief description of the change, what it is and why it was made below.* -->

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
