### PR TITLE
File descriptor will be closed after calling Do()

### DIFF
--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -475,7 +475,7 @@ func uploadFile(ctx context.Context, logger log.Logger, filePath, url string) er
 		req.ContentLength = fi.Size()
 
 		res, clientErr = client.Do(req)
-		if clientErr != nil || (res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusNoContent) {
+		if clientErr != nil || (res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices) {
 			retries--
 		} else {
 			break
@@ -485,7 +485,7 @@ func uploadFile(ctx context.Context, logger log.Logger, filePath, url string) er
 	if res != nil && res.Body != nil {
 		defer res.Body.Close()
 	}
-	if clientErr != nil || (res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusNoContent) {
+	if clientErr != nil || (res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices) {
 		logger.StopSpinnerWithStatus("\t Failed to upload build source file", log.Failed)
 		if clientErr == nil {
 			clientErr = fmt.Errorf("upload failed: %s", res.Status)

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -490,6 +490,9 @@ func uploadFile(ctx context.Context, logger log.Logger, filePath, url string) er
 	}
 	if clientErr != nil || (res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusNoContent) {
 		logger.StopSpinnerWithStatus("\t Failed to upload build source file", log.Failed)
+		if clientErr == nil {
+			clientErr = fmt.Errorf("upload failed: %s", res.Status)
+		}
 		return clientErr
 	}
 

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -55,9 +55,6 @@ type ApplicationResource struct {
 	Destination bool   `json:"destination"`
 	Collection  string `json:"collection"`
 }
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
 
 // GetResourceNamesFromString provides backward compatibility with turbine-go
 // legacy resource listing format.

--- a/cmd/meroxa/turbine/utils_test.go
+++ b/cmd/meroxa/turbine/utils_test.go
@@ -123,6 +123,7 @@ func TestUploadFile(t *testing.T) {
 			status:  http.StatusInternalServerError,
 			retries: 3,
 			output:  "Failed to upload build source file",
+			err:     fmt.Errorf("upload failed: 500 Internal Server Error"),
 		},
 	}
 

--- a/cmd/meroxa/turbine/utils_test.go
+++ b/cmd/meroxa/turbine/utils_test.go
@@ -4,11 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meroxa/cli/log"
 )
 
 func TestGitInit(t *testing.T) {
@@ -77,6 +83,65 @@ func TestGetTurbineJSBinary(t *testing.T) {
 			params := []string{"foo", "bar"}
 			result := getTurbineJSBinary(params)
 			assert.Equal(t, []string{"npx", "--yes", tc.wantCmd, "foo", "bar"}, result)
+		})
+	}
+}
+
+func TestUploadFile(t *testing.T) {
+	ctx := context.Background()
+	retries := 0
+	testCases := []struct {
+		name    string
+		server  func(int) *httptest.Server
+		status  int
+		retries int
+		output  string
+		err     error
+	}{
+		{
+			name: "Successfully upload file",
+			server: func(status int) *httptest.Server {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					retries++
+					w.WriteHeader(status)
+				}))
+				return server
+			},
+			status:  http.StatusOK,
+			retries: 1,
+			output:  "Source uploaded",
+		},
+		{
+			name: "Fail to upload file",
+			server: func(status int) *httptest.Server {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					retries++
+					w.WriteHeader(status)
+				}))
+				return server
+			},
+			status:  http.StatusInternalServerError,
+			retries: 3,
+			output:  "Failed to upload build source file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			retries = 0
+			logger := log.NewTestLogger()
+			logger.StartSpinner("", "")
+			server := tc.server(tc.status)
+			err := uploadFile(ctx, logger, "utils.go", server.URL)
+			if tc.err != nil {
+				assert.Equal(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.retries, retries)
+			output := logger.SpinnerOutput()
+			assert.True(t, strings.Contains(output, tc.output))
+			server.Close()
 		})
 	}
 }


### PR DESCRIPTION
## Description of change

Error: Put "https://meroxa-source-d419bd4a-2984-4126-937b-7cbabdeac6c8.s3.amazonaws.com/9d7d7837-1a9e-4f17-b25f-8669359692bf.tar.gz?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAUCRKS4PCXOMDXBBO%2F20221102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221102T153607Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=590786ecb11cc452b63bf00879775726c87107bf266a1e8a8d88492daa7bbce0": read turbine-go-acceptance-app-c6e0e801-7fc8-4194-af51-2a2aeb97bb1b.tar.gz: file already closed

See this error regularly from the acceptance tests

Fixes https://github.com/meroxa/cli/issues/524

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
