### PR TITLE
Don't error on app logs if deployment not found

### DIFF
--- a/cmd/meroxa/root/apps/logs.go
+++ b/cmd/meroxa/root/apps/logs.go
@@ -125,7 +125,7 @@ func (l *Logs) Execute(ctx context.Context) error {
 	}
 
 	deployment, err := l.client.GetLatestDeployment(ctx, app.Name)
-	if err != nil && !strings.Contains(err.Error(), "user lacks permission") {
+	if err != nil && !strings.Contains(err.Error(), "could not find") {
 		return err
 	}
 


### PR DESCRIPTION
## Description of change

App logs command errors when deployment doesn't exist



## Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

### Create an app that references non-existing function
```
meroxa apps deploy --spec "0.1.1"
Validating your app.json...
	✔ Checked your language is "golang"
	✔ Checked your application name is "test-go"
Checking for uncommitted changes...
	✔ No uncommitted changes!
Preparing to deploy application "test-go"...
	x # meroxa/test-go
./app.go:33:23: undefined: Append0er
warning: failed to clean up /Users/dianadoherty/go/src/meroxa/test-go/test-go
warning: failed to clean up /Users/dianadoherty/go/src/meroxa/test-go/test-go.cross
Error: build failed
```

### Before: get logs
```
meroxa apps logs test-go    
Error: could not find deployment
```


### After: get logs 
```
meroxa apps logs test-go


```
cli doesn't error, but still reports no longs since none of the artifacts were created

## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
