### PR TITLE
Include deployment output logs in app logs

### DIFF
--- a/cmd/meroxa/root/apps/logs.go
+++ b/cmd/meroxa/root/apps/logs.go
@@ -74,9 +74,9 @@ func (l *Logs) Docs() builder.Docs {
 }
 
 func (l *Logs) Execute(ctx context.Context) error {
-	app, err := l.client.GetApplication(ctx, l.args.NameOrUUID)
-	if err != nil {
-		return err
+	app, getErr := l.client.GetApplication(ctx, l.args.NameOrUUID)
+	if getErr != nil {
+		return getErr
 	}
 
 	connectors := make([]*display.AppExtendedConnector, 0)

--- a/cmd/meroxa/root/apps/logs.go
+++ b/cmd/meroxa/root/apps/logs.go
@@ -53,6 +53,7 @@ type applicationLogsClient interface {
 	GetConnectorLogs(ctx context.Context, nameOrID string) (*http.Response, error)
 	GetFunction(ctx context.Context, nameOrUUID string) (*meroxa.Function, error)
 	GetFunctionLogs(ctx context.Context, nameOrUUID string) (*http.Response, error)
+	GetLatestDeployment(ctx context.Context, appName string) (*meroxa.Deployment, error)
 	GetResourceByNameOrID(ctx context.Context, nameOrID string) (*meroxa.Resource, error)
 }
 
@@ -121,7 +122,13 @@ func (l *Logs) Execute(ctx context.Context) error {
 		function.Logs = buf.String()
 		functions = append(functions, function)
 	}
-	output := display.AppLogsTable(resources, connectors, functions)
+
+	deployment, err := l.client.GetLatestDeployment(ctx, app.Name)
+	if err != nil {
+		return err
+	}
+
+	output := display.AppLogsTable(resources, connectors, functions, deployment)
 
 	l.logger.Info(ctx, output)
 	l.logger.JSON(ctx, app)

--- a/cmd/meroxa/root/apps/logs_test.go
+++ b/cmd/meroxa/root/apps/logs_test.go
@@ -120,6 +120,10 @@ func TestApplicationLogsExecution(t *testing.T) {
 		{Name: null.StringFrom("fun1")},
 	}
 
+	deployment := &meroxa.Deployment{
+		UUID:   "ghi-jkl",
+		Status: meroxa.DeploymentStatus{Details: null.StringFrom("deployment in progress")}}
+
 	client.EXPECT().GetApplication(ctx, a.Name).Return(&a, nil)
 	client.EXPECT().GetConnectorByNameOrID(ctx, "conn1").
 		Return(&meroxa.Connector{Name: "conn1", ResourceName: "res1"}, nil)
@@ -129,6 +133,7 @@ func TestApplicationLogsExecution(t *testing.T) {
 	client.EXPECT().GetConnectorLogs(ctx, "conn2").Return(res2, nil)
 	client.EXPECT().GetFunction(ctx, "fun1").Return(functions[0], nil)
 	client.EXPECT().GetFunctionLogs(ctx, "fun1").Return(res3, nil)
+	client.EXPECT().GetLatestDeployment(ctx, a.Name).Return(deployment, nil)
 
 	dc := &Logs{
 		client: client,
@@ -142,7 +147,7 @@ func TestApplicationLogsExecution(t *testing.T) {
 	}
 
 	gotLeveledOutput := logger.LeveledOutput()
-	wantLeveledOutput := display.AppLogsTable(a.Resources, connectors, functions)
+	wantLeveledOutput := display.AppLogsTable(a.Resources, connectors, functions, deployment)
 
 	if !strings.Contains(gotLeveledOutput, wantLeveledOutput) {
 		t.Fatalf(cmp.Diff(wantLeveledOutput, gotLeveledOutput))

--- a/utils/display/apps.go
+++ b/utils/display/apps.go
@@ -94,7 +94,7 @@ func AppTable(app *meroxa.Application, resources []*meroxa.Resource, connectors 
 	return output
 }
 
-func AppLogsTable(resources []meroxa.ApplicationResource, connectors []*AppExtendedConnector, functions []*meroxa.Function) string {
+func AppLogsTable(resources []meroxa.ApplicationResource, connectors []*AppExtendedConnector, functions []*meroxa.Function, deployment *meroxa.Deployment) string {
 	var r meroxa.ApplicationResource
 	var subTable string
 
@@ -132,8 +132,12 @@ func AppLogsTable(resources []meroxa.ApplicationResource, connectors []*AppExten
 
 	for _, f := range functions {
 		if f.Logs != "" {
-			subTable += fmt.Sprintf("\n%s (function)\n\t%s\n", r.Name.String, f.Logs)
+			subTable += fmt.Sprintf("\n%s (function)\n\t%s\n", f.Name, f.Logs)
 		}
+	}
+
+	if deployment != nil && deployment.Status.Details.Valid {
+		subTable += fmt.Sprintf("\n%s (deployment)\n\t%s\n", deployment.UUID, deployment.Status.Details.String)
 	}
 
 	return subTable

--- a/utils/display/apps.go
+++ b/utils/display/apps.go
@@ -94,7 +94,11 @@ func AppTable(app *meroxa.Application, resources []*meroxa.Resource, connectors 
 	return output
 }
 
-func AppLogsTable(resources []meroxa.ApplicationResource, connectors []*AppExtendedConnector, functions []*meroxa.Function, deployment *meroxa.Deployment) string {
+func AppLogsTable(
+	resources []meroxa.ApplicationResource,
+	connectors []*AppExtendedConnector,
+	functions []*meroxa.Function,
+	deployment *meroxa.Deployment) string {
 	var r meroxa.ApplicationResource
 	var subTable string
 

--- a/utils/display/apps_test.go
+++ b/utils/display/apps_test.go
@@ -48,7 +48,11 @@ func TestAppLogsTable(t *testing.T) {
 		{Name: "fun1", UUID: "abc-def", Status: meroxa.FunctionStatus{State: "running"}, Logs: log},
 	}
 
-	out := AppLogsTable(app.Resources, connectors, functions)
+	deployment := &meroxa.Deployment{
+		UUID:   "ghi-jkl",
+		Status: meroxa.DeploymentStatus{Details: null.StringFrom("deployment in progress")}}
+
+	out := AppLogsTable(app.Resources, connectors, functions, deployment)
 
 	if !strings.Contains(out, "custom log") {
 		t.Errorf("expected %q to be shown", log)
@@ -60,5 +64,13 @@ func TestAppLogsTable(t *testing.T) {
 
 	if !strings.Contains(out, fmt.Sprintf("%s (destination)", res2)) {
 		t.Errorf("expected %q to be shown as a destination", res2)
+	}
+
+	if !strings.Contains(out, fmt.Sprintf("%s (function)", functions[0].Name)) {
+		t.Errorf("expected %q to be shown as a function", functions[0].Name)
+	}
+
+	if !strings.Contains(out, fmt.Sprintf("%s (deployment)", deployment.UUID)) {
+		t.Errorf("expected %q to be shown as a deployment", deployment.UUID)
 	}
 }


### PR DESCRIPTION
## Description of change

<!-- Provide a brief description of the change, what it is and why it was made below.* -->

Fixes https://github.com/meroxa/product/issues/552

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [x]  Tested in minikube

## Demo

### Before
Note: 
- connector and function logs were shortened for purpose of example
- function name is not present, and resource name is used instead

```
➜  cli git:(master) meroxa apps logs test-app

important-data (source)
	[2022-09-30T18:25:38Z] Executing prepared statement with incrementing value = 11[2022-09-30T18:25:38Z] Resetting querier TimestampIncrementingTableQuerier{table="public"."sequences", query='null', topicPrefix='resource-2-104604-', incrementingColumn='id', timestampColumns=[]}[2022-09-30T18:25:43Z] Checking for next block of results from TimestampIncrementingTableQuerier{table="public"."sequences", query='null', topicPrefix='resource-2-104604-', 
...

pg (destination)
	[2022-09-30T18:14:23Z] Attempting to open connection #1 to PostgreSql[2022-09-30T18:14:23Z] JdbcDbWriter Connected[2022-09-30T18:14:23Z] buffered records in list 0[2022-09-30T18:14:23Z] Checking PostgreSql dialect for existence of table "public"."account_clone"[2022-09-30T18:14:23Z] Using PostgreSql dialect table 
...

pg (function)
	[2022-09-30T18:14:23Z] 2022/09/30 18:14:23 Received key:"{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":1}"  value:"{\"payload\":{\"id\":1},\"schema\":{\"fields\":[{\"field\":\"id\",\"optional\":false,\"type\":\"int32\"}],\"name\":\"sequences\",\"optional\":false,\"type\":\"struct\"}}"  timestamp:1664561330
...
```

### After with deployment logs
Note: connector and function logs were shortened for purpose of example
```
➜  cli git:(include-deploy-app-logs) meroxa apps logs test-app

important-data (source)
	[2022-09-30T18:13:50Z] WorkerSourceTask{id=connector-3-0} Committing offsets[2022-09-30T18:13:50Z] WorkerSourceTask{id=connector-3-0} flushing 0 outstanding messages for offset commit[2022-09-30T18:13:53Z] Checking for next block of results from TimestampIncrementingTableQuerier{table="public"."sequences", query='null', topicPrefix='resource-2-104604-', incrementingColumn='id', timestampColumns=[]}[2022-09-30T18:13:53Z] 
...

pg (destination)
	[2022-09-30T18:14:23Z] Received 1 records. First record kafka coordinates:(resource-2-104604-sequences-daac15f5-9c3a-4364-9b7c-0b4760ee2397-0-0). Writing them to the database...[2022-09-30T18:14:23Z] Attempting to open connection #1 to PostgreSql[2022-09-30T18:14:23Z] JdbcDbWriter Connected[2022-09-30T18:14:23Z] buffered records in list 0[2022-09-30T18:14:23Z] Checking PostgreSql dialect for existence of table "public"."account_clone"
...

demo (function)
	[2022-09-30T18:14:23Z] 2022/09/30 18:14:23 Received key:"{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":1}"  value:"{\"payload\":{\"id\":1},\"schema\":{\"fields\":[{\"field\":\"id\",\"optional\":false,\"type\":\"int32\"}],\"name\":\"sequences\",\"optional\":false,\"type\":\"struct\"}}"  timestamp:1664561330
[2022-09-30T18:14:23Z] 2022/09/30 18:14:23 Received key:"{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":2}"  value:"{\"payload\":{\"id\":2},\"schema\":{\"fields\":[{\"field\":\"id\",\"optional\":false,\"type\":\"int32\"}],\"name\":\"sequences\",\"optional\":false,\"type\":\"struct\"}}"  timestamp:1664561330
...

728a004c-8482-4b3a-8c63-3897d668e844 (deployment)
	this is a deployment log
```

### After without deployment logs
Note: connector and function logs were shortened for purpose of example

```
➜  cli git:(include-deploy-app-logs) meroxa apps logs test-app                                                        

important-data (source)
	[2022-09-30T18:17:50Z] WorkerSourceTask{id=connector-3-0} Committing offsets[2022-09-30T18:17:50Z] WorkerSourceTask{id=connector-3-0} flushing 0 outstanding messages for offset commit[2022-09-30T18:17:54Z] Checking for next block of results from TimestampIncrementingTableQuerier{table="public"."sequences", query='null', 
...

pg (destination)
	[2022-09-30T18:14:23Z] Attempting to open connection #1 to PostgreSql[2022-09-30T18:14:23Z] JdbcDbWriter Connected[2022-09-30T18:14:23Z] buffered records in list 0[2022-09-30T18:14:23Z] Checking PostgreSql dialect for existence of table "public"."account_clone"[2022-09-30T18:14:23Z] Using PostgreSql dialect table 
...

demo (function)
	[2022-09-30T18:14:23Z] 2022/09/30 18:14:23 Received key:"{\"schema\":{\"type\":\"int32\",\"optional\":false},\"payload\":1}"  value:"{\"payload\":{\"id\":1},\"schema\":{\"fields\":[{\"field\":\"id\",\"optional\":false,\"type\":\"int32\"}],\"name\":\"sequences\",\"optional\":false,\"type\":\"struct\"}}"  timestamp:1664561330
...
```

## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
