### PR TITLE
Early failure for deploying an application with a function to an env

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -482,6 +482,12 @@ func (d *Deploy) getAppImage(ctx context.Context) (string, error) {
 		return "", nil
 	}
 
+	// Prevent creation of function in an Env
+	if d.flags.Environment != "" {
+		d.logger.StopSpinnerWithStatus("\t", log.Failed)
+		return "", errors.New("cannot deploy an application with a functions to an environment")
+	}
+
 	d.logger.StopSpinnerWithStatus("Application processes found. Creating application image...", log.Successful)
 
 	d.localDeploy.Lang = d.lang


### PR DESCRIPTION
## Description of change
Early failure for deploying an application with a function to an env


Fixes https://github.com/meroxa/cli/issues/620

## Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

### Before
```
meroxa apps deploy --env aws     
Validating your app.json...
	✔ Checked your language is "ruby"
	✔ Checked your application name is "test-rb"
Checking for uncommitted changes...
	✔ No uncommitted changes!
Preparing to deploy application "test-rb"...
	✔ Can access your Turbine resources
	✔ Application processes found. Creating application image...
	✔ Platform source fetched
	✔ Dockerfile created
	✔ "turbine-test-rb.tar.gz" successfully created in "/Users/dianadoherty/go/src/meroxa/test-rb"
	✔ Source uploaded
	✔ Removed "turbine-test-rb.tar.gz"
	✔ Dockerfile removed
	✔ Successfully built process image ("e8d91f4d-8a14-49a8-8213-3fb39d3fc370")
⠏ Deploying application "test-rb"...
	successfully validated application pipeline
	successfully created source connector
	cannot deploy functions to an environment
	x Couldn't complete the deployment
Error: 
 Check `meroxa apps logs` for further information
```

### After
```
meroxa apps deploy --env aws
Validating your app.json...
	✔ Checked your language is "ruby"
	✔ Checked your application name is "test-rb"
Checking for uncommitted changes...
	✔ No uncommitted changes!
Preparing to deploy application "test-rb"...
	✔ Can access your Turbine resources
	x 	
Error: cannot deploy an application with a functions to an environment
```

