### PR TITLE
Upgrade turbine-core version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/briandowns/spinner v1.20.0
 	github.com/docker/docker v20.10.22+incompatible
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-core v0.0.0-20221219202059-331a639bddb1
+	github.com/meroxa/turbine-core v0.0.0-20230113145603-c7b1554653fa
 	github.com/meroxa/turbine-go v1.0.0
 	github.com/stretchr/testify v1.8.1
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -538,8 +538,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182aff
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/meroxa/meroxa-go v0.0.0-20221213234938-21f713e84834 h1:QV74sMw7tXBJ6xFt76VDVXrQ7QHVfCuya1sYkdGdLWk=
 github.com/meroxa/meroxa-go v0.0.0-20221213234938-21f713e84834/go.mod h1:OdTP4P/yHcTAqOE86kDXoTTLqC1Vj+/PFMG41kOcmhI=
-github.com/meroxa/turbine-core v0.0.0-20221219202059-331a639bddb1 h1:lKOlEqUYrKYsWqlXVZyVOUhAtogF4OLR+360SLKI7kI=
-github.com/meroxa/turbine-core v0.0.0-20221219202059-331a639bddb1/go.mod h1:zhJZykOx6X/L2OKNv8a2P0w7LrwXv3nLh0BLIzfrUh8=
+github.com/meroxa/turbine-core v0.0.0-20230113145603-c7b1554653fa h1:addv/qyR+R6fqHBrJMf4sLp52BAfk4rf88f58aul1hw=
+github.com/meroxa/turbine-core v0.0.0-20230113145603-c7b1554653fa/go.mod h1:zhJZykOx6X/L2OKNv8a2P0w7LrwXv3nLh0BLIzfrUh8=
 github.com/meroxa/turbine-go v1.0.0 h1:5/mLoRbtdefpcC35fG3YZioz1qgrlaHOKh56n2hJ9lQ=
 github.com/meroxa/turbine-go v1.0.0/go.mod h1:RckvcPOI7MJYRw65dzwk+OFjsCMxaFbthqPBzUn6vQA=
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=

--- a/vendor/github.com/meroxa/turbine-core/pkg/ir/schema.json
+++ b/vendor/github.com/meroxa/turbine-core/pkg/ir/schema.json
@@ -16,7 +16,7 @@
                         },
                         "uuid": {
                             "type": "string",
-                            "minLength": 36,
+                            "minLength": 0,
                             "maxLength": 36
                         },
                         "type": {
@@ -74,7 +74,7 @@
                     "properties": {
                         "uuid": {
                             "type": "string",
-                            "minLength": 36,
+                            "minLength": 0,
                             "maxLength": 36
                         },
                         "name": {
@@ -92,6 +92,8 @@
                     ]
                 }
             ],
+            "minItems": 0,
+			"maxItems": 1,
             "uniqueItems": true
         },
         "streams": {
@@ -102,7 +104,7 @@
                     "properties": {
                         "name": {
                             "type": "string",
-                            "pattern": "^[a-zA-Z][a-zA-Z0-9-_]*$"
+                            "minLength": 1
                         },
                         "from_uuid": {
                             "type": "string",
@@ -116,7 +118,7 @@
                         },
                         "uuid": {
                             "type": "string",
-                            "minLength": 36,
+                            "minLength": 0,
                             "maxLength": 36
                         }
                     },

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -201,7 +201,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-core v0.0.0-20221219202059-331a639bddb1
+# github.com/meroxa/turbine-core v0.0.0-20230113145603-c7b1554653fa
 ## explicit; go 1.19
 github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core
 github.com/meroxa/turbine-core/pkg/app


### PR DESCRIPTION
## Description of change

Upgrade turbine-core version to ensure ruby is using 0.2.0 IR spec

Fixes <GitHub Issue>

Depends on https://github.com/meroxa/platform-api/pull/1580

## Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [x]  Tested in minikube

## Demo

```
{
  "connectors": [
    {
      "uuid": "a20271e8-45eb-42bb-b7e5-0d71f07da353",
      "type": "source",
      "resource": "pg",
      "collection": "sequences"
    },
    {
      "uuid": "767801e7-96a5-47d3-9b72-054ca9606863",
      "type": "destination",
      "resource": "pg",
      "collection": "testing1_no_fn_rb"
    },
    {
      "uuid": "1dd8f613-1779-45bd-8c02-c37e8c47f561",
      "type": "destination",
      "resource": "pg",
      "collection": "testing1_fn_rb"
    }
  ],
  "functions": [
    {
      "uuid": "af760fce-8ef0-4e9f-8146-4ec93140c170",
      "name": "passthrough",
      "image": "7131614c-0120-4277-8de5-d94447f07723"
    }
  ],
  "streams": [
    {
      "uuid": "57c58a10-3828-4e56-ad51-db35c548013d",
      "name": "a20271e8-45eb-42bb-b7e5-0d71f07da353_af760fce-8ef0-4e9f-8146-4ec93140c170",
      "from_uuid": "a20271e8-45eb-42bb-b7e5-0d71f07da353",
      "to_uuid": "af760fce-8ef0-4e9f-8146-4ec93140c170"
    },
    {
      "uuid": "8e70dbd8-5926-41e0-8a41-c330959d6edc",
      "name": "a20271e8-45eb-42bb-b7e5-0d71f07da353_767801e7-96a5-47d3-9b72-054ca9606863",
      "from_uuid": "a20271e8-45eb-42bb-b7e5-0d71f07da353",
      "to_uuid": "767801e7-96a5-47d3-9b72-054ca9606863"
    },
    {
      "uuid": "54892041-43df-4c96-9f2d-63a87f31cb6e",
      "name": "af760fce-8ef0-4e9f-8146-4ec93140c170_1dd8f613-1779-45bd-8c02-c37e8c47f561",
      "from_uuid": "af760fce-8ef0-4e9f-8146-4ec93140c170",
      "to_uuid": "1dd8f613-1779-45bd-8c02-c37e8c47f561"
    }
  ],
  "definition": {
    "git_sha": "5088c2e0d0ee35bd27a7ea9d349b13bebf932077",
    "metadata": {
      "turbine": {
        "language": "ruby",
        "version": "0.2.5"
      },
      "spec_version": "0.2.0"
    }
  }
}
```