### PR TITLE
feat: make non ir deployments default

### DIFF
--- a/cmd/meroxa/turbine/golang/deploy.go
+++ b/cmd/meroxa/turbine/golang/deploy.go
@@ -24,8 +24,10 @@ func (t *turbineGoCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		appName,
 		"--gitsha",
 		gitSha,
-		"--spec",
-		specVersion,
+	}
+
+	if specVersion != "" {
+		args = append(args, "--spec", specVersion)
 	}
 
 	if imageName != "" {
@@ -53,9 +55,11 @@ func (t *turbineGoCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		return deploymentSpec, errors.New(string(output))
 	}
 
-	deploymentSpec, err = utils.GetTurbineResponseFromOutput(string(output))
-	if err != nil {
-		err = fmt.Errorf("unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
+	if specVersion != "" {
+		deploymentSpec, err = utils.GetTurbineResponseFromOutput(string(output))
+		if err != nil {
+			err = fmt.Errorf("unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
+		}
 	}
 
 	return deploymentSpec, err

--- a/cmd/meroxa/turbine/javascript/deploy.go
+++ b/cmd/meroxa/turbine/javascript/deploy.go
@@ -39,7 +39,11 @@ func (t *turbineJsCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		output         string
 		deploymentSpec string
 	)
-	params := []string{"clideploy", imageName, t.appPath, appName, gitSha, specVersion}
+	params := []string{"clideploy", imageName, t.appPath, appName, gitSha}
+
+	if specVersion != "" {
+		params = append(params, specVersion)
+	}
 
 	cmd := utils.RunTurbineJS(ctx, params...)
 
@@ -57,10 +61,13 @@ func (t *turbineJsCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 	if err != nil {
 		return deploymentSpec, err
 	}
-	deploymentSpec, err = utils.GetTurbineResponseFromOutput(output)
-	if err != nil {
-		err = fmt.Errorf(
-			"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
+
+	if specVersion != "" {
+		deploymentSpec, err = utils.GetTurbineResponseFromOutput(output)
+		if err != nil {
+			err = fmt.Errorf(
+				"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
+		}
 	}
 	return deploymentSpec, err
 }

--- a/cmd/meroxa/turbine/python/deploy.go
+++ b/cmd/meroxa/turbine/python/deploy.go
@@ -43,7 +43,11 @@ func (t *turbinePyCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		output         string
 		deploymentSpec string
 	)
-	args := []string{"clideploy", t.appPath, imageName, appName, gitSha, specVersion}
+	args := []string{"clideploy", t.appPath, imageName, appName, gitSha}
+
+	if specVersion != "" {
+		args = append(args, specVersion)
+	}
 
 	cmd := exec.CommandContext(ctx, "turbine-py", args...)
 
@@ -66,10 +70,12 @@ func (t *turbinePyCLI) Deploy(ctx context.Context, imageName, appName, gitSha, s
 		return deploymentSpec, err
 	}
 
-	deploymentSpec, err = utils.GetTurbineResponseFromOutput(output)
-	if err != nil {
-		err = fmt.Errorf(
-			"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
+	if specVersion != "" {
+		deploymentSpec, err = utils.GetTurbineResponseFromOutput(output)
+		if err != nil {
+			err = fmt.Errorf(
+				"unable to receive the deployment spec for the Meroxa Application at %s", t.appPath)
+		}
 	}
 	return deploymentSpec, err
 }


### PR DESCRIPTION
## Description of change

Deploying using IR is still possible via `--spec 0.1.1`

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

**Before**

```
$ meroxa apps deploy . 
// deploy using IR
```

**Now**

```
$ meroxa apps deploy . 
// deploy using pre-IR

$ meroxa apps deploy . --spec 0.1.1 
// deploy using IR

```