### PR TITLE
Pass env info on app deploy to api

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -912,19 +912,17 @@ func (d *Deploy) Execute(ctx context.Context) error {
 		if err = ir.ValidateSpecVersion(d.specVersion); err != nil {
 			return err
 		}
-
-		// Creates application
-		app, err = d.client.CreateApplicationV2(ctx, &meroxa.CreateApplicationInput{
+		appInput := &meroxa.CreateApplicationInput{
 			Name:     d.appName,
 			Language: d.lang,
 			GitSha:   gitSha,
-		})
-
-		if d.flags.Environment != "" {
-			app.Environment = meroxa.ApplicationEnvironment{
-				EntityIdentifier: meroxa.EntityIdentifier{Name: d.flags.Environment},
-			}
 		}
+		// Creates application
+		if d.flags.Environment != "" {
+			appInput.Environment = &meroxa.EntityIdentifier{Name: d.flags.Environment}
+		}
+		app, err = d.client.CreateApplicationV2(ctx, appInput)
+
 		if err != nil {
 			if strings.Contains(err.Error(), "already exists") {
 				msg := fmt.Sprintf("%s\n\tUse `meroxa apps remove %s` if you want to redeploy to this application", err, d.appName)


### PR DESCRIPTION
## Description of change

Pass env info on app deploy to api


Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

App 1-2 were created without the change, apps 3-4 were created with the change in this PR 
```
meroxa-api=# select id, name, language, environment_uuid from application;
 id |  name   | language |           environment_uuid           
----+---------+----------+--------------------------------------
  1 | test-rb | ruby     | 
  2 | test-rb | ruby     | 
  3 | test-rb | ruby     | 9364f5ef-3b09-4b63-85f6-b9588c69f613
  4 | test-rb | ruby     | 9364f5ef-3b09-4b63-85f6-b9588c69f613
```

