### PR TITLE
Update format of Resource Types list

### DIFF
--- a/cmd/meroxa/root/resources/list.go
+++ b/cmd/meroxa/root/resources/list.go
@@ -19,10 +19,9 @@ package resources
 import (
 	"context"
 
-	"github.com/meroxa/cli/utils/display"
-
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils/display"
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 )
 
@@ -38,7 +37,7 @@ var (
 
 type listResourcesClient interface {
 	ListResources(ctx context.Context) ([]*meroxa.Resource, error)
-	ListResourceTypes(ctx context.Context) ([]string, error)
+	ListResourceTypesV2(ctx context.Context) ([]meroxa.ResourceType, error)
 }
 
 type List struct {
@@ -75,21 +74,15 @@ func (l *List) Aliases() []string {
 }
 
 func (l *List) Execute(ctx context.Context) error {
-	var err error
-
 	// What used to be `meroxa list resource-types`
 	if l.flags.Types || l.flags.Type || l.ListTypes {
-		var rTypes []string
-
-		rTypes, err = l.client.ListResourceTypes(ctx)
-
+		rTypes, err := l.client.ListResourceTypesV2(ctx)
 		if err != nil {
 			return err
 		}
 
 		l.logger.JSON(ctx, rTypes)
 		l.logger.Info(ctx, display.ResourceTypesTable(rTypes, l.hideHeaders))
-
 		return nil
 	}
 

--- a/cmd/meroxa/root/resources/list_test.go
+++ b/cmd/meroxa/root/resources/list_test.go
@@ -129,21 +129,61 @@ func TestListResourceTypesExecution(t *testing.T) {
 	client := mock.NewMockClient(ctrl)
 	logger := log.NewTestLogger()
 
-	var types = []string{
-		"postgres",
-		"s3",
-		"redshift",
-		"mysql",
-		"url",
-		"mongodb",
-		"elasticsearch",
-		"snowflakedb",
-		"bigquery",
+	var types = []meroxa.ResourceType{
+		{
+			Name:         string(meroxa.ResourceTypePostgres),
+			ReleaseStage: meroxa.ResourceTypeReleaseStageBeta,
+			FormConfig: map[string]interface{}{
+				meroxa.ResourceTypeFormConfigHumanReadableKey: "PostgreSQL",
+			},
+		},
+		{
+			Name:         string(meroxa.ResourceTypeS3),
+			ReleaseStage: meroxa.ResourceTypeReleaseStageBeta,
+			FormConfig: map[string]interface{}{
+				meroxa.ResourceTypeFormConfigHumanReadableKey: "AWS S3",
+			},
+		},
+		{
+			Name:         string(meroxa.ResourceTypeRedshift),
+			ReleaseStage: meroxa.ResourceTypeReleaseStageBeta,
+			FormConfig: map[string]interface{}{
+				meroxa.ResourceTypeFormConfigHumanReadableKey: "AWS Redshift",
+			},
+		},
+		{
+			Name:         string(meroxa.ResourceTypeMysql),
+			ReleaseStage: meroxa.ResourceTypeReleaseStageBeta,
+			FormConfig: map[string]interface{}{
+				meroxa.ResourceTypeFormConfigHumanReadableKey: "MySQL",
+			},
+		},
+		{
+			Name:         string(meroxa.ResourceTypeUrl),
+			ReleaseStage: meroxa.ResourceTypeReleaseStageBeta,
+			FormConfig: map[string]interface{}{
+				meroxa.ResourceTypeFormConfigHumanReadableKey: "Generic HTTP",
+			},
+		},
+		{
+			Name:         string(meroxa.ResourceTypeMongodb),
+			ReleaseStage: meroxa.ResourceTypeReleaseStageBeta,
+			FormConfig: map[string]interface{}{
+				meroxa.ResourceTypeFormConfigHumanReadableKey: "MongoDB",
+			},
+		},
+		{
+			Name:         string(meroxa.ResourceTypeElasticsearch),
+			ReleaseStage: meroxa.ResourceTypeReleaseStageBeta,
+			FormConfig: map[string]interface{}{
+				meroxa.ResourceTypeFormConfigHumanReadableKey: "Elasticsearch",
+			},
+		},
 	}
 
 	client.
 		EXPECT().
-		ListResourceTypes(ctx).
+		ListResourceTypesV2(ctx).
 		Return(types, nil)
 
 	l := &List{
@@ -167,7 +207,7 @@ func TestListResourceTypesExecution(t *testing.T) {
 	}
 
 	gotJSONOutput := logger.JSONOutput()
-	var gotTypes []string
+	var gotTypes []meroxa.ResourceType
 	err = json.Unmarshal([]byte(gotJSONOutput), &gotTypes)
 
 	if err != nil {

--- a/utils/display/resources.go
+++ b/utils/display/resources.go
@@ -2,8 +2,10 @@ package display
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/alexeyco/simpletable"
+
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 )
 
@@ -128,20 +130,54 @@ func PrintResourcesTable(resources []*meroxa.Resource, hideHeaders bool) {
 	fmt.Println(ResourcesTable(resources, hideHeaders))
 }
 
-func ResourceTypesTable(types []string, hideHeaders bool) string {
+func ResourceTypesTable(types []meroxa.ResourceType, hideHeaders bool) string {
+	gaResourceNames := []string{}
+	gaResourceTypes := make(map[string]string)
+	betaResourceNames := []string{}
+	betaResourceTypes := make(map[string]string)
+
+	for _, t := range types {
+		val := fmt.Sprintf("%s", t.FormConfig[meroxa.ResourceTypeFormConfigHumanReadableKey])
+		if val == "" {
+			continue
+		}
+		if t.ReleaseStage == meroxa.ResourceTypeReleaseStageGA {
+			gaResourceNames = append(gaResourceNames, val)
+			gaResourceTypes[val] = t.Name
+		} else if t.ReleaseStage == meroxa.ResourceTypeReleaseStageBeta {
+			betaResourceNames = append(betaResourceNames, val)
+			betaResourceTypes[val] = t.Name
+		}
+	}
+	sort.Strings(gaResourceNames)
+	sort.Strings(betaResourceNames)
+
 	table := simpletable.New()
 
 	if !hideHeaders {
 		table.Header = &simpletable.Header{
 			Cells: []*simpletable.Cell{
-				{Align: simpletable.AlignCenter, Text: "TYPES"},
+				{Align: simpletable.AlignCenter, Text: "NAME"},
+				{Align: simpletable.AlignCenter, Text: "TYPE"},
+				{Align: simpletable.AlignCenter, Text: "RELEASE STAGE"},
 			},
 		}
 	}
 
-	for _, t := range types {
+	for _, t := range gaResourceNames {
 		r := []*simpletable.Cell{
-			{Align: simpletable.AlignRight, Text: t},
+			{Align: simpletable.AlignLeft, Text: t},
+			{Align: simpletable.AlignLeft, Text: gaResourceTypes[t]},
+			{Align: simpletable.AlignLeft, Text: string(meroxa.ResourceTypeReleaseStageGA)},
+		}
+
+		table.Body.Cells = append(table.Body.Cells, r)
+	}
+	for _, t := range betaResourceNames {
+		r := []*simpletable.Cell{
+			{Align: simpletable.AlignLeft, Text: t},
+			{Align: simpletable.AlignLeft, Text: betaResourceTypes[t]},
+			{Align: simpletable.AlignLeft, Text: string(meroxa.ResourceTypeReleaseStageBeta)},
 		}
 
 		table.Body.Cells = append(table.Body.Cells, r)
@@ -150,6 +186,6 @@ func ResourceTypesTable(types []string, hideHeaders bool) string {
 	return table.String()
 }
 
-func PrintResourceTypesTable(types []string, hideHeaders bool) {
+func PrintResourceTypesTable(types []meroxa.ResourceType, hideHeaders bool) {
 	fmt.Println(ResourceTypesTable(types, hideHeaders))
 }

--- a/utils/display/resources_test.go
+++ b/utils/display/resources_test.go
@@ -133,10 +133,13 @@ func TestResourceTypesTable(t *testing.T) {
 		PrintResourceTypesTable(types, false)
 	})
 
-	if !strings.Contains(out, "Resource Type") {
-		t.Errorf("table headers is missing")
+	if !strings.Contains(out, "NAME") {
+		t.Errorf("NAME table headers is missing")
 	}
-	if !strings.Contains(out, "Release Stage") {
+	if !strings.Contains(out, "TYPE") {
+		t.Errorf("TYPE table headers is missing")
+	}
+	if !strings.Contains(out, "RELEASE STAGE") {
 		t.Errorf("table headers is missing")
 	}
 
@@ -154,11 +157,14 @@ func TestResourceTypesTableWithoutHeaders(t *testing.T) {
 		PrintResourceTypesTable(types, true)
 	})
 
-	if strings.Contains(out, "Resource Type") {
-		t.Errorf("table headers unexpected")
+	if strings.Contains(out, "NAME") {
+		t.Errorf("NAME table headers unexpected")
 	}
-	if strings.Contains(out, "Release Stage") {
-		t.Errorf("table headers unexpected")
+	if strings.Contains(out, "TYPE") {
+		t.Errorf("TYPE table headers unexpected")
+	}
+	if strings.Contains(out, "RELEASE STAGE") {
+		t.Errorf("RELEASE STAGE table headers unexpected")
 	}
 
 	for _, rType := range types {

--- a/utils/display/resources_test.go
+++ b/utils/display/resources_test.go
@@ -118,37 +118,54 @@ func TestResourcesTableWithoutHeaders(t *testing.T) {
 	}
 }
 
-func TestResourceTypesTable(t *testing.T) {
-	types := []string{"postgres", "s3", "redshift", "mysql", "jdbc", "url", "mongodb"}
+var types = []meroxa.ResourceType{
+	{
+		Name:         string(meroxa.ResourceTypePostgres),
+		ReleaseStage: meroxa.ResourceTypeReleaseStageBeta,
+		FormConfig: map[string]interface{}{
+			meroxa.ResourceTypeFormConfigHumanReadableKey: "PostgreSQL",
+		},
+	},
+}
 
+func TestResourceTypesTable(t *testing.T) {
 	out := utils.CaptureOutput(func() {
 		PrintResourceTypesTable(types, false)
 	})
 
-	if !strings.Contains(out, "TYPES") {
+	if !strings.Contains(out, "Resource Type") {
+		t.Errorf("table headers is missing")
+	}
+	if !strings.Contains(out, "Release Stage") {
 		t.Errorf("table headers is missing")
 	}
 
 	for _, rType := range types {
-		if !strings.Contains(out, rType) {
-			t.Errorf("%s, not found", rType)
+		if !strings.Contains(
+			out,
+			fmt.Sprintf("%s", rType.FormConfig[meroxa.ResourceTypeFormConfigHumanReadableKey])) {
+			t.Errorf("%s, not found", rType.Name)
 		}
 	}
 }
 
 func TestResourceTypesTableWithoutHeaders(t *testing.T) {
-	types := []string{"postgres", "s3", "redshift", "mysql", "jdbc", "url", "mongodb"}
 	out := utils.CaptureOutput(func() {
 		PrintResourceTypesTable(types, true)
 	})
 
-	if strings.Contains(out, "TYPES") {
-		t.Errorf("table header should not be displayed")
+	if strings.Contains(out, "Resource Type") {
+		t.Errorf("table headers unexpected")
+	}
+	if strings.Contains(out, "Release Stage") {
+		t.Errorf("table headers unexpected")
 	}
 
 	for _, rType := range types {
-		if !strings.Contains(out, rType) {
-			t.Errorf("%s, not found", rType)
+		if !strings.Contains(
+			out,
+			fmt.Sprintf("%s", rType.FormConfig[meroxa.ResourceTypeFormConfigHumanReadableKey])) {
+			t.Errorf("%s, not found", rType.Name)
 		}
 	}
 }


### PR DESCRIPTION
## Description of change

Update the resource type list format to display type name and release stage
provide a link to the Resource Catalog in the Dashboard

Fixes https://github.com/meroxa/cli/issues/596

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
| 
![Screenshot from 2023-01-30 18-07-35](https://user-images.githubusercontent.com/12731615/215641658-ec972d32-8c60-4bd8-be85-d8231f2978d4.png)
|
![Screenshot from 2023-01-31 10-57-20](https://user-images.githubusercontent.com/12731615/215860825-c34b6c2f-5f4a-49ab-a93a-63473b25b20d.png)


|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
