### PR TITLE
Git init failing

### DIFF
--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -195,7 +195,7 @@ func GitInit(ctx context.Context, appPath string) error {
 	}
 
 	if !isGitOlderThan228 {
-		cmd := exec.CommandContext(ctx, "git", "config", "init.defaultBranch", "main")
+		cmd = exec.CommandContext(ctx, "git", "config", "init.defaultBranch", "main")
 		cmd.Dir = appPath
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return errors.New(string(out))

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -189,19 +189,18 @@ func GitInit(ctx context.Context, appPath string) error {
 		return err
 	}
 
-	if !isGitOlderThan228 {
-		cmd := exec.CommandContext(ctx, "git", "config", "--global", "init.defaultBranch", "main")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return errors.New(string(out))
-		}
-	}
-
 	cmd := exec.CommandContext(ctx, "git", "init", appPath)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf(string(out))
 	}
 
-	if isGitOlderThan228 {
+	if !isGitOlderThan228 {
+		cmd := exec.CommandContext(ctx, "git", "config", "init.defaultBranch", "main")
+		cmd.Dir = appPath
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return errors.New(string(out))
+		}
+	} else {
 		cmd := exec.CommandContext(ctx, "git", "checkout", "-b", "main")
 		cmd.Dir = appPath
 		if out, err := cmd.CombinedOutput(); err != nil {

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -200,13 +200,13 @@ func GitInit(ctx context.Context, appPath string) error {
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return errors.New(string(out))
 		}
-	} else {
-		cmd := exec.CommandContext(ctx, "git", "checkout", "-b", "main")
-		cmd.Dir = appPath
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return errors.New(string(out))
-		}
 	}
+	cmd = exec.CommandContext(ctx, "git", "checkout", "-b", "main")
+	cmd.Dir = appPath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return errors.New(string(out))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description of change

	x 	The final step to 'git init' the Application repo failed. Please complete this step manually.
Error: warning: init.defaultbranch has multiple values
error: cannot overwrite multiple values with a single value
       Use a regexp, --add or --replace-all to change init.defaultBranch.


Setting the global config was a bit aggressive of us... just locally to the repo is better

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
