### PR TITLE
Ignore low level logs from npm

### DIFF
--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -290,12 +290,12 @@ func RunCmdWithErrorDetection(ctx context.Context, cmd *exec.Cmd, l log.Logger) 
 			// ignore most npm messages
 			errorLogs := trimNonNpmErrorLines(stdErrMsg)
 			if len(errorLogs) > 0 {
-				errLog = stdErrMsg
+				errLog = errorLogs
 			}
 		} else if errMsg != "" {
 			errLog = errMsg
 		}
-		if errMsg != "" {
+		if errLog != "" {
 			if stdOutMsg != "" {
 				l.Info(ctx, "\n"+stdOutMsg+"\n")
 			}

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -287,16 +287,43 @@ func RunCmdWithErrorDetection(ctx context.Context, cmd *exec.Cmd, l log.Logger) 
 			errMsg = err.Error()
 		}
 		if stdErrMsg != "" {
-			errLog = stdErrMsg
+			// ignore most npm messages
+			errorLogs := trimNonNpmErrorLines(stdErrMsg)
+			if len(errorLogs) > 0 {
+				errLog = stdErrMsg
+			}
 		} else if errMsg != "" {
 			errLog = errMsg
 		}
-		if stdOutMsg != "" {
-			l.Info(ctx, "\n"+stdOutMsg+"\n")
+		if errMsg != "" {
+			if stdOutMsg != "" {
+				l.Info(ctx, "\n"+stdOutMsg+"\n")
+			}
+			return "", errors.New(errLog)
 		}
-		return "", errors.New(errLog)
 	}
 	return stdOutMsg, nil
+}
+
+func trimNonNpmErrorLines(output string) string {
+	ignoreThese := []string{"npm info", "npm timing", "npm http", "npm notice", "npm warn"}
+	allLines := strings.Split(output, "\n")
+	errorLines := []string{}
+
+	for _, line := range allLines {
+		skip := false
+		for _, ignore := range ignoreThese {
+			if strings.HasPrefix(line, ignore) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			errorLines = append(errorLines, line)
+		}
+	}
+
+	return strings.Join(errorLines, "\n")
 }
 
 // SwitchToAppDirectory switches temporarily to the application's directory.


### PR DESCRIPTION
## Description of change

Npm logs are sent to stderr and need to be processed especially to ignore most of them.

Fixes https://github.com/meroxa/turbine-project/issues/145

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

$ npm config set loglevel=info
$ m apps init --lang js --path ~/go/src/github.com/meroxa/jsdemos warntest4
	⠦ Initializing application "warntest4" in "/home/janelle/go/src/github.com/meroxa/jsdemos"...err: <nil>
