### PR TITLE
Do not gate the whole command on the ruby feature flag

### DIFF
--- a/cmd/meroxa/root/apps/init.go
+++ b/cmd/meroxa/root/apps/init.go
@@ -158,6 +158,9 @@ func newTurbineCLI(logger log.Logger, lang, path string) (turbine.CLI, error) {
 	case "py", turbine.Python3, turbine.Python:
 		return turbinePY.New(logger, path), nil
 	case "rb", turbine.Ruby:
+		if !builder.CheckFeatureFlag(turbineRb.TurbineRubyFeatureFlag) {
+			return nil, turbineRb.ErrTurbineRubyFeatureFlag
+		}
 		return turbineRb.New(logger, path), nil
 	default:
 		return nil, fmt.Errorf("language %q not supported. %s", lang, LanguageNotSupportedError)

--- a/cmd/meroxa/root/apps/run.go
+++ b/cmd/meroxa/root/apps/run.go
@@ -42,11 +42,10 @@ type Run struct {
 }
 
 var (
-	_ builder.CommandWithDocs        = (*Run)(nil)
-	_ builder.CommandWithFlags       = (*Run)(nil)
-	_ builder.CommandWithExecute     = (*Run)(nil)
-	_ builder.CommandWithLogger      = (*Run)(nil)
-	_ builder.CommandWithFeatureFlag = (*Run)(nil)
+	_ builder.CommandWithDocs    = (*Run)(nil)
+	_ builder.CommandWithFlags   = (*Run)(nil)
+	_ builder.CommandWithExecute = (*Run)(nil)
+	_ builder.CommandWithLogger  = (*Run)(nil)
 )
 
 func (*Run) Usage() string {
@@ -70,10 +69,6 @@ func (r *Run) Logger(logger log.Logger) {
 
 func (r *Run) Flags() []builder.Flag {
 	return builder.BuildFlags(&r.flags)
-}
-
-func (r *Run) FeatureFlag() (string, error) {
-	return turbineRB.TurbineRubyFeatureFlag, turbineRB.ErrTurbineRubyFeatureFlag
 }
 
 func (r *Run) Execute(ctx context.Context) error {
@@ -110,8 +105,8 @@ func (r *Run) Execute(ctx context.Context) error {
 		}
 		return r.turbineCLI.Run(ctx)
 	case "rb", turbine.Ruby:
-		if err = builder.CheckCMDFeatureFlag(r, r); err != nil {
-			return err
+		if !builder.CheckFeatureFlag(turbineRB.TurbineRubyFeatureFlag) {
+			return turbineRB.ErrTurbineRubyFeatureFlag
 		}
 		if r.turbineCLI == nil {
 			r.turbineCLI = turbineRB.New(r.logger, r.path)

--- a/cmd/meroxa/root/apps/upgrade.go
+++ b/cmd/meroxa/root/apps/upgrade.go
@@ -70,6 +70,7 @@ func (u *Upgrade) Flags() []builder.Flag {
 	return builder.BuildFlags(&u.flags)
 }
 
+//nolint:gocyclo
 func (u *Upgrade) Execute(ctx context.Context) error {
 	var err error
 	if u.config == nil {
@@ -90,24 +91,19 @@ func (u *Upgrade) Execute(ctx context.Context) error {
 		u.logger.StopSpinnerWithStatus(fmt.Sprintf("Determined the details of the %q Application", u.config.Name), log.Successful)
 	}
 
-	lang := u.config.Language
-	vendor, _ := strconv.ParseBool(u.config.Vendor)
-	switch lang {
+	switch u.config.Language {
 	case "go", turbine.GoLang:
 		if u.turbineCLI == nil {
 			u.turbineCLI = turbineGo.New(u.logger, u.path)
 		}
-		err = u.turbineCLI.Upgrade(vendor)
 	case "js", turbine.JavaScript, turbine.NodeJs:
 		if u.turbineCLI == nil {
 			u.turbineCLI = turbineJS.New(u.logger, u.path)
 		}
-		err = u.turbineCLI.Upgrade(vendor)
 	case "py", turbine.Python3, turbine.Python:
 		if u.turbineCLI == nil {
 			u.turbineCLI = turbinePY.New(u.logger, u.path)
 		}
-		err = u.turbineCLI.Upgrade(vendor)
 	case "ub", turbine.Ruby:
 		if !builder.CheckFeatureFlag(turbineRB.TurbineRubyFeatureFlag) {
 			return turbineRB.ErrTurbineRubyFeatureFlag
@@ -115,11 +111,11 @@ func (u *Upgrade) Execute(ctx context.Context) error {
 		if u.turbineCLI == nil {
 			u.turbineCLI = turbineRB.New(u.logger, u.path)
 		}
-		err = u.turbineCLI.Upgrade(vendor)
 	default:
-		return fmt.Errorf("language %q not supported. %s", lang, LanguageNotSupportedError)
+		return fmt.Errorf("language %q not supported. %s", u.config.Language, LanguageNotSupportedError)
 	}
-	if err != nil {
+	vendor, _ := strconv.ParseBool(u.config.Vendor)
+	if err = u.turbineCLI.Upgrade(vendor); err != nil {
 		return err
 	}
 
@@ -138,8 +134,7 @@ func (u *Upgrade) Execute(ctx context.Context) error {
 			},
 		}
 	}
-	err = u.run.Execute(ctx)
-	if err != nil {
+	if err = u.run.Execute(ctx); err != nil {
 		u.logger.Error(ctx, buf.String())
 		u.logger.StopSpinnerWithStatus("Upgrades were not entirely successful."+
 			" Fix any issues before adding and committing all upgrades.", log.Failed)

--- a/cmd/meroxa/root/apps/upgrade.go
+++ b/cmd/meroxa/root/apps/upgrade.go
@@ -27,6 +27,7 @@ import (
 	turbineGo "github.com/meroxa/cli/cmd/meroxa/turbine/golang"
 	turbineJS "github.com/meroxa/cli/cmd/meroxa/turbine/javascript"
 	turbinePY "github.com/meroxa/cli/cmd/meroxa/turbine/python"
+	turbineRB "github.com/meroxa/cli/cmd/meroxa/turbine/ruby"
 	"github.com/meroxa/cli/log"
 )
 
@@ -105,6 +106,14 @@ func (u *Upgrade) Execute(ctx context.Context) error {
 	case "py", turbine.Python3, turbine.Python:
 		if u.turbineCLI == nil {
 			u.turbineCLI = turbinePY.New(u.logger, u.path)
+		}
+		err = u.turbineCLI.Upgrade(vendor)
+	case "ub", turbine.Ruby:
+		if !builder.CheckFeatureFlag(turbineRB.TurbineRubyFeatureFlag) {
+			return turbineRB.ErrTurbineRubyFeatureFlag
+		}
+		if u.turbineCLI == nil {
+			u.turbineCLI = turbineRB.New(u.logger, u.path)
 		}
 		err = u.turbineCLI.Upgrade(vendor)
 	default:


### PR DESCRIPTION
## Description of change

=== RUN   TestAppMgmt/GO:_Run_app#01
    shared_test.go:164: /app/bin/meroxa --cli-config-file /root/meroxa.invited.env app run --path /apps/turbine_go/tmp/app/go-acceptance-app-2d055645-2cc9-481f-9e51-7b6a6fd21297 --json
    shared_test.go:166: Error: no access to the Meroxa Turbine Ruby feature.
        Sign up for the Beta here: https://share.hsforms.com/1Uq6UYoL8Q6eV5QzSiyIQkAc2sme
    turbine_test.go:410: exit status 1

run on a go app is being blocked on a lack of feature flag for ruby

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
