### PR TITLE
chore: Upgrade to latest turbine-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-go v0.0.0-20220914094650-33161f78b4f1
+	github.com/meroxa/turbine-go v0.0.0-20220916102051-afeafade0815
 	github.com/stretchr/testify v1.8.0
 	github.com/volatiletech/null/v8 v8.1.2
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/meroxa/meroxa-go v0.0.0-20220912230249-20686297f457 h1:+ZwU/WVSFwfoZish4Siiv1/6oObE5zffKl1cocU19/I=
 github.com/meroxa/meroxa-go v0.0.0-20220912230249-20686297f457/go.mod h1:qczCsZeXwn2R+JeEVjPkgtIMGROQ1Si8ox+OC2nfOYg=
-github.com/meroxa/turbine-go v0.0.0-20220914094650-33161f78b4f1 h1:u8vX683YPLvKtxtfJQBBWX+FDuO7c0C2asclv/GPv6E=
-github.com/meroxa/turbine-go v0.0.0-20220914094650-33161f78b4f1/go.mod h1:kjatgrAl5+fvXEnNO3GL5CImR+Yuiyd2iTCD+ceM+C4=
+github.com/meroxa/turbine-go v0.0.0-20220916102051-afeafade0815 h1:LK1pZvQ1cVFZCePSPqypS/EbszzoxqkSaW6L1qbaMX0=
+github.com/meroxa/turbine-go v0.0.0-20220916102051-afeafade0815/go.mod h1:kjatgrAl5+fvXEnNO3GL5CImR+Yuiyd2iTCD+ceM+C4=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -193,7 +193,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-go v0.0.0-20220914094650-33161f78b4f1
+# github.com/meroxa/turbine-go v0.0.0-20220916102051-afeafade0815
 ## explicit; go 1.18
 github.com/meroxa/turbine-go
 github.com/meroxa/turbine-go/deploy


### PR DESCRIPTION
The following commands were run to generate changes: go get -u github.com/meroxa/turbine-go@latest and make gomod