### PR TITLE
Friendly error when turbine version is outdated

### DIFF
--- a/cmd/meroxa/turbine/golang/deploy.go
+++ b/cmd/meroxa/turbine/golang/deploy.go
@@ -49,6 +49,9 @@ func (t *turbineGoCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		if strings.Contains(string(output), "flag provided but not defined") {
+			return deploymentSpec, errors.New(utils.IncompatibleTurbineVersion)
+		}
 		return deploymentSpec, errors.New(string(output))
 	}
 

--- a/cmd/meroxa/turbine/python/deploy.go
+++ b/cmd/meroxa/turbine/python/deploy.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/meroxa/cli/cmd/meroxa/global"
 	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
@@ -62,6 +63,10 @@ func (t *turbinePyCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 
 	output, err = utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
 	if err != nil {
+		if strings.Contains(err.Error(), "unrecognized arguments") {
+			return deploymentSpec, errors.New(utils.IncompatibleTurbineVersion)
+		}
+
 		return deploymentSpec, err
 	}
 	if specVersion != "" {

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -32,6 +32,10 @@ const (
 	turbineJSVersion  = "1.3.3"
 	isTrue            = "true"
 	AccountUUIDEnvVar = "MEROXA_ACCOUNT_UUID"
+
+	IncompatibleTurbineVersion = `your Turbine library version is incompatible with the Meroxa CLI.
+For guidance on updating to the latest version, visit: 
+https://docs.meroxa.com/beta-overview#updated-meroxa-cli-and-outdated-turbine-library`
 )
 
 type AppConfig struct {


### PR DESCRIPTION
## Description of change

Catch errors indicating that an app has an outdated turbine version 

Fixes https://github.com/meroxa/product/issues/598

## Type of change
- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

### Go
| before | after |
|--------|-------|
|<img width="338" alt="Screenshot 2022-10-26 at 4 09 14 PM" src="https://user-images.githubusercontent.com/31331000/198141607-5bf48cc2-c23d-4818-8ccc-116d7f8d4c87.png">|<img width="479" alt="Screenshot 2022-10-26 at 4 34 38 PM" src="https://user-images.githubusercontent.com/31331000/198141808-be6bd2d6-d887-4288-955f-1709bc36ca01.png">|

### Python
| before | after |
|--------|-------|
|<img width="479" alt="Screenshot 2022-10-26 at 5 18 52 PM" src="https://user-images.githubusercontent.com/31331000/198142198-83e15a57-68ac-46e2-9a0b-df649935a8e6.png">|<img width="479" alt="Screenshot 2022-10-26 at 5 23 22 PM" src="https://user-images.githubusercontent.com/31331000/198142209-325add47-ee51-4c18-bd51-42e6ddbb74ed.png">|


### JavaScript
| before | after |
|--------|-------|
|<img width="479" alt="Screenshot 2022-10-26 at 5 37 45 PM" src="https://user-images.githubusercontent.com/31331000/198143313-66937023-a0c1-4f0f-a92d-c7cbee2aca3f.png">|Unable to determine|

JavaScript's deployment error doesn't indicate anything about the turbine version being outdate, so I'm not sure if it'll be possible for us to capture the error properly. 


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
