### PR TITLE
feat: make ir deployments default

### DIFF
--- a/cmd/meroxa/turbine/golang/deploy.go
+++ b/cmd/meroxa/turbine/golang/deploy.go
@@ -24,10 +24,8 @@ func (t *turbineGoCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		appName,
 		"--gitsha",
 		gitSha,
-	}
-
-	if specVersion != "" {
-		args = append(args, "--spec", specVersion)
+		"--spec",
+		specVersion,
 	}
 
 	if imageName != "" {
@@ -55,13 +53,11 @@ func (t *turbineGoCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		return deploymentSpec, errors.New(string(output))
 	}
 
-	if specVersion != "" {
-		deploymentSpec, err = utils.GetTurbineResponseFromOutput(string(output))
-		if err != nil {
-			err = fmt.Errorf(
-				"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
-		}
+	deploymentSpec, err = utils.GetTurbineResponseFromOutput(string(output))
+	if err != nil {
+		err = fmt.Errorf("unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
 	}
+
 	return deploymentSpec, err
 }
 

--- a/cmd/meroxa/turbine/javascript/deploy.go
+++ b/cmd/meroxa/turbine/javascript/deploy.go
@@ -39,11 +39,7 @@ func (t *turbineJsCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		output         string
 		deploymentSpec string
 	)
-	params := []string{"clideploy", imageName, t.appPath, appName, gitSha}
-
-	if specVersion != "" {
-		params = append(params, specVersion)
-	}
+	params := []string{"clideploy", imageName, t.appPath, appName, gitSha, specVersion}
 
 	cmd := utils.RunTurbineJS(ctx, params...)
 
@@ -61,12 +57,10 @@ func (t *turbineJsCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 	if err != nil {
 		return deploymentSpec, err
 	}
-	if specVersion != "" {
-		deploymentSpec, err = utils.GetTurbineResponseFromOutput(output)
-		if err != nil {
-			err = fmt.Errorf(
-				"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
-		}
+	deploymentSpec, err = utils.GetTurbineResponseFromOutput(output)
+	if err != nil {
+		err = fmt.Errorf(
+			"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
 	}
 	return deploymentSpec, err
 }

--- a/cmd/meroxa/turbine/python/deploy.go
+++ b/cmd/meroxa/turbine/python/deploy.go
@@ -43,11 +43,7 @@ func (t *turbinePyCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		output         string
 		deploymentSpec string
 	)
-	args := []string{"clideploy", t.appPath, imageName, appName, gitSha}
-
-	if specVersion != "" {
-		args = append(args, specVersion)
-	}
+	args := []string{"clideploy", t.appPath, imageName, appName, gitSha, specVersion}
 
 	cmd := exec.CommandContext(ctx, "turbine-py", args...)
 
@@ -69,12 +65,11 @@ func (t *turbinePyCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 
 		return deploymentSpec, err
 	}
-	if specVersion != "" {
-		deploymentSpec, err = utils.GetTurbineResponseFromOutput(output)
-		if err != nil {
-			err = fmt.Errorf(
-				"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
-		}
+
+	deploymentSpec, err = utils.GetTurbineResponseFromOutput(output)
+	if err != nil {
+		err = fmt.Errorf(
+			"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
 	}
 	return deploymentSpec, err
 }

--- a/cmd/meroxa/turbine/python/upgrade.go
+++ b/cmd/meroxa/turbine/python/upgrade.go
@@ -7,7 +7,7 @@ import (
 	"github.com/meroxa/cli/log"
 )
 
-const turbinePYVersion = "1.5.0"
+const turbinePYVersion = "1.5.3"
 
 // Upgrade fetches the latest Meroxa dependencies.
 func (t *turbinePyCLI) Upgrade(vendor bool) error {

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -371,7 +371,7 @@ func UploadSource(ctx context.Context, logger log.Logger, language, appPath, app
 	var err error
 
 	if language == GoLang || language == JavaScript {
-		logger.StartSpinner("\t", fmt.Sprintf("Creating Dockerfile before uploading source in %s", appPath))
+		logger.StartSpinner("\t", fmt.Sprintf(" Creating Dockerfile before uploading source in %s", appPath))
 
 		if language == GoLang {
 			err = turbineGo.CreateDockerfile(appName, appPath)


### PR DESCRIPTION
## Description of change

Fixes https://github.com/meroxa/product/issues/559

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

**Before**

Regular deployment (pre: intermediate representation)

```
$ meroxa apps deploy .
```

To use a deployment using Intermediate representation:

```
$ meroxa apps deploy . --spec 0.1.1
```

**After**

To use a deployment using Intermediate representation, it'll fetch latest version and it'll be sent to all turbine libraries.

```
$ meroxa apps deploy .
```

## Additional references

This will be a nice to have right after we ship this pull-request to prevent unexpected behavior coming from old libraries: https://github.com/meroxa/product/issues/598.

A changelog will be needed in https://github.com/meroxa/product/issues/593.