### PR TITLE
Glob patterns exclude double digits in tags

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -22,7 +22,7 @@ jobs:
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
-          DESCRIBE=`git describe --match "v[0-9].[0-9].[0-9]" --abbrev=0`
+          DESCRIBE=`git tag -l --sort=-v:refname | grep -v nightly | head -n 1`
           MAJOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[1]}'`
           MINOR_VERSION=`echo $DESCRIBE | awk '{split($0,a,"."); print a[2]}'`
           MINOR_VERSION="$((${MINOR_VERSION} + 1))"


### PR DESCRIPTION
## Description of change

Nightly builds are based on an old tag

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
