### PR TITLE
Ensure deployment spec is json

### DIFF
--- a/cmd/meroxa/root/apps/deploy_test.go
+++ b/cmd/meroxa/root/apps/deploy_test.go
@@ -690,7 +690,10 @@ func TestDeployApp(t *testing.T) {
 	imageName := "doc.ker:latest"
 	gitSha := "aa:bb:cc:dd"
 	specVersion := "latest"
-	spec := "{}"
+	specStr := `{"metadata": "metadata"}`
+	spec := map[string]interface{}{
+		"metadata": "metadata",
+	}
 	err := fmt.Errorf("nope")
 
 	tests := []struct {
@@ -724,7 +727,7 @@ func TestDeployApp(t *testing.T) {
 				mockTurbineCLI := turbine_mock.NewMockCLI(ctrl)
 				mockTurbineCLI.EXPECT().
 					Deploy(ctx, imageName, appName, gitSha, specVersion).
-					Return(spec, err)
+					Return(specStr, err)
 				return mockTurbineCLI
 			},
 			err: err,
@@ -748,7 +751,7 @@ func TestDeployApp(t *testing.T) {
 				mockTurbineCLI := turbine_mock.NewMockCLI(ctrl)
 				mockTurbineCLI.EXPECT().
 					Deploy(ctx, imageName, appName, gitSha, specVersion).
-					Return(spec, nil)
+					Return(specStr, nil)
 				return mockTurbineCLI
 			},
 			err: err,

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20221003164709-2ee53200b21e
+	github.com/meroxa/meroxa-go v0.0.0-20221004210210-bbd506fa518b
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,8 @@ github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
-github.com/meroxa/meroxa-go v0.0.0-20221003164709-2ee53200b21e h1:PGaUh6pkpEpIyiUYmRvOm21JA/yQAjDbbjtAJmo+Coc=
-github.com/meroxa/meroxa-go v0.0.0-20221003164709-2ee53200b21e/go.mod h1:OdTP4P/yHcTAqOE86kDXoTTLqC1Vj+/PFMG41kOcmhI=
+github.com/meroxa/meroxa-go v0.0.0-20221004210210-bbd506fa518b h1:DQfmgUyJ85OZV1CpHaALV9aJyyoMdgbXAXetyfWq+GU=
+github.com/meroxa/meroxa-go v0.0.0-20221004210210-bbd506fa518b/go.mod h1:OdTP4P/yHcTAqOE86kDXoTTLqC1Vj+/PFMG41kOcmhI=
 github.com/meroxa/turbine-go v0.0.0-20220929144639-55053b3b6c6b h1:6vwbdSoVn219nmAHPfNGgPlCVVVr/sNhjncnAP53PaE=
 github.com/meroxa/turbine-go v0.0.0-20220929144639-55053b3b6c6b/go.mod h1:oOFZFDs/Vt6bpSLfBtcs7mAL+DuX63nSoyWBVMzbYIM=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/deployment.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/deployment.go
@@ -24,22 +24,22 @@ type DeploymentStatus struct {
 }
 
 type Deployment struct {
-	UUID        string           `json:"uuid"`
-	GitSha      string           `json:"git_sha"`
-	Application EntityIdentifier `json:"application"`
-	CreatedAt   time.Time        `json:"created_at"`
-	DeletedAt   time.Time        `json:"deleted_at,omitempty"`
-	Status      DeploymentStatus `json:"status"`
-	Spec        string           `json:"spec,omitempty"`
-	SpecVersion string           `json:"spec_version,omitempty"`
-	CreatedBy   string           `json:"created_by"`
+	UUID        string                 `json:"uuid"`
+	GitSha      string                 `json:"git_sha"`
+	Application EntityIdentifier       `json:"application"`
+	CreatedAt   time.Time              `json:"created_at"`
+	DeletedAt   time.Time              `json:"deleted_at,omitempty"`
+	Status      DeploymentStatus       `json:"status"`
+	Spec        map[string]interface{} `json:"spec,omitempty"`
+	SpecVersion string                 `json:"spec_version,omitempty"`
+	CreatedBy   string                 `json:"created_by"`
 }
 
 type CreateDeploymentInput struct {
-	GitSha      string           `json:"git_sha"`
-	Application EntityIdentifier `json:"application"`
-	Spec        string           `json:"spec,omitempty"`
-	SpecVersion string           `json:"spec_version,omitempty"`
+	GitSha      string                 `json:"git_sha"`
+	Application EntityIdentifier       `json:"application"`
+	Spec        map[string]interface{} `json:"spec,omitempty"`
+	SpecVersion string                 `json:"spec_version,omitempty"`
 }
 
 func (c *client) GetLatestDeployment(ctx context.Context, appIdentifier string) (*Deployment, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,7 +176,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20221003164709-2ee53200b21e
+# github.com/meroxa/meroxa-go v0.0.0-20221004210210-bbd506fa518b
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock


### PR DESCRIPTION
## Description of change

Ensure deployment spec is json

Currently, cli sends the spec as a string json, and not a json blob:
```
"{\"connectors\":[{\"type\":\"source\",\"resource\":\"pg\",\"collection\":\"sequences\"},{\"type\":\"destination\",\"resource\":\"pg\",\"collection\":\"sequences_greeting\"}],\"definition\":{\"git_sha\":\"353b34ac6917dcdb10cc00b74010f9222914518c\\n\",\"metadata\":{\"turbine\":{\"language\":\"golang\",\"version\":\"1.19.1\"},\"spec_version\":\"0.1.1\"}}}"
```

We want the json to be parsed into a json blob instead:
```
 {"connectors": [{"type": "source", "resource": "pg", "collection": "sequences"}, {"type": "destination", "resource": "pg", "collection": "sequences_greeting"}], "definition": {"git_sha": "353b34ac6917dcdb10cc00b74010f9222914518c\n", "metadata": {"turbine": {"version": "1.19.1", "language": "golang"}, "spec_version": "0.1.1"}}}
```

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [x]  Tested in minikube

