### PR TITLE
Remove cli logic to handle common env for api

### DIFF
--- a/cmd/meroxa/root/pipelines/create.go
+++ b/cmd/meroxa/root/pipelines/create.go
@@ -76,8 +76,7 @@ func (c *Create) Execute(ctx context.Context) error {
 		p.Metadata = metadata
 	}
 
-	// If the environment specified is not the common environment.
-	if c.flags.Environment != "" && c.flags.Environment != string(meroxa.EnvironmentTypeCommon) {
+	if c.flags.Environment != "" {
 		err := builder.CheckCMDFeatureFlag(c, &environments.Environments{})
 		if err != nil {
 			return err

--- a/cmd/meroxa/root/resources/create.go
+++ b/cmd/meroxa/root/resources/create.go
@@ -157,8 +157,7 @@ func (c *Create) Execute(ctx context.Context) error {
 		return fmt.Errorf("required flag(s) \"url\" not set")
 	}
 
-	// If the environment specified is not the common environment.
-	if c.flags.Environment != "" && c.flags.Environment != string(meroxa.EnvironmentTypeCommon) {
+	if c.flags.Environment != "" {
 		err := builder.CheckCMDFeatureFlag(c, &environments.Environments{})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description of change

Remove cli logic to handle common env for api

Fixes https://github.com/meroxa/cli/issues/623

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

### Before
```
meroxa resource create pg --type postgres --url  $PG_URL --env common 
Creating "postgres" resource in "common" environment...
Resource "pg" is successfully created!
```

### After 

```
meroxa resource create pg-c --type postgres --url $PG_URL --env common
Creating "postgres" resource in "common" environment...
Error: could not find environment. 1 detail reported:
1. type: "postgres"

```