### PR TITLE
fix: restore apps logs without IR

### DIFF
--- a/cmd/meroxa/root/apps/logs.go
+++ b/cmd/meroxa/root/apps/logs.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/meroxa/cli/utils/display"
 
@@ -124,7 +125,7 @@ func (l *Logs) Execute(ctx context.Context) error {
 	}
 
 	deployment, err := l.client.GetLatestDeployment(ctx, app.Name)
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "user lacks permission") {
 		return err
 	}
 


### PR DESCRIPTION
## Description of change

Do not require feature flags for apps logs

Fixes https://github.com/meroxa/cli/issues/487

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo
BEFORE
![Screenshot from 2022-10-17 13-48-39](https://user-images.githubusercontent.com/12731615/196280503-8cb214b5-961f-4241-b1b5-a8d64daf50ed.png)


AFTER
![Screenshot from 2022-10-17 13-49-38](https://user-images.githubusercontent.com/12731615/196280518-9b5bc175-d1ef-4775-9ab2-cf8ef091bf43.png)




## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
