### PR TITLE
fix: wrong gem name

### DIFF
--- a/cmd/meroxa/turbine/ruby/version.go
+++ b/cmd/meroxa/turbine/ruby/version.go
@@ -12,7 +12,7 @@ func (t *turbineRbCLI) GetVersion(ctx context.Context) (string, error) {
 	cmd := exec.Command("ruby", []string{
 		"-r", "rubygems",
 		"-r", fmt.Sprintf("%s/app", t.appPath),
-		"-e", `'puts Gem.loaded_specs["turbin_rb"].version.version'`,
+		"-e", `'puts Gem.loaded_specs["turbine_rb"].version.version'`,
 	}...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Description of change

Testing a ruby application in staging noticed this issue.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Tested in staging

## Demo

**before**

```
$ meroxa apps deploy ...
Validating your app.json...
	✔ Checked your language is "ruby"
	✔ Checked your application name is "ruby-example"
Error: unable to determine the turbine-rb version of the Meroxa Application at /Users/rb/code/meroxa/turbine-examples/ruby/simple
```

**after**

```
$ meroxa apps deploy ...
Validating your app.json...
	✔ Checked your language is "ruby"
	✔ Checked your application name is "ruby-example"
Checking for uncommitted changes...
...
```


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
