### PR TITLE
fix: wrong auto-close message

### DIFF
--- a/cmd/meroxa/root/auth/login.go
+++ b/cmd/meroxa/root/auth/login.go
@@ -135,18 +135,17 @@ func (l *Login) authorizeUser(ctx context.Context, clientID, authDomain, audienc
 		// return an indication of success to the caller
 		_, _ = io.WriteString(w, `
 			<html>
-				<div style="width:100%!; color:#282D39; display:flex; flex-direction: column; justify-content: center; align-items:center;">
-					<img src="https://meroxa-public-assets.s3.us-east-2.amazonaws.com/MeroxaTransparent%402x.png" alt="Meroxa"
+				<div style="width:100%!; color:#282D39; display:flex; flex-direction: column; justify-content:center; 
+						align-items:center; margin-top:40px;">
+					<img src="https://meroxa-public-assets.s3.us-east-2.amazonaws.com/MeroxaTransparent%402x.png" alt="Meroxa logo"
 						 width="150" padding="2000px">
 					<h1 style="margin-top:40px; font-size:43px; text-align:left; color: #282D39; font-family: Arial; font-weight: bold;">
-						Successfully logged in</h1>
-					<p style="margin-top:17px; font-size:18px; text-align:left; color: #282D39; font-family: Arial;">You can now return
-						to the CLI. This will auto-close.</p></div>
-				<script>
-					window.onload = function () {
-						setTimeout(this.close, 5000)
-					}
-				</script>
+						Successfully logged in
+					</h1>
+					<p style="margin-top:17px; font-size:18px; text-align:left; color: #282D39; font-family: Arial;">
+						You can close this window now and return to the CLI.
+					</p>
+				</div>
 			</html>`)
 
 		l.logger.Infof(ctx, "Successfully logged in.")


### PR DESCRIPTION
## Description of change

This in fact is not working. After a bit of investigation, I couldn't figure out the root cause. Considering this is not highly critical, I think it's best simply update the wording for now.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- In different web browsers.

## Demo

**Before**

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/306015/195562072-45ea1617-f900-41fb-b8c7-e931e67377a7.png">

**After this PR**

<img width="915" alt="image" src="https://user-images.githubusercontent.com/306015/195560900-12931f4e-6726-4df5-8f30-7fd0f9e12ec8.png">

## Additional references

Reported by @hariso in our #CLI slack channel.