### PR TITLE
Filter npm logs from all npx calls

### DIFF
--- a/cmd/meroxa/turbine/javascript/init.go
+++ b/cmd/meroxa/turbine/javascript/init.go
@@ -7,8 +7,7 @@ import (
 )
 
 func (t *turbineJsCLI) Init(ctx context.Context, name string) error {
-	cmd := RunTurbineJS(ctx, "generate", name, t.appPath)
-	_, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	_, err := RunTurbineJS(ctx, t.logger, "generate", name, t.appPath)
 	return err
 }
 

--- a/cmd/meroxa/turbine/javascript/run.go
+++ b/cmd/meroxa/turbine/javascript/run.go
@@ -2,14 +2,11 @@ package turbinejs
 
 import (
 	"context"
-
-	utils "github.com/meroxa/cli/cmd/meroxa/turbine"
 )
 
 // Run calls turbine-js to exercise the app.
 func (t *turbineJsCLI) Run(ctx context.Context) (err error) {
-	cmd := RunTurbineJS(ctx, "test", t.appPath)
-	stdOut, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	stdOut, err := RunTurbineJS(ctx, t.logger, "test", t.appPath)
 	t.logger.Info(ctx, stdOut)
 	return err
 }

--- a/cmd/meroxa/turbine/javascript/version.go
+++ b/cmd/meroxa/turbine/javascript/version.go
@@ -9,11 +9,10 @@ import (
 
 // GetVersion calls turbine-js-cli to get the turbine-js-framework version used by the given app.
 func (t *turbineJsCLI) GetVersion(ctx context.Context) (string, error) {
-	cmd := RunTurbineJS(ctx, "version", t.appPath)
-	stdOut, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	stdOut, err := RunTurbineJS(ctx, t.logger, "version", t.appPath)
 	fmtErr := fmt.Errorf(
-		"unable to determine the version of turbine-js-framework used by the Meroxa Application at %s",
-		t.appPath)
+		"unable to determine the version of turbine-js-framework used by the Meroxa Application at %s: %s",
+		t.appPath, err)
 	if err != nil {
 		return "", fmtErr
 	}


### PR DESCRIPTION
## Description of change

Not all turbine-js-* commands were getting npm logs filtered out

Related to https://github.com/meroxa/turbine-project/issues/145

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
