### PR TITLE
Fix flapping test and rename TurbineRb

### DIFF
--- a/cmd/meroxa/root/apps/run_test.go
+++ b/cmd/meroxa/root/apps/run_test.go
@@ -154,28 +154,28 @@ Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sm
 	}
 }
 
-// setFeatures sets features from a map which designates enabled/disabled features
+// setFeatures sets features from a map which designates enabled/disabled features.
 func setFeatures(features map[string]bool) {
-	current := getFeatures()
+	currentFlags := getFeatures()
 
 	for k, v := range features {
 		switch v {
 		case true:
-			current[k] = v
+			currentFlags[k] = v
 		case false:
-			delete(current, k)
+			delete(currentFlags, k)
 		}
 	}
 
 	var flags []string
-	for k, _ := range current {
+	for k := range currentFlags {
 		flags = append(flags, k)
 	}
 
 	global.Config.Set(global.UserFeatureFlagsEnv, strings.Join(flags, " "))
 }
 
-// resetFeatures inverts the state of features defined in the map
+// resetFeatures inverts the state of features defined in the map.
 func resetFeatures(features map[string]bool) {
 	reset := make(map[string]bool)
 	for k, v := range features {

--- a/cmd/meroxa/root/apps/run_test.go
+++ b/cmd/meroxa/root/apps/run_test.go
@@ -67,7 +67,7 @@ func TestRunExecute(t *testing.T) {
 		desc     string
 		cli      turbine.CLI
 		config   turbine.AppConfig
-		features []string
+		features map[string]bool
 		err      error
 	}{
 		{
@@ -94,7 +94,9 @@ func TestRunExecute(t *testing.T) {
 				Name:     "ruby-test",
 				Language: turbine.Ruby,
 			},
-			features: []string{"ruby_implementation"},
+			features: map[string]bool{
+				"ruby_implementation": true,
+			},
 		},
 		{
 			desc: "Execute Ruby Run (Missing feature)",
@@ -102,6 +104,9 @@ func TestRunExecute(t *testing.T) {
 			config: turbine.AppConfig{
 				Name:     "ruby-test",
 				Language: turbine.Ruby,
+			},
+			features: map[string]bool{
+				"ruby_implementation": false,
 			},
 			err: fmt.Errorf(`no access to the Meroxa Turbine Ruby feature.
 Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sme`),
@@ -136,8 +141,8 @@ Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sm
 			}
 
 			if len(tt.features) != 0 {
-				oldflags := setFlags(tt.features, false)
-				defer setFlags(oldflags, true)
+				setFeatures(tt.features)
+				defer resetFeatures(tt.features)
 			}
 
 			err := u.Execute(ctx)
@@ -149,23 +154,45 @@ Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sm
 	}
 }
 
-// setFlags adds newflags to the global flag collection and returns old flags,
-// when replace is true, flags will be overwritten with newflags.
-func setFlags(newflags []string, replace bool) []string {
-	var flags string
-	oldflags := global.Config.Get(global.UserFeatureFlagsEnv)
-	if oldflags != nil {
-		flags = oldflags.(string)
-	} else {
-		oldflags = ""
+// setFeatures sets features from a map which designates enabled/disabled features
+func setFeatures(features map[string]bool) {
+	current := getFeatures()
+
+	for k, v := range features {
+		switch v {
+		case true:
+			current[k] = v
+		case false:
+			delete(current, k)
+		}
 	}
 
-	if replace {
-		flags = strings.Join(newflags, " ")
-	} else {
-		flags += " " + strings.Join(newflags, " ")
+	var flags []string
+	for k, _ := range current {
+		flags = append(flags, k)
 	}
-	global.Config.Set(global.UserFeatureFlagsEnv, flags)
 
-	return strings.Split(oldflags.(string), " ")
+	global.Config.Set(global.UserFeatureFlagsEnv, strings.Join(flags, " "))
+}
+
+// resetFeatures inverts the state of features defined in the map
+func resetFeatures(features map[string]bool) {
+	reset := make(map[string]bool)
+	for k, v := range features {
+		reset[k] = !v
+	}
+
+	setFeatures(reset)
+}
+
+func getFeatures() map[string]bool {
+	flags := make(map[string]bool)
+
+	if s := global.Config.Get(global.UserFeatureFlagsEnv); s != nil {
+		for _, t := range strings.Split(s.(string), " ") {
+			flags[t] = true
+		}
+	}
+
+	return flags
 }

--- a/cmd/meroxa/turbine/ruby/internal/cmd.go
+++ b/cmd/meroxa/turbine/ruby/internal/cmd.go
@@ -10,7 +10,7 @@ import (
 func NewTurbineCmd(appPath string, env map[string]string) *exec.Cmd {
 	cmd := exec.Command("ruby", []string{
 		"-r", path.Join(appPath, "app"),
-		"-e", "Turbine.run",
+		"-e", "TurbineRb.run",
 	}...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/meroxa/turbine/ruby/internal/cmd_test.go
+++ b/cmd/meroxa/turbine/ruby/internal/cmd_test.go
@@ -20,7 +20,7 @@ func Test_NewTurbineCmd(t *testing.T) {
 	assert.Equal(t, cmd.Args, []string{
 		"ruby",
 		"-r", "/my/path/app",
-		"-e", "Turbine.run",
+		"-e", "TurbineRb.run",
 	})
 	assert.Contains(t, cmd.Env, "foo=bar")
 	assert.Contains(t, cmd.Env, "x=y")


### PR DESCRIPTION
## Description of change

Fixes flapping test in `apps run` for ruby and renames `Turbine` to `TurbineRb`
## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
