### PR TITLE
Ensure turbine resource is in the same environment as the app

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -567,6 +567,7 @@ func (d *Deploy) validateAppJSON(ctx context.Context) error {
 
 func (d *Deploy) validateResources(ctx context.Context, rr []turbine.ApplicationResource) error {
 	var errs []error
+	validated := make(map[string]bool)
 
 	wrapNotFound := func(name string, err error) error {
 		if strings.Contains(err.Error(), "could not find") {
@@ -576,6 +577,11 @@ func (d *Deploy) validateResources(ctx context.Context, rr []turbine.Application
 	}
 
 	for _, r := range rr {
+		// dedup resources for validation
+		if _, ok := validated[r.Name]; ok {
+			continue
+		}
+
 		resource, err := d.client.GetResourceByNameOrID(ctx, r.Name)
 		// order is important
 		switch {
@@ -606,6 +612,8 @@ func (d *Deploy) validateResources(ctx context.Context, rr []turbine.Application
 				resource.Environment.Name,
 			))
 		}
+
+		validated[r.Name] = true
 	}
 
 	return wrapErrors(errs)

--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -592,7 +592,7 @@ func (d *Deploy) validateResources(ctx context.Context, rr []turbine.Application
 		// app is provisioned in common env, but resource was added at self hosted env
 		case d.flags.Environment == "" && resource.Environment != nil:
 			errs = append(errs, fmt.Errorf(
-				"resource %q is in common env, but app is in %q",
+				"resource %q is in %q, but app is in common",
 				r.Name,
 				resource.Environment.Name,
 			))

--- a/cmd/meroxa/root/apps/deploy_test.go
+++ b/cmd/meroxa/root/apps/deploy_test.go
@@ -238,6 +238,7 @@ func Test_validateResource(t *testing.T) {
 	appResources := []turbine.ApplicationResource{
 		{Name: "nozzle"},
 		{Name: "engine"},
+		{Name: "engine"}, // should be dedupped in all cases.
 	}
 	testCases := []struct {
 		name        string

--- a/cmd/meroxa/root/apps/deploy_test.go
+++ b/cmd/meroxa/root/apps/deploy_test.go
@@ -287,7 +287,7 @@ func Test_validateResource(t *testing.T) {
 			}(),
 		},
 		{
-			name: "invalid when resources are not available",
+			name:    "invalid when resources are not available",
 			deploy: func() *Deploy {
 				r1 := utils.GenerateResourceWithNameAndStatus(appResources[0].Name, "")
 				r2 := utils.GenerateResourceWithNameAndStatus(appResources[1].Name, "")
@@ -304,7 +304,7 @@ func Test_validateResource(t *testing.T) {
 			wantErr: errors.New(`resource "nozzle" is not ready and usable; resource "engine" is not ready and usable`),
 		},
 		{
-			name: "invalid when envs do not match",
+			name:        "invalid when envs do not match",
 			deploy: func() *Deploy {
 				r1 := utils.GenerateResourceWithNameAndStatus(appResources[0].Name, "ready")
 				r2 := utils.GenerateResourceWithNameAndStatus(appResources[1].Name, "ready")
@@ -323,10 +323,10 @@ func Test_validateResource(t *testing.T) {
 
 				return d
 			}(),
-			wantErr: errors.New(`resource "nozzle" is not in app env "test-env", but in "wrong-env"; resource "engine" is not in app env "test-env", but in "wrong-env"`), //nolint:lll
+			wantErr:     errors.New(`resource "nozzle" is not in app env "test-env", but in "wrong-env"; resource "engine" is not in app env "test-env", but in "wrong-env"`), //nolint:lll
 		},
 		{
-			name: "invalid when env is common and resource in not",
+			name:        "invalid when env is common and resource in not",
 			deploy: func() *Deploy {
 				r1 := utils.GenerateResourceWithNameAndStatus(appResources[0].Name, "ready")
 				r2 := utils.GenerateResourceWithNameAndStatus(appResources[1].Name, "ready")
@@ -344,7 +344,7 @@ func Test_validateResource(t *testing.T) {
 
 				return d
 			}(),
-			wantErr: errors.New(`resource "nozzle" is in common env, but app is in "wrong-env"; resource "engine" is in common env, but app is in "wrong-env"`), //nolint:lll
+			wantErr:     errors.New(`resource "nozzle" is in "wrong-env", but app is in common; resource "engine" is in "wrong-env", but app is in common`), //nolint:lll
 		},
 	}
 

--- a/cmd/meroxa/root/apps/deploy_test.go
+++ b/cmd/meroxa/root/apps/deploy_test.go
@@ -257,7 +257,7 @@ func Test_validateResource(t *testing.T) {
 		},
 		{
 			name:        "invalid when environment does not match",
-			wantErr:     errors.New(`resource "nozzle" is not in app env "test-env", but in "wrong-env"; resource "engine" is not in app env "test-env", but in "wrong-env"`),
+			wantErr:     errors.New(`resource "nozzle" is not in app env "test-env", but in "wrong-env"; resource "engine" is not in app env "test-env", but in "wrong-env"`), //nolint:lll
 			state:       "ready",
 			envName:     "test-env",
 			resourceEnv: "wrong-env",

--- a/cmd/meroxa/root/apps/errors.go
+++ b/cmd/meroxa/root/apps/errors.go
@@ -1,0 +1,6 @@
+package apps
+
+const (
+	resourceInvalidError = "⚠️  Run 'meroxa resources list' to verify that the resource names " +
+		"defined in your Turbine app are identical to the resources you have created on the Meroxa Platform before deploying again"
+)

--- a/utils/tests.go
+++ b/utils/tests.go
@@ -51,7 +51,7 @@ func GenerateResourceWithNameAndStatus(resourceName, resourceState string) merox
 	return newResource
 }
 
-// Add environment to resource
+// Add environment to resource.
 func ResourceWithEnvironment(r meroxa.Resource, env string) meroxa.Resource {
 	r.Environment = &meroxa.EntityIdentifier{
 		UUID: "424ec647-9f0f-45a5-8e4b-3e0441f12444",

--- a/utils/tests.go
+++ b/utils/tests.go
@@ -51,6 +51,15 @@ func GenerateResourceWithNameAndStatus(resourceName, resourceState string) merox
 	return newResource
 }
 
+// Add environment to resource
+func ResourceWithEnvironment(r meroxa.Resource, env string) meroxa.Resource {
+	r.Environment = &meroxa.EntityIdentifier{
+		UUID: "424ec647-9f0f-45a5-8e4b-3e0441f12444",
+		Name: env,
+	}
+	return r
+}
+
 func GenerateResourceWithEnvironment() meroxa.Resource {
 	r := GenerateResource()
 


### PR DESCRIPTION
## Description of change

Turbine apps provisioned on env only supports resource which are part of these environments.
This change adds validation to ensure this is the case.

Minor refactor, rename method and ensure it returns errors rather than strings.
Create file to store error messages, it is a start.
Flatten bunch of obvious conditional paths.

Fixes #593

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
