### PR TITLE
Revert "renaming usage and docs"

### DIFF
--- a/cmd/meroxa/global/client.go
+++ b/cmd/meroxa/global/client.go
@@ -119,10 +119,10 @@ func SetAccountUUID(client meroxa.Client) error {
 	// loading current user accounts
 	accounts, err := client.ListAccounts(context.Background())
 	if err != nil {
-		return fmt.Errorf("meroxa: could not fetch user projects: %v", err)
+		return fmt.Errorf("meroxa: could not fetch user accounts: %v", err)
 	}
 	if len(accounts) <= 0 {
-		return fmt.Errorf("meroxa: user doesn't have any projects, please create or accept them in the web dashboard")
+		return fmt.Errorf("meroxa: no accounts created for this account, please create them in the website")
 	}
 	// write account uuid
 	Config.Set(UserAccountUUID, accounts[0].UUID) // TODO add account ID

--- a/cmd/meroxa/root/account/accounts.go
+++ b/cmd/meroxa/root/account/accounts.go
@@ -22,8 +22,6 @@ import (
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 )
 
-// Account implement the projects management onto the Meroxa platform.
-// Accounts on the platform were renamed to Projects, to fix the information architecture.
 type Account struct{}
 
 var (
@@ -33,16 +31,16 @@ var (
 )
 
 func (*Account) Aliases() []string {
-	return []string{"projects"}
+	return []string{"accounts"}
 }
 
 func (*Account) Usage() string {
-	return "project"
+	return "account"
 }
 
 func (*Account) Docs() builder.Docs {
 	return builder.Docs{
-		Short: "Manage Meroxa Projects",
+		Short: "Manage Meroxa Accounts",
 		Beta:  true,
 	}
 }

--- a/cmd/meroxa/root/account/list.go
+++ b/cmd/meroxa/root/account/list.go
@@ -58,7 +58,7 @@ func (l *List) Config(cfg config.Config) {
 
 func (l *List) Docs() builder.Docs {
 	return builder.Docs{
-		Short: "List available projects",
+		Short: "List Turbine Data Applications",
 		Beta:  true,
 	}
 }

--- a/cmd/meroxa/root/account/set.go
+++ b/cmd/meroxa/root/account/set.go
@@ -53,7 +53,7 @@ func (s *Set) Usage() string {
 
 func (s *Set) Docs() builder.Docs {
 	return builder.Docs{
-		Short: "Set active project",
+		Short: "Set active account",
 	}
 }
 
@@ -82,7 +82,7 @@ func (s *Set) Execute(ctx context.Context) error {
 		}
 	}
 	if !found {
-		return fmt.Errorf("'%s' is an invalid project UUID", s.args.UUID)
+		return fmt.Errorf("'%s' is an invalid account UUID", s.args.UUID)
 	}
 	s.config.Set(global.UserAccountUUID, uuid)
 
@@ -95,7 +95,7 @@ func (s *Set) Logger(logger log.Logger) {
 
 func (s *Set) ParseArgs(args []string) error {
 	if len(args) < 1 {
-		return errors.New("requires project UUID")
+		return errors.New("requires account UUID or name")
 	}
 
 	s.args.UUID = args[0]

--- a/docs/cmd/md/meroxa.md
+++ b/docs/cmd/md/meroxa.md
@@ -25,6 +25,7 @@ meroxa resources list --types
 
 ### SEE ALSO
 
+* [meroxa account](meroxa_account.md)	 - Manage Meroxa Accounts (Beta)
 * [meroxa api](meroxa_api.md)	 - Invoke Meroxa API
 * [meroxa apps](meroxa_apps.md)	 - Manage Turbine Data Applications (Beta)
 * [meroxa auth](meroxa_auth.md)	 - Authentication commands for Meroxa
@@ -37,7 +38,6 @@ meroxa resources list --types
 * [meroxa login](meroxa_login.md)	 - Login or Sign up to the Meroxa Platform
 * [meroxa logout](meroxa_logout.md)	 - Clears local login credentials of the Meroxa Platform
 * [meroxa open](meroxa_open.md)	 - Open in a web browser
-* [meroxa project](meroxa_project.md)	 - Manage Meroxa Projects (Beta)
 * [meroxa resources](meroxa_resources.md)	 - Manage resources on Meroxa
 * [meroxa transforms](meroxa_transforms.md)	 - Manage transforms on Meroxa
 * [meroxa version](meroxa_version.md)	 - Display the Meroxa CLI version

--- a/docs/cmd/md/meroxa_account.md
+++ b/docs/cmd/md/meroxa_account.md
@@ -1,22 +1,11 @@
----
-createdAt: 
-updatedAt: 
-title: "meroxa project set"
-slug: meroxa-project-set
-url: /cli/cmd/meroxa-project-set/
----
-## meroxa project set
+## meroxa account
 
-Set active project
-
-```
-meroxa project set [flags]
-```
+Manage Meroxa Accounts (Beta)
 
 ### Options
 
 ```
-  -h, --help   help for set
+  -h, --help   help for account
 ```
 
 ### Options inherited from parent commands
@@ -30,5 +19,7 @@ meroxa project set [flags]
 
 ### SEE ALSO
 
-* [meroxa project](/cli/cmd/meroxa-project/)	 - Manage Meroxa Projects (Beta)
+* [meroxa](meroxa.md)	 - The Meroxa CLI
+* [meroxa account list](meroxa_account_list.md)	 - List Turbine Data Applications (Beta)
+* [meroxa account set](meroxa_account_set.md)	 - Set current active account connector
 

--- a/docs/cmd/md/meroxa_account_list.md
+++ b/docs/cmd/md/meroxa_account_list.md
@@ -1,11 +1,16 @@
-## meroxa project
+## meroxa account list
 
-Manage Meroxa Projects (Beta)
+List Turbine Data Applications (Beta)
+
+```
+meroxa account list [flags]
+```
 
 ### Options
 
 ```
-  -h, --help   help for project
+  -h, --help         help for list
+      --no-headers   display output without headers
 ```
 
 ### Options inherited from parent commands
@@ -19,7 +24,5 @@ Manage Meroxa Projects (Beta)
 
 ### SEE ALSO
 
-* [meroxa](meroxa.md)	 - The Meroxa CLI
-* [meroxa project list](meroxa_project_list.md)	 - List available projects (Beta)
-* [meroxa project set](meroxa_project_set.md)	 - Set active project
+* [meroxa account](meroxa_account.md)	 - Manage Meroxa Accounts (Beta)
 

--- a/docs/cmd/md/meroxa_account_set.md
+++ b/docs/cmd/md/meroxa_account_set.md
@@ -1,9 +1,9 @@
-## meroxa project set
+## meroxa account set
 
-Set active project
+Set current active account connector
 
 ```
-meroxa project set [flags]
+meroxa account set [flags]
 ```
 
 ### Options
@@ -23,5 +23,5 @@ meroxa project set [flags]
 
 ### SEE ALSO
 
-* [meroxa project](meroxa_project.md)	 - Manage Meroxa Projects (Beta)
+* [meroxa account](meroxa_account.md)	 - Manage Meroxa Accounts (Beta)
 

--- a/docs/cmd/www/meroxa-account-list.md
+++ b/docs/cmd/www/meroxa-account-list.md
@@ -1,16 +1,16 @@
 ---
 createdAt: 
 updatedAt: 
-title: "meroxa project list"
-slug: meroxa-project-list
-url: /cli/cmd/meroxa-project-list/
+title: "meroxa account list"
+slug: meroxa-account-list
+url: /cli/cmd/meroxa-account-list/
 ---
-## meroxa project list
+## meroxa account list
 
-List available projects (Beta)
+List Turbine Data Applications (Beta)
 
 ```
-meroxa project list [flags]
+meroxa account list [flags]
 ```
 
 ### Options
@@ -31,5 +31,5 @@ meroxa project list [flags]
 
 ### SEE ALSO
 
-* [meroxa project](/cli/cmd/meroxa-project/)	 - Manage Meroxa Projects (Beta)
+* [meroxa account](/cli/cmd/meroxa-account/)	 - Manage Meroxa Accounts (Beta)
 

--- a/docs/cmd/www/meroxa-account-set.md
+++ b/docs/cmd/www/meroxa-account-set.md
@@ -1,16 +1,22 @@
-## meroxa project list
+---
+createdAt: 
+updatedAt: 
+title: "meroxa account set"
+slug: meroxa-account-set
+url: /cli/cmd/meroxa-account-set/
+---
+## meroxa account set
 
-List available projects (Beta)
+Set current active account connector
 
 ```
-meroxa project list [flags]
+meroxa account set [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help         help for list
-      --no-headers   display output without headers
+  -h, --help   help for set
 ```
 
 ### Options inherited from parent commands
@@ -24,5 +30,5 @@ meroxa project list [flags]
 
 ### SEE ALSO
 
-* [meroxa project](meroxa_project.md)	 - Manage Meroxa Projects (Beta)
+* [meroxa account](/cli/cmd/meroxa-account/)	 - Manage Meroxa Accounts (Beta)
 

--- a/docs/cmd/www/meroxa-account.md
+++ b/docs/cmd/www/meroxa-account.md
@@ -1,18 +1,18 @@
 ---
 createdAt: 
 updatedAt: 
-title: "meroxa project"
-slug: meroxa-project
-url: /cli/cmd/meroxa-project/
+title: "meroxa account"
+slug: meroxa-account
+url: /cli/cmd/meroxa-account/
 ---
-## meroxa project
+## meroxa account
 
-Manage Meroxa Projects (Beta)
+Manage Meroxa Accounts (Beta)
 
 ### Options
 
 ```
-  -h, --help   help for project
+  -h, --help   help for account
 ```
 
 ### Options inherited from parent commands
@@ -27,6 +27,6 @@ Manage Meroxa Projects (Beta)
 ### SEE ALSO
 
 * [meroxa](/cli/cmd/meroxa/)	 - The Meroxa CLI
-* [meroxa project list](/cli/cmd/meroxa-project-list/)	 - List available projects (Beta)
-* [meroxa project set](/cli/cmd/meroxa-project-set/)	 - Set active project
+* [meroxa account list](/cli/cmd/meroxa-account-list/)	 - List Turbine Data Applications (Beta)
+* [meroxa account set](/cli/cmd/meroxa-account-set/)	 - Set current active account connector
 

--- a/docs/cmd/www/meroxa.md
+++ b/docs/cmd/www/meroxa.md
@@ -32,6 +32,7 @@ meroxa resources list --types
 
 ### SEE ALSO
 
+* [meroxa account](/cli/cmd/meroxa-account/)	 - Manage Meroxa Accounts (Beta)
 * [meroxa api](/cli/cmd/meroxa-api/)	 - Invoke Meroxa API
 * [meroxa apps](/cli/cmd/meroxa-apps/)	 - Manage Turbine Data Applications (Beta)
 * [meroxa auth](/cli/cmd/meroxa-auth/)	 - Authentication commands for Meroxa
@@ -44,7 +45,6 @@ meroxa resources list --types
 * [meroxa login](/cli/cmd/meroxa-login/)	 - Login or Sign up to the Meroxa Platform
 * [meroxa logout](/cli/cmd/meroxa-logout/)	 - Clears local login credentials of the Meroxa Platform
 * [meroxa open](/cli/cmd/meroxa-open/)	 - Open in a web browser
-* [meroxa project](/cli/cmd/meroxa-project/)	 - Manage Meroxa Projects (Beta)
 * [meroxa resources](/cli/cmd/meroxa-resources/)	 - Manage resources on Meroxa
 * [meroxa transforms](/cli/cmd/meroxa-transforms/)	 - Manage transforms on Meroxa
 * [meroxa version](/cli/cmd/meroxa-version/)	 - Display the Meroxa CLI version

--- a/etc/completion/meroxa.completion.sh
+++ b/etc/completion/meroxa.completion.sh
@@ -360,6 +360,125 @@ __meroxa_handle_word()
     __meroxa_handle_word
 }
 
+_meroxa_account_help()
+{
+    last_command="meroxa_account_help"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    has_completion_function=1
+    noun_aliases=()
+}
+
+_meroxa_account_list()
+{
+    last_command="meroxa_account_list"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--no-headers")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_account_set()
+{
+    last_command="meroxa_account_set"
+
+    command_aliases=()
+
+    commands=()
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
+_meroxa_account()
+{
+    last_command="meroxa_account"
+
+    command_aliases=()
+
+    commands=()
+    commands+=("help")
+    commands+=("list")
+    if [[ -z "${BASH_VERSION:-}" || "${BASH_VERSINFO[0]:-}" -gt 3 ]]; then
+        command_aliases+=("ls")
+        aliashash["ls"]="list"
+    fi
+    commands+=("set")
+
+    flags=()
+    two_word_flags=()
+    local_nonpersistent_flags=()
+    flags_with_completion=()
+    flags_completion=()
+
+    flags+=("--help")
+    flags+=("-h")
+    flags+=("--cli-config-file=")
+    two_word_flags+=("--cli-config-file")
+    flags+=("--debug")
+    flags+=("--json")
+    flags+=("--timeout=")
+    two_word_flags+=("--timeout")
+
+    must_have_one_flag=()
+    must_have_one_noun=()
+    noun_aliases=()
+}
+
 _meroxa_api()
 {
     last_command="meroxa_api"
@@ -1768,125 +1887,6 @@ _meroxa_open()
     noun_aliases=()
 }
 
-_meroxa_project_help()
-{
-    last_command="meroxa_project_help"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--cli-config-file=")
-    two_word_flags+=("--cli-config-file")
-    flags+=("--debug")
-    flags+=("--json")
-    flags+=("--timeout=")
-    two_word_flags+=("--timeout")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    has_completion_function=1
-    noun_aliases=()
-}
-
-_meroxa_project_list()
-{
-    last_command="meroxa_project_list"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-    flags+=("--no-headers")
-    flags+=("--cli-config-file=")
-    two_word_flags+=("--cli-config-file")
-    flags+=("--debug")
-    flags+=("--json")
-    flags+=("--timeout=")
-    two_word_flags+=("--timeout")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_meroxa_project_set()
-{
-    last_command="meroxa_project_set"
-
-    command_aliases=()
-
-    commands=()
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-    flags+=("--cli-config-file=")
-    two_word_flags+=("--cli-config-file")
-    flags+=("--debug")
-    flags+=("--json")
-    flags+=("--timeout=")
-    two_word_flags+=("--timeout")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
-_meroxa_project()
-{
-    last_command="meroxa_project"
-
-    command_aliases=()
-
-    commands=()
-    commands+=("help")
-    commands+=("list")
-    if [[ -z "${BASH_VERSION:-}" || "${BASH_VERSINFO[0]:-}" -gt 3 ]]; then
-        command_aliases+=("ls")
-        aliashash["ls"]="list"
-    fi
-    commands+=("set")
-
-    flags=()
-    two_word_flags=()
-    local_nonpersistent_flags=()
-    flags_with_completion=()
-    flags_completion=()
-
-    flags+=("--help")
-    flags+=("-h")
-    flags+=("--cli-config-file=")
-    two_word_flags+=("--cli-config-file")
-    flags+=("--debug")
-    flags+=("--json")
-    flags+=("--timeout=")
-    two_word_flags+=("--timeout")
-
-    must_have_one_flag=()
-    must_have_one_noun=()
-    noun_aliases=()
-}
-
 _meroxa_resources_create()
 {
     last_command="meroxa_resources_create"
@@ -2368,6 +2368,11 @@ _meroxa_root_command()
     command_aliases=()
 
     commands=()
+    commands+=("account")
+    if [[ -z "${BASH_VERSION:-}" || "${BASH_VERSINFO[0]:-}" -gt 3 ]]; then
+        command_aliases+=("accounts")
+        aliashash["accounts"]="account"
+    fi
     commands+=("api")
     commands+=("apps")
     if [[ -z "${BASH_VERSION:-}" || "${BASH_VERSINFO[0]:-}" -gt 3 ]]; then
@@ -2403,11 +2408,6 @@ _meroxa_root_command()
     commands+=("login")
     commands+=("logout")
     commands+=("open")
-    commands+=("project")
-    if [[ -z "${BASH_VERSION:-}" || "${BASH_VERSINFO[0]:-}" -gt 3 ]]; then
-        command_aliases+=("projects")
-        aliashash["projects"]="project"
-    fi
     commands+=("resources")
     if [[ -z "${BASH_VERSION:-}" || "${BASH_VERSINFO[0]:-}" -gt 3 ]]; then
         command_aliases+=("resource")

--- a/etc/man/man1/meroxa-account-list.1
+++ b/etc/man/man1/meroxa-account-list.1
@@ -1,25 +1,29 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
-meroxa-project - Manage Meroxa Projects (Beta)
+meroxa-account-list - List Turbine Data Applications (Beta)
 
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa project [flags]\fP
+\fBmeroxa account list [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
-Manage Meroxa Projects (Beta)
+List Turbine Data Applications (Beta)
 
 
 .SH OPTIONS
 .PP
 \fB-h\fP, \fB--help\fP[=false]
-	help for project
+	help for list
+
+.PP
+\fB--no-headers\fP[=false]
+	display output without headers
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -42,4 +46,4 @@ Manage Meroxa Projects (Beta)
 
 .SH SEE ALSO
 .PP
-\fBmeroxa(1)\fP, \fBmeroxa-project-list(1)\fP, \fBmeroxa-project-set(1)\fP
+\fBmeroxa-account(1)\fP

--- a/etc/man/man1/meroxa-account-set.1
+++ b/etc/man/man1/meroxa-account-set.1
@@ -1,29 +1,25 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
-meroxa-project-list - List available projects (Beta)
+meroxa-account-set - Set current active account connector
 
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa project list [flags]\fP
+\fBmeroxa account set [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
-List available projects (Beta)
+Set current active account connector
 
 
 .SH OPTIONS
 .PP
 \fB-h\fP, \fB--help\fP[=false]
-	help for list
-
-.PP
-\fB--no-headers\fP[=false]
-	display output without headers
+	help for set
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -46,4 +42,4 @@ List available projects (Beta)
 
 .SH SEE ALSO
 .PP
-\fBmeroxa-project(1)\fP
+\fBmeroxa-account(1)\fP

--- a/etc/man/man1/meroxa-account.1
+++ b/etc/man/man1/meroxa-account.1
@@ -1,25 +1,25 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
-meroxa-project-set - Set active project
+meroxa-account - Manage Meroxa Accounts (Beta)
 
 
 .SH SYNOPSIS
 .PP
-\fBmeroxa project set [flags]\fP
+\fBmeroxa account [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
-Set active project
+Manage Meroxa Accounts (Beta)
 
 
 .SH OPTIONS
 .PP
 \fB-h\fP, \fB--help\fP[=false]
-	help for set
+	help for account
 
 
 .SH OPTIONS INHERITED FROM PARENT COMMANDS
@@ -42,4 +42,4 @@ Set active project
 
 .SH SEE ALSO
 .PP
-\fBmeroxa-project(1)\fP
+\fBmeroxa(1)\fP, \fBmeroxa-account-list(1)\fP, \fBmeroxa-account-set(1)\fP

--- a/etc/man/man1/meroxa-api.1
+++ b/etc/man/man1/meroxa-api.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-deploy.1
+++ b/etc/man/man1/meroxa-apps-deploy.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-describe.1
+++ b/etc/man/man1/meroxa-apps-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-init.1
+++ b/etc/man/man1/meroxa-apps-init.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-list.1
+++ b/etc/man/man1/meroxa-apps-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-logs.1
+++ b/etc/man/man1/meroxa-apps-logs.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-remove.1
+++ b/etc/man/man1/meroxa-apps-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-run.1
+++ b/etc/man/man1/meroxa-apps-run.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-upgrade.1
+++ b/etc/man/man1/meroxa-apps-upgrade.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps.1
+++ b/etc/man/man1/meroxa-apps.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-login.1
+++ b/etc/man/man1/meroxa-auth-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-logout.1
+++ b/etc/man/man1/meroxa-auth-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-whoami.1
+++ b/etc/man/man1/meroxa-auth-whoami.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth.1
+++ b/etc/man/man1/meroxa-auth.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-billing.1
+++ b/etc/man/man1/meroxa-billing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-builds-describe.1
+++ b/etc/man/man1/meroxa-builds-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-builds-logs.1
+++ b/etc/man/man1/meroxa-builds-logs.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-builds.1
+++ b/etc/man/man1/meroxa-builds.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-completion.1
+++ b/etc/man/man1/meroxa-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-config-describe.1
+++ b/etc/man/man1/meroxa-config-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-config-set.1
+++ b/etc/man/man1/meroxa-config-set.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-config.1
+++ b/etc/man/man1/meroxa-config.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints-create.1
+++ b/etc/man/man1/meroxa-endpoints-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints-describe.1
+++ b/etc/man/man1/meroxa-endpoints-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints-list.1
+++ b/etc/man/man1/meroxa-endpoints-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints-remove.1
+++ b/etc/man/man1/meroxa-endpoints-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-endpoints.1
+++ b/etc/man/man1/meroxa-endpoints.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-create.1
+++ b/etc/man/man1/meroxa-environments-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-describe.1
+++ b/etc/man/man1/meroxa-environments-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-list.1
+++ b/etc/man/man1/meroxa-environments-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-remove.1
+++ b/etc/man/man1/meroxa-environments-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-repair.1
+++ b/etc/man/man1/meroxa-environments-repair.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-update.1
+++ b/etc/man/man1/meroxa-environments-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments.1
+++ b/etc/man/man1/meroxa-environments.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-login.1
+++ b/etc/man/man1/meroxa-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-logout.1
+++ b/etc/man/man1/meroxa-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-open-billing.1
+++ b/etc/man/man1/meroxa-open-billing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-open.1
+++ b/etc/man/man1/meroxa-open.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-create.1
+++ b/etc/man/man1/meroxa-resources-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-describe.1
+++ b/etc/man/man1/meroxa-resources-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-list.1
+++ b/etc/man/man1/meroxa-resources-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-remove.1
+++ b/etc/man/man1/meroxa-resources-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-rotate-tunnel-key.1
+++ b/etc/man/man1/meroxa-resources-rotate-tunnel-key.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-update.1
+++ b/etc/man/man1/meroxa-resources-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-validate.1
+++ b/etc/man/man1/meroxa-resources-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources.1
+++ b/etc/man/man1/meroxa-resources.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-transforms-list.1
+++ b/etc/man/man1/meroxa-transforms-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-transforms.1
+++ b/etc/man/man1/meroxa-transforms.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-version.1
+++ b/etc/man/man1/meroxa-version.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-whoami.1
+++ b/etc/man/man1/meroxa-whoami.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa.1
+++ b/etc/man/man1/meroxa.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "Oct 2022" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Sep 2022" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP
@@ -48,4 +48,4 @@ meroxa resources list --types
 
 .SH SEE ALSO
 .PP
-\fBmeroxa-api(1)\fP, \fBmeroxa-apps(1)\fP, \fBmeroxa-auth(1)\fP, \fBmeroxa-billing(1)\fP, \fBmeroxa-builds(1)\fP, \fBmeroxa-completion(1)\fP, \fBmeroxa-config(1)\fP, \fBmeroxa-endpoints(1)\fP, \fBmeroxa-environments(1)\fP, \fBmeroxa-login(1)\fP, \fBmeroxa-logout(1)\fP, \fBmeroxa-open(1)\fP, \fBmeroxa-project(1)\fP, \fBmeroxa-resources(1)\fP, \fBmeroxa-transforms(1)\fP, \fBmeroxa-version(1)\fP, \fBmeroxa-whoami(1)\fP
+\fBmeroxa-account(1)\fP, \fBmeroxa-api(1)\fP, \fBmeroxa-apps(1)\fP, \fBmeroxa-auth(1)\fP, \fBmeroxa-billing(1)\fP, \fBmeroxa-builds(1)\fP, \fBmeroxa-completion(1)\fP, \fBmeroxa-config(1)\fP, \fBmeroxa-endpoints(1)\fP, \fBmeroxa-environments(1)\fP, \fBmeroxa-login(1)\fP, \fBmeroxa-logout(1)\fP, \fBmeroxa-open(1)\fP, \fBmeroxa-resources(1)\fP, \fBmeroxa-transforms(1)\fP, \fBmeroxa-version(1)\fP, \fBmeroxa-whoami(1)\fP


### PR DESCRIPTION
Reverts meroxa/cli#486

Following our previous discussion, we'd like to stick to the `account` wording around the collaboration feature for now.

Part of https://github.com/meroxa/cli/issues/485