### PR TITLE
feat: add hidden verbose flag to apps deploy to show more logs

### DIFF
--- a/cmd/meroxa/root/apps/upgrade.go
+++ b/cmd/meroxa/root/apps/upgrade.go
@@ -73,7 +73,7 @@ func (u *Upgrade) Execute(ctx context.Context) error {
 	var err error
 	if u.config == nil {
 		u.path, err = turbine.GetPath(u.flags.Path)
-		u.logger.StartSpinner("\t", fmt.Sprintf(" Fetching details of application in %q...", u.path))
+		u.logger.StartSpinner("\t", fmt.Sprintf("Fetching details of application in %q...", u.path))
 		if err != nil {
 			u.logger.StopSpinnerWithStatus("\t", log.Failed)
 			return err
@@ -114,7 +114,7 @@ func (u *Upgrade) Execute(ctx context.Context) error {
 		return err
 	}
 
-	u.logger.StartSpinner("\t", " Testing upgrades locally...")
+	u.logger.StartSpinner("\t", "Testing upgrades locally...")
 	runOutput := ""
 	buf := bytes.NewBufferString(runOutput)
 	if u.run == nil {

--- a/cmd/meroxa/turbine/golang/build.go
+++ b/cmd/meroxa/turbine/golang/build.go
@@ -13,7 +13,7 @@ import (
 func (t *turbineGoCLI) Build(ctx context.Context, appName string, platform bool) (string, error) {
 	var cmd *exec.Cmd
 
-	t.logger.StartSpinner("\t", " Building Golang binary...")
+	t.logger.StartSpinner("\t", "Building Golang binary...")
 	if platform {
 		cmd = exec.CommandContext(ctx, "go", "build", "--tags", "platform", "-o", appName, "./...")
 	} else {

--- a/cmd/meroxa/turbine/golang/init.go
+++ b/cmd/meroxa/turbine/golang/init.go
@@ -27,7 +27,7 @@ func (t *turbineGoCLI) GitInit(ctx context.Context, name string) error {
 }
 
 func GoInit(l log.Logger, appPath string, skipInit, vendor bool) error {
-	l.StartSpinner("\t", " Running golang module initializing...")
+	l.StartSpinner("\t", "Running golang module initializing...")
 	skipLog := "skipping go module initialization\n\tFor guidance, visit " +
 		"https://docs.meroxa.com/beta-overview#go-mod-init-for-a-new-golang-turbine-data-application"
 	goPath := os.Getenv("GOPATH")

--- a/cmd/meroxa/turbine/golang/upgrade.go
+++ b/cmd/meroxa/turbine/golang/upgrade.go
@@ -31,7 +31,7 @@ func (t *turbineGoCLI) Upgrade(vendor bool) error {
 
 func (t *turbineGoCLI) tidy(vendor bool) error {
 	var err error
-	t.logger.StartSpinner("\t", " Tidying up Golang modules...")
+	t.logger.StartSpinner("\t", "Tidying up Golang modules...")
 	if vendor {
 		_, err = os.Stat("vendor")
 		if !os.IsNotExist(err) {

--- a/cmd/meroxa/turbine/golang/utils.go
+++ b/cmd/meroxa/turbine/golang/utils.go
@@ -9,7 +9,7 @@ import (
 
 // GoGetDeps updates the latest Meroxa mods.
 func GoGetDeps(l log.Logger) error {
-	l.StartSpinner("\t", " Getting latest turbine-go and turbine-go/running dependencies...")
+	l.StartSpinner("\t", "Getting latest turbine-go and turbine-go/running dependencies...")
 	cmd := exec.Command("go", "get", "-u", "github.com/meroxa/turbine-go")
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/meroxa/turbine/javascript/upgrade.go
+++ b/cmd/meroxa/turbine/javascript/upgrade.go
@@ -13,7 +13,7 @@ func (t *turbineJsCLI) Upgrade(vendor bool) error {
 	cmd.Dir = t.appPath
 	err := cmd.Wait()
 	if err != nil {
-		t.logger.StartSpinner("\t", " Adding @meroxa/turbine-js-framework requirement...")
+		t.logger.StartSpinner("\t", "Adding @meroxa/turbine-js-framework requirement...")
 		cmd = exec.Command("npm", "install", "@meroxa/turbine-js-framework", "--save")
 		cmd.Dir = t.appPath
 		out, err := cmd.CombinedOutput()
@@ -38,7 +38,7 @@ func (t *turbineJsCLI) Upgrade(vendor bool) error {
 		}
 		t.logger.StopSpinnerWithStatus("Added @meroxa/turbine-js-framework requirement successfully!", log.Successful)
 	} else {
-		t.logger.StartSpinner("\t", " Upgrading @meroxa/turbine-js-framework...")
+		t.logger.StartSpinner("\t", "Upgrading @meroxa/turbine-js-framework...")
 		cmd = exec.Command("npm", "upgrade", "@meroxa/turbine-js-framework")
 		cmd.Dir = t.appPath
 		out, err := cmd.CombinedOutput()

--- a/cmd/meroxa/turbine/python/build.go
+++ b/cmd/meroxa/turbine/python/build.go
@@ -11,7 +11,7 @@ import (
 
 // Build created the needed structure for a python app.
 func (t *turbinePyCLI) Build(ctx context.Context, appName string, platform bool) (string, error) {
-	t.logger.StartSpinner("\t", " Building application...")
+	t.logger.StartSpinner("\t", "Building application...")
 	cmd := exec.CommandContext(ctx, "turbine-py", "clibuild", t.appPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/cmd/meroxa/turbine/python/upgrade.go
+++ b/cmd/meroxa/turbine/python/upgrade.go
@@ -15,7 +15,7 @@ func (t *turbinePyCLI) Upgrade(vendor bool) error {
 	cmd.Dir = t.appPath
 	err := cmd.Run()
 	if err != nil {
-		t.logger.StartSpinner("\t", " Tidying up requirements.txt...")
+		t.logger.StartSpinner("\t", "Tidying up requirements.txt...")
 		cmd = exec.Command("bash", "-c", "sed -i 's+meroxa-py++g' requirements.txt")
 		cmd.Dir = t.appPath
 		err1 := cmd.Run()
@@ -31,7 +31,7 @@ func (t *turbinePyCLI) Upgrade(vendor bool) error {
 		}
 	}
 
-	t.logger.StartSpinner("\t", " Updating Python dependencies...")
+	t.logger.StartSpinner("\t", "Updating Python dependencies...")
 	cmd = exec.Command("pip", "install", "turbine-py", "-U")
 	cmd.Dir = t.appPath
 	out, err := cmd.CombinedOutput()

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -90,7 +90,7 @@ func GetPath(flag string) (string, error) {
 
 // GetLangFromAppJSON returns specified language in users' app.json.
 func GetLangFromAppJSON(ctx context.Context, l log.Logger, pwd string) (string, error) {
-	l.StartSpinner("\t", " Determining application language from app.json...")
+	l.StartSpinner("\t", "Determining application language from app.json...")
 	appConfig, err := ReadConfigFile(pwd)
 	if err != nil {
 		l.StopSpinnerWithStatus("Something went wrong reading your app.json", log.Failed)
@@ -107,7 +107,7 @@ func GetLangFromAppJSON(ctx context.Context, l log.Logger, pwd string) (string, 
 
 // GetAppNameFromAppJSON returns specified app name in users' app.json.
 func GetAppNameFromAppJSON(ctx context.Context, l log.Logger, pwd string) (string, error) {
-	l.StartSpinner("\t", " Reading application name from app.json...")
+	l.StartSpinner("\t", "Reading application name from app.json...")
 	appConfig, err := ReadConfigFile(pwd)
 	if err != nil {
 		return "", err
@@ -371,7 +371,7 @@ func UploadSource(ctx context.Context, logger log.Logger, language, appPath, app
 	var err error
 
 	if language == GoLang || language == JavaScript {
-		logger.StartSpinner("\t", fmt.Sprintf(" Creating Dockerfile before uploading source in %s", appPath))
+		logger.StartSpinner("\t", fmt.Sprintf("Creating Dockerfile before uploading source in %s", appPath))
 
 		if language == GoLang {
 			err = turbineGo.CreateDockerfile(appName, appPath)
@@ -405,7 +405,7 @@ func UploadSource(ctx context.Context, logger log.Logger, language, appPath, app
 		return err
 	}
 
-	logger.StartSpinner("\t", fmt.Sprintf(" Creating %q in %q to upload to our build service...", appPath, dFile))
+	logger.StartSpinner("\t", fmt.Sprintf("Creating %q in %q to upload to our build service...", appPath, dFile))
 
 	fileToWrite, err := os.OpenFile(dFile, os.O_CREATE|os.O_RDWR, os.FileMode(0777)) //nolint:gomnd
 	defer func(fileToWrite *os.File) {
@@ -415,7 +415,7 @@ func UploadSource(ctx context.Context, logger log.Logger, language, appPath, app
 		}
 
 		// remove .tar.gz file
-		logger.StartSpinner("\t", fmt.Sprintf(" Removing %q...", dFile))
+		logger.StartSpinner("\t", fmt.Sprintf("Removing %q...", dFile))
 		removeErr := os.Remove(dFile)
 		if removeErr != nil {
 			logger.StopSpinnerWithStatus(fmt.Sprintf("\t Something went wrong trying to remove %q", dFile), log.Failed)
@@ -439,7 +439,7 @@ func UploadSource(ctx context.Context, logger log.Logger, language, appPath, app
 }
 
 func uploadFile(ctx context.Context, logger log.Logger, filePath, url string) error {
-	logger.StartSpinner("\t", " Uploading source...")
+	logger.StartSpinner("\t", "Uploading source...")
 
 	fh, err := os.Open(filePath)
 	if err != nil {
@@ -526,7 +526,7 @@ func createJavascriptDockerfile(ctx context.Context, appPath string) error {
 
 // cleanUpPythonTempBuildLocation removes any artifacts in the temporary directory.
 func cleanUpPythonTempBuildLocation(ctx context.Context, logger log.Logger, appPath string) {
-	logger.StartSpinner("\t", fmt.Sprintf(" Removing artifacts from building the Python Application at %s...", appPath))
+	logger.StartSpinner("\t", fmt.Sprintf("Removing artifacts from building the Python Application at %s...", appPath))
 
 	cmd := exec.CommandContext(ctx, "turbine-py", "cliclean", appPath)
 	output, err := cmd.CombinedOutput()

--- a/log/spinner.go
+++ b/log/spinner.go
@@ -38,7 +38,7 @@ type spinnerLogger struct {
 func (l *spinnerLogger) StartSpinner(prefix, suffix string) {
 	l.s = spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithWriter(l.out)) //nolint:gomnd
 	l.s.Prefix = prefix
-	l.s.Suffix = suffix
+	l.s.Suffix = " " + suffix
 	l.s.Start()
 }
 


### PR DESCRIPTION
## Description of change

This pull request adds the `--verbose` flag (which will be hidden until we validate it with customers). 

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

**With `--verbose` on a successful deployment**

```
$ meroxa apps deploy --path ../../trash/simple-js/ --verbose
Validating your app.json...
	✔ Checked your language is "javascript"
	✔ Checked your application name is "simple-js-ir"
Checking for uncommitted changes...
	✔ No uncommitted changes!
Preparing to deploy application "simple-js-ir"...
	✔ Can access your Turbine resources
	✔ No need to create process image
Deploying application "simple-js-ir"...
	successfully validated application pipeline
	failed to create source connector

	✔ Application "simple-js-ir" successfully deployed!

  ✨ To visualize your application visit https://dashboard.meroxa.io/apps/simple-js-ir/detail
```

**Without `--verbose` on a successful deployment**

```
$ meroxa apps deploy --path ../../trash/simple-js/ --verbose
Validating your app.json...
	✔ Checked your language is "javascript"
	✔ Checked your application name is "simple-js-ir"
Checking for uncommitted changes...
	✔ No uncommitted changes!
Preparing to deploy application "simple-js-ir"...
	✔ Can access your Turbine resources
	✔ No need to create process image
Deploying application "simple-js-ir"...
	✔ Application "simple-js-ir" successfully deployed!

  ✨ To visualize your application visit https://dashboard.meroxa.io/apps/simple-js-ir/detail
```

## Additional references

There are demos about this Slack.