### PR TITLE
fix: Drop brackets before assessing how many functions there are in a Go app

### DIFF
--- a/cmd/meroxa/turbine/golang/deploy.go
+++ b/cmd/meroxa/turbine/golang/deploy.go
@@ -104,6 +104,11 @@ func (t *turbineGoCLI) NeedsToBuild(ctx context.Context, appName string) (bool, 
 	list, err := utils.GetTurbineResponseFromOutput(string(output))
 	if err == nil && list != "" {
 		// ignores any lines that are not intended to be part of the response
+		list = strings.Trim(list, "[]")
+		if list == "" {
+			return false, nil
+		}
+
 		hasFunctions := len(strings.Split(list, ",")) > 0
 		return hasFunctions, nil
 	}


### PR DESCRIPTION
## Description of change

An empty set is interpreted as at least 1, and a function build occurs unnecessarily.

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

BEFORE
![Screenshot from 2022-10-26 12-00-02](https://user-images.githubusercontent.com/12731615/198113391-29cfb087-8dc6-4e43-a5ac-a616c9ef9662.png)


AFTER
![Screenshot from 2022-10-26 11-58-37](https://user-images.githubusercontent.com/12731615/198113192-c650a1a0-990c-4d65-b34e-8eafa502e705.png)



## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