stdout: 
stderr: npm info using npm@8.19.2
npm info using node@v16.17.0
npm timing npm:load:whichnode Completed in 1ms
npm timing config:load:defaults Completed in 1ms
npm timing config:load:file:/usr/local/lib/node_modules/npm/npmrc Completed in 4ms
npm timing config:load:builtin Completed in 4ms
npm timing config:load:cli Completed in 2ms
npm timing config:load:env Completed in 0ms
npm timing config:load:file:/home/janelle/go/src/github.com/meroxa/.npmrc Completed in 0ms
npm timing config:load:project Completed in 4ms
npm timing config:load:file:/home/janelle/.npmrc Completed in 1ms
npm timing config:load:user Completed in 1ms
npm timing config:load:file:/etc/npmrc Completed in 0ms
npm timing config:load:global Completed in 0ms
npm timing config:load:validate Completed in 2ms
npm timing config:load:credentials Completed in 0ms
npm timing config:load:setEnvs Completed in 1ms
npm timing config:load Completed in 16ms
npm timing npm:load:configload Completed in 16ms
npm timing npm:load:mkdirpcache Completed in 1ms
npm timing npm:load:mkdirplogs Completed in 1ms
npm timing npm:load:setTitle Completed in 1ms
npm timing config:load:flatten Completed in 2ms
npm timing npm:load:display Completed in 4ms
npm timing npm:load:logFile Completed in 5ms
npm timing npm:load:timers Completed in 0ms
npm timing npm:load:configScope Completed in 0ms
npm timing npm:load Completed in 29ms
npm timing arborist:ctor Completed in 1ms
npm timing arborist:ctor Completed in 0ms
npm http fetch GET 200 https://registry.npmjs.org/@meroxa%2Fturbine-js-cli 400ms (cache revalidated)
npm timing arborist:ctor Completed in 0ms
npm timing arborist:ctor Completed in 0ms
npm timing arborist:ctor Completed in 0ms
npm info using npm@8.19.2
npm info using node@v16.17.0
npm timing npm:load:whichnode Completed in 0ms
npm timing config:load:defaults Completed in 2ms
npm timing config:load:file:/usr/local/lib/node_modules/npm/npmrc Completed in 2ms
npm timing config:load:builtin Completed in 2ms
npm timing config:load:cli Completed in 3ms
npm timing config:load:env Completed in 1ms
npm timing config:load:file:/home/janelle/go/src/github.com/meroxa/jsdemos/warntest4/.npmrc Completed in 1ms
npm timing config:load:project Completed in 1ms
npm timing config:load:file:/home/janelle/.npmrc Completed in 2ms
npm timing config:load:user Completed in 2ms
npm timing config:load:file:/etc/npmrc Completed in 0ms
npm timing config:load:global Completed in 0ms
npm timing config:load:validate Completed in 1ms
npm timing config:load:credentials Completed in 1ms
npm timing config:load:setEnvs Completed in 1ms
npm timing config:load Completed in 15ms
npm timing npm:load:configload Completed in 15ms
npm timing npm:load:mkdirpcache Completed in 1ms
npm timing npm:load:mkdirplogs Completed in 0ms
npm timing npm:load:setTitle Completed in 1ms
npm timing config:load:flatten Completed in 2ms
npm timing npm:load:display Completed in 4ms
npm timing npm:load:logFile Completed in 4ms
npm timing npm:load:timers Completed in 1ms
npm timing npm:load:configScope Completed in 0ms
npm timing npm:load Completed in 26ms
npm timing arborist:ctor Completed in 1ms
npm timing arborist:ctor Completed in 0ms
npm timing idealTree:init Completed in 11ms
npm timing idealTree:userRequests Completed in 0ms
npm http fetch GET 200 https://registry.npmjs.org/@meroxa%2Fturbine-js-framework 411ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/string-hash 57ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/qunit 193ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/get-value 76ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/commander 112ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/set-value 117ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/google-protobuf 120ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/tiny-glob 124ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@grpc%2Fproto-loader 129ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/grpc-js-health-check 134ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@grpc%2Fgrpc-js 155ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/node-watch 225ms (cache revalidated)
npm timing idealTree:#root Completed in 907ms
npm http fetch GET 200 https://registry.npmjs.org/lodash.camelcase 81ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/is-primitive 80ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/long 83ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/lodash 82ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@types%2Fnode 90ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/protobufjs 98ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@types%2Flong 111ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/yargs 111ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/isobject 117ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/is-plain-object 169ms (cache revalidated)
npm timing idealTree:node_modules/@meroxa/turbine-js-framework Completed in 184ms
npm timing idealTree:node_modules/@grpc/grpc-js Completed in 1ms
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Faspromise 101ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Fcodegen 113ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/cliui 112ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Futf8 116ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Ffloat 120ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Feventemitter 130ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/require-directory 124ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/y18n 124ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Ffetch 135ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Fpath 135ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/get-caller-file 136ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/yargs-parser 137ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/string-width 142ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/escalade 145ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Finquire 150ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Fbase64 163ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/@protobufjs%2Fpool 187ms (cache revalidated)
npm timing idealTree:node_modules/@grpc/proto-loader Completed in 201ms
npm timing idealTree:node_modules/@types/long Completed in 0ms
npm timing idealTree:node_modules/@types/node Completed in 0ms
npm timing idealTree:node_modules/get-value Completed in 1ms
npm timing idealTree:node_modules/google-protobuf Completed in 0ms
npm timing idealTree:node_modules/grpc-js-health-check Completed in 6ms
npm timing idealTree:node_modules/isobject Completed in 0ms
npm timing idealTree:node_modules/lodash Completed in 0ms
npm timing idealTree:node_modules/lodash.camelcase Completed in 0ms
npm timing idealTree:node_modules/long Completed in 0ms
npm timing idealTree:node_modules/protobufjs Completed in 10ms
npm timing idealTree:node_modules/@protobufjs/aspromise Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/base64 Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/codegen Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/eventemitter Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/fetch Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/float Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/inquire Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/path Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/pool Completed in 0ms
npm timing idealTree:node_modules/@protobufjs/utf8 Completed in 0ms
npm http fetch GET 200 https://registry.npmjs.org/globalyzer 57ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/globrex 87ms (cache revalidated)
npm timing idealTree:node_modules/qunit Completed in 92ms
npm timing idealTree:node_modules/commander Completed in 0ms
npm timing idealTree:node_modules/node-watch Completed in 0ms
npm timing idealTree:node_modules/set-value Completed in 2ms
npm timing idealTree:node_modules/is-plain-object Completed in 1ms
npm timing idealTree:node_modules/is-primitive Completed in 0ms
npm timing idealTree:node_modules/string-hash Completed in 0ms
npm timing idealTree:node_modules/tiny-glob Completed in 2ms
npm timing idealTree:node_modules/globalyzer Completed in 0ms
npm timing idealTree:node_modules/globrex Completed in 0ms
npm http fetch GET 200 https://registry.npmjs.org/emoji-regex 64ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/strip-ansi 68ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/strip-ansi 72ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/is-fullwidth-code-point 75ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/wrap-ansi 86ms (cache revalidated)
npm timing idealTree:node_modules/yargs Completed in 96ms
npm http fetch GET 200 https://registry.npmjs.org/ansi-styles 62ms (cache revalidated)
npm http fetch GET 200 https://registry.npmjs.org/ansi-regex 64ms (cache revalidated)
npm timing idealTree:node_modules/cliui Completed in 67ms
npm timing idealTree:node_modules/escalade Completed in 0ms
npm timing idealTree:node_modules/get-caller-file Completed in 0ms
npm timing idealTree:node_modules/require-directory Completed in 0ms
npm timing idealTree:node_modules/string-width Completed in 2ms
npm timing idealTree:node_modules/emoji-regex Completed in 0ms
npm timing idealTree:node_modules/is-fullwidth-code-point Completed in 0ms
npm timing idealTree:node_modules/strip-ansi Completed in 1ms
npm timing idealTree:node_modules/ansi-regex Completed in 0ms
npm http fetch GET 200 https://registry.npmjs.org/color-convert 71ms (cache revalidated)
npm timing idealTree:node_modules/wrap-ansi Completed in 73ms
npm http fetch GET 200 https://registry.npmjs.org/color-name 52ms (cache revalidated)
npm timing idealTree:node_modules/ansi-styles Completed in 54ms
npm timing idealTree:node_modules/color-convert Completed in 1ms
npm timing idealTree:node_modules/color-name Completed in 0ms
npm timing idealTree:node_modules/y18n Completed in 0ms
npm timing idealTree:node_modules/yargs-parser Completed in 0ms
npm timing idealTree:node_modules/grpc-js-health-check/node_modules/@grpc/proto-loader Completed in 3ms
npm timing idealTree:node_modules/grpc-js-health-check/node_modules/protobufjs Completed in 0ms
npm timing idealTree:node_modules/protobufjs/node_modules/long Completed in 0ms
npm timing idealTree:buildDeps Completed in 1707ms
npm timing idealTree:fixDepFlags Completed in 1ms
npm timing idealTree Completed in 1720ms
npm timing reify:loadTrees Completed in 1721ms
npm timing reify:diffTrees Completed in 2ms
npm timing reify:retireShallow Completed in 1ms
npm timing reify:createSparse Completed in 13ms
npm timing reify:loadBundles Completed in 0ms
npm notice Beginning October 4, 2021, all connections to the npm registry - including for package installation - must use TLS 1.2 or higher. You are currently using plaintext http to connect. Please visit the GitHub blog for more information: https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/
npm http fetch POST 426 http://registry.npmjs.org/-/npm/v1/security/advisories/bulk 29ms
npm notice Beginning October 4, 2021, all connections to the npm registry - including for package installation - must use TLS 1.2 or higher. You are currently using plaintext http to connect. Please visit the GitHub blog for more information: https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/
npm http fetch POST 426 http://registry.npmjs.org/-/npm/v1/security/audits/quick 152ms
npm timing auditReport:getReport Completed in 196ms
npm timing reify:audit Completed in 196ms
npm timing reifyNode:node_modules/color-name Completed in 231ms
npm timing reifyNode:node_modules/wrap-ansi Completed in 232ms
npm timing reifyNode:node_modules/is-primitive Completed in 232ms
npm timing reifyNode:node_modules/@types/long Completed in 233ms
npm timing reifyNode:node_modules/ansi-regex Completed in 234ms
npm timing reifyNode:node_modules/is-fullwidth-code-point Completed in 234ms
npm timing reifyNode:node_modules/strip-ansi Completed in 234ms
npm timing reifyNode:node_modules/string-width Completed in 234ms
npm timing reifyNode:node_modules/globrex Completed in 234ms
npm timing reifyNode:node_modules/is-plain-object Completed in 235ms
npm timing reifyNode:node_modules/lodash.camelcase Completed in 235ms
npm timing reifyNode:node_modules/isobject Completed in 236ms
npm timing reifyNode:node_modules/set-value Completed in 236ms
npm timing reifyNode:node_modules/get-value Completed in 236ms
npm timing reifyNode:node_modules/ansi-styles Completed in 238ms
npm timing reifyNode:node_modules/get-caller-file Completed in 237ms
npm timing reifyNode:node_modules/globalyzer Completed in 238ms
npm timing reifyNode:node_modules/string-hash Completed in 237ms
npm timing reifyNode:node_modules/@protobufjs/path Completed in 239ms
npm timing reifyNode:node_modules/tiny-glob Completed in 239ms
npm timing reifyNode:node_modules/@protobufjs/codegen Completed in 239ms
npm timing reifyNode:node_modules/@protobufjs/eventemitter Completed in 240ms
npm timing reifyNode:node_modules/@protobufjs/fetch Completed in 240ms
npm timing reifyNode:node_modules/@protobufjs/aspromise Completed in 240ms
npm timing reifyNode:node_modules/@protobufjs/base64 Completed in 240ms
npm timing reifyNode:node_modules/require-directory Completed in 241ms
npm timing reifyNode:node_modules/@protobufjs/pool Completed in 241ms
npm timing reifyNode:node_modules/color-convert Completed in 243ms
npm timing reifyNode:node_modules/grpc-js-health-check Completed in 243ms
npm timing reifyNode:node_modules/node-watch Completed in 243ms
npm timing reifyNode:node_modules/grpc-js-health-check/node_modules/@grpc/proto-loader Completed in 244ms
npm timing reifyNode:node_modules/@protobufjs/utf8 Completed in 245ms
npm timing reifyNode:node_modules/escalade Completed in 245ms
npm timing reifyNode:node_modules/emoji-regex Completed in 246ms
npm timing reifyNode:node_modules/@protobufjs/float Completed in 246ms
npm timing reifyNode:node_modules/@protobufjs/inquire Completed in 246ms
npm timing reifyNode:node_modules/y18n Completed in 248ms
npm timing reifyNode:node_modules/cliui Completed in 247ms
npm timing reifyNode:node_modules/commander Completed in 250ms
npm timing reifyNode:node_modules/protobufjs/node_modules/long Completed in 251ms
npm timing reifyNode:node_modules/long Completed in 252ms
npm timing reifyNode:node_modules/@meroxa/turbine-js-framework Completed in 252ms
npm timing reifyNode:node_modules/yargs-parser Completed in 255ms
npm timing reifyNode:node_modules/@grpc/proto-loader Completed in 253ms
npm timing reifyNode:node_modules/qunit Completed in 258ms
npm timing reifyNode:node_modules/google-protobuf Completed in 290ms
npm timing reifyNode:node_modules/yargs Completed in 297ms
npm timing reifyNode:node_modules/protobufjs Completed in 374ms
npm timing reifyNode:node_modules/grpc-js-health-check/node_modules/protobufjs Completed in 401ms
npm timing reifyNode:node_modules/@types/node Completed in 406ms
npm timing reifyNode:node_modules/@grpc/grpc-js Completed in 451ms
npm timing reifyNode:node_modules/lodash Completed in 518ms
npm timing reify:unpack Completed in 519ms
npm timing reify:unretire Completed in 0ms
npm timing build:queue Completed in 2ms
npm timing build:link:node_modules/@grpc/proto-loader Completed in 21ms
npm timing build:link:node_modules/@meroxa/turbine-js-framework Completed in 21ms
npm timing build:link:node_modules/grpc-js-health-check/node_modules/protobufjs Completed in 21ms
npm timing build:link:node_modules/qunit Completed in 21ms
npm timing build:link Completed in 22ms
npm info run protobufjs@7.1.2 postinstall node_modules/protobufjs node scripts/postinstall
npm info run protobufjs@6.11.3 postinstall node_modules/grpc-js-health-check/node_modules/protobufjs node scripts/postinstall
npm info run protobufjs@7.1.2 postinstall { code: 0, signal: null }
npm timing build:run:postinstall:node_modules/protobufjs Completed in 68ms
npm info run protobufjs@6.11.3 postinstall { code: 0, signal: null }
npm timing build:run:postinstall:node_modules/grpc-js-health-check/node_modules/protobufjs Completed in 82ms
npm timing build:run:postinstall Completed in 94ms
npm timing build:deps Completed in 118ms
npm timing build Completed in 118ms
npm timing reify:build Completed in 118ms
npm timing reify:trash Completed in 0ms
npm timing reify:save Completed in 15ms
npm timing reify Completed in 2408ms
npm timing command:install Completed in 2417ms
npm timing npm Completed in 2525ms
npm info ok 
npm timing command:exec Completed in 4079ms
npm timing npm Completed in 4211ms
npm info ok 

	✔ Application directory created!
	✔ Git initialized successfully!
Turbine Data Application successfully initialized!
You can start interacting with Meroxa in your app located at "/home/janelle/go/src/github.com/meroxa/jsdemos/warntest4".
Your Application will not be visible in the Meroxa Dashboard until after deployment.



## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
