### PR TITLE
Retry uploading build source file to AWS three times

### DIFF
--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -466,14 +466,24 @@ func uploadFile(ctx context.Context, logger log.Logger, filePath, url string) er
 	req.ContentLength = fi.Size()
 
 	client := &http.Client{}
-	res, err := client.Do(req)
-	if err != nil {
-		logger.StopSpinnerWithStatus("\t Failed to send PUT request", log.Failed)
-		return err
+
+	retries := 3
+	var res *http.Response
+	for retries > 0 {
+		res, err = client.Do(req)
+		if err != nil {
+			retries -= 1
+		} else {
+			break
+		}
 	}
 
 	if res.Body != nil {
 		defer res.Body.Close()
+	}
+	if err != nil {
+		logger.StopSpinnerWithStatus("\t Failed to upload build source file", log.Failed)
+		return err
 	}
 
 	logger.StopSpinnerWithStatus("Source uploaded", log.Successful)

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -472,7 +472,7 @@ func uploadFile(ctx context.Context, logger log.Logger, filePath, url string) er
 	for retries > 0 {
 		res, err = client.Do(req)
 		if err != nil {
-			retries -= 1
+			retries--
 		} else {
 			break
 		}


### PR DESCRIPTION
## Description of change

We may be able to avoid failing a deployment by retrying an upload to AWS

Fixes https://github.com/meroxa/product/issues/501

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|=== RUN   TestAppSecurity/deploy_vulnerability_detecting_Go_App
    security_test.go:179: /app/bin/meroxa --cli-config-file /root/meroxa.env app deploy --path /apps/security/ --json
    security_test.go:179: 	✔ Checked your language is "golang"
        	✔ Checked your application name is "security3umrzkxsfftnxtpesg01"
        	✔ Deployment allowed from "master" branch
        	✔ Application built
        	✔ Can access to your Turbine resources
        	✔ Application processes found. Creating application image...
        	✔ Platform source fetched
        	✔ Dockerfile created
        	✔ "turbine-security3umrzkxsfftnxtpesg01.tar.gz" successfully created in "/apps/security"
        	x 	 Failed to send PUT request
        	✔ Removed "turbine-security3umrzkxsfftnxtpesg01.tar.gz"
        	✔ Dockerfile removed
        Error: Put "https://meroxa-source-d419bd4a-2984-4126-937b-7cbabdeac6c8.s3.amazonaws.com/0d6c3664-f362-4dee-8b10-8758bc8aeafe.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAUCRKS4PCXOMDXBBO%2F[202](https://github.com/meroxa/acceptance/runs/7772900153?check_suite_focus=true#step:8:203)20810%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220810T180012Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=f8a6f8efa96e4110c2280b744a9971646edec7cffc4d8d7370c964fdf0cf87c4": write tcp 172.17.0.2:44182->52.217.86.212:443: write: connection reset by peer
|hopefully not that|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
