### PR TITLE
feat(apps): deploy support `--env`

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/meroxa/cli/cmd/meroxa/builder"
 	"github.com/meroxa/cli/cmd/meroxa/global"
 	"github.com/meroxa/cli/cmd/meroxa/turbine"
@@ -227,9 +228,18 @@ func (d *Deploy) getPlatformImage(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
 	sourceBlob := meroxa.SourceBlob{Url: s.GetUrl}
 	buildInput := &meroxa.CreateBuildInput{SourceBlob: sourceBlob}
+
+	if d.flags.Environment != "" {
+		_, err = uuid.Parse(d.flags.Environment)
+		switch {
+		case err == nil:
+			buildInput.Environment = &meroxa.EntityIdentifier{UUID: d.flags.Environment}
+		default:
+			buildInput.Environment = &meroxa.EntityIdentifier{Name: d.flags.Environment}
+		}
+	}
 
 	build, err := d.client.CreateBuild(ctx, buildInput)
 	if err != nil {


### PR DESCRIPTION
## Description of change

Passing env flag to CreateBuilds as part of functions + env changes. Env is needed for builds actions. 

<!-- Provide a brief description of the change, what it is and why it was made below.* -->

Fixes https://github.com/meroxa/cli/issues/641

## Type of change

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube


