### PR TITLE
feat(apps): Include environment info in `apps describe`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,3 +95,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.sum
+++ b/go.sum
@@ -536,8 +536,6 @@ github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lL
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
-github.com/meroxa/meroxa-go v0.0.0-20230130142300-e99165dbd53f h1:ZvvLmUiTzEaVMuF3YFrMgGhF6JjvRl4Fluy53VQdJqM=
-github.com/meroxa/meroxa-go v0.0.0-20230130142300-e99165dbd53f/go.mod h1:OdTP4P/yHcTAqOE86kDXoTTLqC1Vj+/PFMG41kOcmhI=
 github.com/meroxa/turbine-core v0.0.0-20230113145603-c7b1554653fa h1:addv/qyR+R6fqHBrJMf4sLp52BAfk4rf88f58aul1hw=
 github.com/meroxa/turbine-core v0.0.0-20230113145603-c7b1554653fa/go.mod h1:zhJZykOx6X/L2OKNv8a2P0w7LrwXv3nLh0BLIzfrUh8=
 github.com/meroxa/turbine-go v1.0.0 h1:5/mLoRbtdefpcC35fG3YZioz1qgrlaHOKh56n2hJ9lQ=

--- a/utils/display/apps.go
+++ b/utils/display/apps.go
@@ -105,6 +105,10 @@ func AppTable(app *meroxa.Application) string {
 	if subTable != "" {
 		output += "\n" + subTable
 	}
+	subTable = appEnvironmentTable(app.Environment)
+	if subTable != "" {
+		output += "\n" + subTable
+	}
 	subTable = appFunctionsTable(app.Functions)
 	if subTable != "" {
 		output += "\n" + subTable
@@ -147,6 +151,20 @@ func appResourcesTable(resources []meroxa.ApplicationResource, connectors []mero
 		}
 		status = ""
 	}
+
+	return subTable
+}
+
+func appEnvironmentTable(env meroxa.ApplicationEnvironment) string {
+	if !itShouldEnvInfo(env) {
+		return ""
+	}
+	subTable := "\tEnvironment\n"
+
+	subTable += fmt.Sprintf("\t    %s\n", env.Name)
+	subTable += fmt.Sprintf("\t\t\t\t%5s:\t\t\t%s\n", "UUID", env.UUID)
+	subTable += fmt.Sprintf("\t\t\t\t %5s:  %s\n", "Provider", env.Provider)
+	subTable += fmt.Sprintf("\t\t\t\t%5s:\t\t\t%s\n", "Type", env.Type)
 
 	return subTable
 }

--- a/utils/display/apps_test.go
+++ b/utils/display/apps_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/meroxa/cli/utils"
+
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 )
 
@@ -37,5 +39,85 @@ func TestAppLogsTable(t *testing.T) {
 	}
 	if !strings.Contains(out, fmt.Sprintf("# Logs for %s deployment\n\n%s", deploymentUUID, log)) {
 		t.Errorf("expected %q to be shown with logs", deploymentUUID)
+	}
+}
+
+func TestAppDescribeTable(t *testing.T) {
+	testCases := []struct {
+		desc                 string
+		app                  func() *meroxa.Application
+		shouldErrorOnEnvInfo func(string) bool
+	}{
+		{
+			desc: "Application with no environment",
+			app: func() *meroxa.Application {
+				a := utils.GenerateApplication("")
+				return &a
+			},
+			shouldErrorOnEnvInfo: func(output string) bool {
+				return strings.Contains(output, "Environment")
+			},
+		},
+		{
+			desc: "Application with a common environment",
+			app: func() *meroxa.Application {
+				a := utils.GenerateApplicationWithEnv("", meroxa.EnvironmentTypeCommon, "")
+				return &a
+			},
+			shouldErrorOnEnvInfo: func(output string) bool {
+				return strings.Contains(output, "Environment")
+			},
+		},
+		{
+			desc: "Application with in a private environment",
+			app: func() *meroxa.Application {
+				a := utils.GenerateApplicationWithEnv("", meroxa.EnvironmentTypePrivate, meroxa.EnvironmentProviderAws)
+				return &a
+			},
+			shouldErrorOnEnvInfo: func(output string) bool {
+				return !strings.Contains(output, "Environment")
+			},
+		},
+		{
+			desc: "Application with in a private environment",
+			app: func() *meroxa.Application {
+				a := utils.GenerateApplicationWithEnv("", meroxa.EnvironmentTypeSelfHosted, "")
+				return &a
+			},
+			shouldErrorOnEnvInfo: func(output string) bool {
+				return !strings.Contains(output, "Environment")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			app := tc.app()
+			out := AppTable(app)
+			if !strings.Contains(out, "UUID") {
+				t.Errorf("expected %q to be shown\n%s\n", app.UUID, out)
+			}
+			if !strings.Contains(out, "Name:") {
+				t.Errorf("expected %q to be shown\n%s\n", app.Name, out)
+			}
+			if !strings.Contains(out, "Language:") {
+				t.Errorf("expected %q to be shown\n%s\n", app.Language, out)
+			}
+			if !strings.Contains(out, "Git SHA:") {
+				t.Errorf("expected %q to be shown\n%s\n", app.GitSha, out)
+			}
+			if !strings.Contains(out, "Created At:") {
+				t.Errorf("expected %q to be shown\n%s\n", app.CreatedAt, out)
+			}
+			if !strings.Contains(out, "Updated At:") {
+				t.Errorf("expected %q to be shown\n%s\n", app.UpdatedAt, out)
+			}
+			if !strings.Contains(out, "State:") {
+				t.Errorf("expected %q to be shown\n%s\n", app.Status.State, out)
+			}
+			if tc.shouldErrorOnEnvInfo(out) {
+				t.Errorf("expected environment information to be shown\n%s\n", out)
+			}
+		})
 	}
 }

--- a/utils/tests.go
+++ b/utils/tests.go
@@ -190,7 +190,7 @@ func GenerateApplicationWithEnv(
 	provider meroxa.EnvironmentProvider) meroxa.Application {
 	app := GenerateApplication(state)
 	app.Environment = meroxa.ApplicationEnvironment{
-		EntityIdentifier: meroxa.EntityIdentifier{Name: "my-env"},
+		EntityIdentifier: meroxa.EntityIdentifier{UUID: uuid.NewString(), Name: "my-env"},
 		Provider:         provider,
 		Type:             envType,
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -197,7 +197,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20230130142300-e99165dbd53f
+# github.com/meroxa/meroxa-go v0.0.0-20230130142300-e99165dbd53f => ../meroxa-go
 ## explicit; go 1.17
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
@@ -466,3 +466,4 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/meroxa/meroxa-go => ../meroxa-go


### PR DESCRIPTION
## Description of change

Fixes https://github.com/meroxa/cli/issues/592

⚠️ It's branched off https://github.com/meroxa/cli/pull/603

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

**Before**

```
$ meroxa app describe rubyapp   
       UUID:   6c5e1c07-a42e-4079-85e1-efeceaae777f     
       Name:   rubyapp                                  
   Language:   ruby                                     
    Git SHA:   a29551e15bdb9363edd319dee46403a4e4b4b6cd 
 Created At:   2023-01-17 19:36:59 +0000 UTC            
 Updated At:   2023-01-17 19:36:59 +0000 UTC            
      State:   degraded                                 
	Resources
	    dest (destination)
		 UUID:   04636b3d-1ccd-4a5a-bb2a-5969abb52395
		 Type:   postgres
		State:   running
	    dest2 (destination)
		 UUID:   ceb130fa-3769-4796-8f47-a2471fa18a07
		 Type:   postgres
		State:   running
	    source (source)
		 UUID:   bd295652-df7f-44ec-acf8-3a75e8d2e079
		 Type:   postgres
		State:   failed
```

**Now with no environment Info, or if environment is common**

Same as _**Before**_

**With environment Info (that's not common)**

```
$ meroxa app describe rubyapp   
       UUID:   6c5e1c07-a42e-4079-85e1-efeceaae777f     
       Name:   rubyapp                                  
   Language:   ruby                                     
    Git SHA:   a29551e15bdb9363edd319dee46403a4e4b4b6cd 
 Created At:   2023-01-17 19:36:59 +0000 UTC            
 Updated At:   2023-01-17 19:36:59 +0000 UTC            
      State:   degraded                                 
	Resources
	    dest (destination)
		 UUID:   04636b3d-1ccd-4a5a-bb2a-5969abb52395
		 Type:   postgres
		State:   running
	    dest2 (destination)
		 UUID:   ceb130fa-3769-4796-8f47-a2471fa18a07
		 Type:   postgres
		State:   running
	    source (source)
		 UUID:   bd295652-df7f-44ec-acf8-3a75e8d2e079
		 Type:   postgres
		State:   failed
        Environment 
             my-env 
                 UUID:	    b614bd17-477a-4717-a61a-b8774081b9e0
                 Provider:  aws
                 Type:	    private
```
