### PR TITLE
Add version function for each turbine library

### DIFF
--- a/cmd/meroxa/turbine/golang/version.go
+++ b/cmd/meroxa/turbine/golang/version.go
@@ -29,8 +29,9 @@ func (t *turbineGoCLI) GetVersion(ctx context.Context) (string, error) {
 	chars := []rune(version)
 	if chars[0] == 'v' {
 		// Looks like v0.0.0-20221024132549-e6470e58b719
+		const sections = 3
 		parts := strings.Split(version, "-")
-		if len(parts) < 3 {
+		if len(parts) < sections {
 			return "", fmtErr
 		}
 		version = parts[2]

--- a/cmd/meroxa/turbine/golang/version.go
+++ b/cmd/meroxa/turbine/golang/version.go
@@ -17,7 +17,7 @@ func (t *turbineGoCLI) GetVersion(ctx context.Context) (string, error) {
 		"list", "-m", "-f", "'{{ .Version }}'", "github.com/meroxa/turbine-go")
 	cmd.Dir = t.appPath
 	fmtErr := fmt.Errorf(
-		"unable to determine the version of turbine-js-cli used for the Meroxa Application at %s",
+		"unable to determine the version of turbine-go used by the Meroxa Application at %s",
 		t.appPath)
 
 	stdout, err := cmd.CombinedOutput()

--- a/cmd/meroxa/turbine/golang/version.go
+++ b/cmd/meroxa/turbine/golang/version.go
@@ -1,0 +1,39 @@
+package turbinego
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GetVersion will return the tag or hash of the turbine-go dependency of a given app.
+func (t *turbineGoCLI) GetVersion(ctx context.Context) (string, error) {
+	var cmd *exec.Cmd
+
+	cmd = exec.CommandContext(
+		ctx,
+		"go",
+		"list", "-m", "-f", "'{{ .Version }}'", "github.com/meroxa/turbine-go")
+	cmd.Dir = t.appPath
+	fmtErr := fmt.Errorf(
+		"unable to determine the version of turbine-js-cli used for the Meroxa Application at %s",
+		t.appPath)
+
+	stdout, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmtErr
+	}
+
+	version := string(stdout)
+	chars := []rune(version)
+	if chars[0] == 'v' {
+		// Looks like v0.0.0-20221024132549-e6470e58b719
+		parts := strings.Split(version, "-")
+		if len(parts) < 3 {
+			return "", fmtErr
+		}
+		version = parts[2]
+	}
+	return version, nil
+}

--- a/cmd/meroxa/turbine/golang/version.go
+++ b/cmd/meroxa/turbine/golang/version.go
@@ -25,7 +25,7 @@ func (t *turbineGoCLI) GetVersion(ctx context.Context) (string, error) {
 		return "", fmtErr
 	}
 
-	version := string(stdout)
+	version := strings.TrimSpace(string(stdout))
 	chars := []rune(version)
 	if chars[0] == 'v' {
 		// Looks like v0.0.0-20221024132549-e6470e58b719

--- a/cmd/meroxa/turbine/interface.go
+++ b/cmd/meroxa/turbine/interface.go
@@ -9,6 +9,7 @@ type CLI interface {
 	CleanUpBinaries(ctx context.Context, appName string)
 	Deploy(ctx context.Context, imageName, appName, gitSha, specVersion, accountUUID string) (string, error)
 	GetResources(ctx context.Context, appName string) ([]ApplicationResource, error)
+	GetVersion(ctx context.Context) (string, error)
 	GitInit(ctx context.Context, name string) error
 	GitChecks(ctx context.Context) error
 	GetGitSha(ctx context.Context) (string, error)

--- a/cmd/meroxa/turbine/javascript/version.go
+++ b/cmd/meroxa/turbine/javascript/version.go
@@ -11,11 +11,16 @@ import (
 func (t *turbineJsCLI) GetVersion(ctx context.Context) (string, error) {
 	cmd := utils.RunTurbineJS(ctx, "version", t.appPath)
 	stdOut, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	fmtErr := fmt.Errorf(
+		"unable to determine the version of turbine-js-cli used for the Meroxa Application at %s",
+		t.appPath)
+	if err != nil {
+		return "", fmtErr
+	}
 
 	version, err := utils.GetTurbineResponseFromOutput(stdOut)
 	if err != nil {
-		err = fmt.Errorf(
-			"unable to determine the version of turbine-js-cli used for the Meroxa Application at %s", t.appPath)
+		err = fmtErr
 	}
 	return version, err
 }

--- a/cmd/meroxa/turbine/javascript/version.go
+++ b/cmd/meroxa/turbine/javascript/version.go
@@ -1,0 +1,21 @@
+package turbinejs
+
+import (
+	"context"
+	"fmt"
+
+	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
+)
+
+// GetVersion calls turbine-js-cli to get the version of the app.
+func (t *turbineJsCLI) GetVersion(ctx context.Context) (string, error) {
+	cmd := utils.RunTurbineJS(ctx, "version", t.appPath)
+	stdOut, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+
+	version, err := utils.GetTurbineResponseFromOutput(stdOut)
+	if err != nil {
+		err = fmt.Errorf(
+			"unable to determine the version of turbine-js-cli used for the Meroxa Application at %s", t.appPath)
+	}
+	return version, err
+}

--- a/cmd/meroxa/turbine/javascript/version.go
+++ b/cmd/meroxa/turbine/javascript/version.go
@@ -7,12 +7,12 @@ import (
 	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
 )
 
-// GetVersion calls turbine-js-cli to get the version of the app.
+// GetVersion calls turbine-js-cli to get the turbine-js-framework version used by the given app.
 func (t *turbineJsCLI) GetVersion(ctx context.Context) (string, error) {
 	cmd := utils.RunTurbineJS(ctx, "version", t.appPath)
 	stdOut, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
 	fmtErr := fmt.Errorf(
-		"unable to determine the version of turbine-js-cli used for the Meroxa Application at %s",
+		"unable to determine the version of turbine-js-framework used by the Meroxa Application at %s",
 		t.appPath)
 	if err != nil {
 		return "", fmtErr

--- a/cmd/meroxa/turbine/mock/cli.go
+++ b/cmd/meroxa/turbine/mock/cli.go
@@ -107,6 +107,21 @@ func (mr *MockCLIMockRecorder) GetResources(ctx, appName interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResources", reflect.TypeOf((*MockCLI)(nil).GetResources), ctx, appName)
 }
 
+// GetVersion mocks base method.
+func (m *MockCLI) GetVersion(ctx context.Context) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVersion", ctx)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVersion indicates an expected call of GetVersion.
+func (mr *MockCLIMockRecorder) GetVersion(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockCLI)(nil).GetVersion), ctx)
+}
+
 // GitChecks mocks base method.
 func (m *MockCLI) GitChecks(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/cmd/meroxa/turbine/python/version.go
+++ b/cmd/meroxa/turbine/python/version.go
@@ -1,0 +1,31 @@
+package turbinepy
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
+)
+
+// GetVersion calls turbine-py to get the version of the app.
+func (t *turbinePyCLI) GetVersion(ctx context.Context) (string, error) {
+	cmd := exec.Command("turbine-py", "version", t.appPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf(
+			"unable to determine the turbine-py version of the Meroxa Application at %s",
+			t.appPath)
+		return "", err
+	}
+
+	version, err := utils.GetTurbineResponseFromOutput(string(output))
+	if err != nil {
+		// For versions <= v1.6.1
+		version = string(output)
+		version = strings.TrimSpace(version)
+		return version, nil
+	}
+	return version, err
+}

--- a/cmd/meroxa/turbine/python/version.go
+++ b/cmd/meroxa/turbine/python/version.go
@@ -9,13 +9,13 @@ import (
 	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
 )
 
-// GetVersion calls turbine-py to get the version of the app.
+// GetVersion calls turbine-py to get its version used by the given app.
 func (t *turbinePyCLI) GetVersion(ctx context.Context) (string, error) {
 	cmd := exec.Command("turbine-py", "version", t.appPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		err = fmt.Errorf(
-			"unable to determine the turbine-py version of the Meroxa Application at %s",
+			"unable to determine the version of turbine-py used by the Meroxa Application at %s",
 			t.appPath)
 		return "", err
 	}

--- a/cmd/meroxa/turbine/ruby/version.go
+++ b/cmd/meroxa/turbine/ruby/version.go
@@ -1,0 +1,11 @@
+package turbinerb
+
+import (
+	"context"
+	"fmt"
+)
+
+// GetVersion will return the version of turbine-rb dependency of a given app.
+func (t *turbineRbCLI) GetVersion(ctx context.Context) (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}

--- a/cmd/meroxa/turbine/ruby/version.go
+++ b/cmd/meroxa/turbine/ruby/version.go
@@ -7,5 +7,18 @@ import (
 
 // GetVersion will return the version of turbine-rb dependency of a given app.
 func (t *turbineRbCLI) GetVersion(ctx context.Context) (string, error) {
-	return "", fmt.Errorf("unimplemented")
+	cmd := exec.Command("ruby", []string{
+		"-r", "rubygems",
+		"-r", fmt.Sprintf("%s/app", t.appPath),
+		"-e", `puts Gem.loaded_specs["turbine"].version.version`
+	})
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf(
+			"unable to determine the turbine-rb version of the Meroxa Application at %s",
+			t.appPath)
+		return "", err	
+	}
+	
+	return strings.TrimSpace(string(output)), nil
 }

--- a/cmd/meroxa/turbine/ruby/version.go
+++ b/cmd/meroxa/turbine/ruby/version.go
@@ -3,6 +3,8 @@ package turbinerb
 import (
 	"context"
 	"fmt"
+	"os/exec"
+	"strings"
 )
 
 // GetVersion will return the version of turbine-rb dependency of a given app.
@@ -10,15 +12,15 @@ func (t *turbineRbCLI) GetVersion(ctx context.Context) (string, error) {
 	cmd := exec.Command("ruby", []string{
 		"-r", "rubygems",
 		"-r", fmt.Sprintf("%s/app", t.appPath),
-		"-e", `puts Gem.loaded_specs["turbine"].version.version`
-	})
+		"-e", `puts Gem.loaded_specs["turbine"].version.version`,
+	}...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		err = fmt.Errorf(
 			"unable to determine the turbine-rb version of the Meroxa Application at %s",
 			t.appPath)
-		return "", err	
+		return "", err
 	}
-	
+
 	return strings.TrimSpace(string(output)), nil
 }


### PR DESCRIPTION
## Description of change

Determine the version of turbine-go used in an App
make grabbing all versions of turbine libs used in an App accessible

Fixes https://github.com/meroxa/turbine-project/issues/266

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
