### PR TITLE
Ignore brew errors

### DIFF
--- a/cmd/meroxa/builder/builder.go
+++ b/cmd/meroxa/builder/builder.go
@@ -503,8 +503,8 @@ func buildCommandAutoUpdate(cmd *cobra.Command) {
 
 			github.Client = &http.Client{}
 			latestCLIVersion, err := github.GetLatestCLITag(cmd.Context())
-			if err != nil {
-				return err
+			if err != nil || latestCLIVersion == "" {
+				return nil
 			}
 
 			if global.Version != latestCLIVersion {

--- a/cmd/meroxa/github/github.go
+++ b/cmd/meroxa/github/github.go
@@ -73,7 +73,11 @@ func getContentHomebrewFormula(ctx context.Context) (string, error) {
 // and extracts its version number.
 func parseVersionFromFormulaFile(content string) string {
 	r := regexp.MustCompile(`version "(\d+.\d+.\d+)"`)
-	return r.FindStringSubmatch(content)[1]
+	matches := r.FindStringSubmatch(content)
+	if len(matches) >= 2 { //nolint:gomnd
+		return matches[1]
+	}
+	return ""
 }
 
 // GetLatestCLITag fetches the content formula file from GitHub and then parses its version.


### PR DESCRIPTION
## Description of change

Acceptance tests failed because we didn't get a coherent response from brew.  Printing the upgrade message doesn't seem important enough to fail, so these changes just skip it and exit with no error instead.

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

=== RUN   TestCollaborationsMySQLToPG/list_resource_types
    shared_test.go:164: /app/bin/meroxa --cli-config-file /root/meroxa.main.env resources list --types
    shared_test.go:166:      TYPES      
        ================
               bigquery 
          elasticsearch 
                  kafka 
                mongodb 
                  mysql 
               postgres 
               redshift 
                     s3 
            snowflakedb 
              sqlserver 
                 notion 
         confluentcloud 
        panic: runtime error: index out of range [1] with length 0
        
        goroutine 1 [running]:
        github.com/meroxa/cli/cmd/meroxa/github.parseVersionFromFormulaFile({0x0, 0x0})
        	/build/cli/cmd/meroxa/github/github.go:76 +0x68
        github.com/meroxa/cli/cmd/meroxa/github.GetLatestCLITag({0xe09988?, 0xc000050030?})
        	/build/cli/cmd/meroxa/github/github.go:87 +0x39
        github.com/meroxa/cli/cmd/meroxa/builder.buildCommandAutoUpdate.func1(0xc0004e6000, {0xc000411350?, 0x0?, 0x1?})
        	/build/cli/cmd/meroxa/builder/builder.go:505 +0x1a6
        github.com/spf13/cobra.(*Command).execute(0xc0004e6000, {0xc000034230, 0x1, 0x1})
        	/build/cli/vendor/github.com/spf13/cobra/command.go:923 +0x8c3
        github.com/spf13/cobra.(*Command).ExecuteC(0xc0004be000)
        	/build/cli/vendor/github.com/spf13/cobra/command.go:1044 +0x3bd
        github.com/spf13/cobra.(*Command).Execute(...)
        	/build/cli/vendor/github.com/spf13/cobra/command.go:968
        github.com/spf13/cobra.(*Command).ExecuteContext(...)
        	/build/cli/vendor/github.com/spf13/cobra/command.go:961
        github.com/meroxa/cli/cmd/meroxa/root.Run()
        	/build/cli/cmd/meroxa/root/root.go:52 +0x65
        main.main()
        	/build/cli/cmd/meroxa/main.go:52 +0x253
        
    mysql_collaborations_test.go:125: exit status 2

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
