### PR TITLE
deps(turbine-js): bump turbine-js-cli to latest (v1.3.8)

### DIFF
--- a/cmd/meroxa/turbine/javascript/deploy.go
+++ b/cmd/meroxa/turbine/javascript/deploy.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	TurbineJSVersion = "1.3.5"
+	TurbineJSVersion = "1.3.8"
 )
 
 func (t *turbineJsCLI) NeedsToBuild(ctx context.Context, appName string) (bool, error) {


### PR DESCRIPTION
## Description of change

Fixes https://github.com/meroxa/turbine-js/issues/241

With this change, we're bumping the version of turbine-js that the CLI uses to manage Turbine apps.

Includes https://github.com/meroxa/turbine-js/pull/265
Includes https://github.com/meroxa/turbine-js/pull/242
Includes https://github.com/meroxa/turbine-js/pull/234


## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

### Error Wrong Table

![errorme_wrongtable](https://user-images.githubusercontent.com/8811742/225953001-3b3614b9-78d1-4375-80a7-adb13b9c10a1.gif)

### Error Wrong Resource

![errorme_wrongresource](https://user-images.githubusercontent.com/8811742/225953087-9c2d3640-3c1f-48ac-b17f-0f6c06a78305.gif)
