### PR TITLE
Always use v2 Source endpoint on App Deploy

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -204,12 +204,11 @@ func (d *Deploy) Logger(logger log.Logger) {
 
 // getAppSource will return the proper destination where the application source will be uploaded and fetched.
 func (d *Deploy) getAppSource(ctx context.Context) (*meroxa.Source, error) {
+	var sourceInput meroxa.CreateSourceInputV2
 	if env := d.flags.Environment; env != "" {
-		sourceInput := meroxa.CreateSourceInputV2{Environment: &meroxa.EntityIdentifier{Name: env}}
-		return d.client.CreateSourceV2(ctx, &sourceInput)
+		sourceInput = meroxa.CreateSourceInputV2{Environment: &meroxa.EntityIdentifier{Name: env}}
 	}
-
-	return d.client.CreateSource(ctx)
+	return d.client.CreateSourceV2(ctx, &sourceInput)
 }
 
 func (d *Deploy) getPlatformImage(ctx context.Context) (string, error) {

--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -206,7 +206,13 @@ func (d *Deploy) Logger(logger log.Logger) {
 func (d *Deploy) getAppSource(ctx context.Context) (*meroxa.Source, error) {
 	var sourceInput meroxa.CreateSourceInputV2
 	if env := d.flags.Environment; env != "" {
-		sourceInput = meroxa.CreateSourceInputV2{Environment: &meroxa.EntityIdentifier{Name: env}}
+		_, err := uuid.Parse(d.flags.Environment)
+		switch {
+		case err == nil:
+			sourceInput = meroxa.CreateSourceInputV2{Environment: &meroxa.EntityIdentifier{UUID: env}}
+		default:
+			sourceInput = meroxa.CreateSourceInputV2{Environment: &meroxa.EntityIdentifier{Name: env}}
+		}
 	}
 	return d.client.CreateSourceV2(ctx, &sourceInput)
 }

--- a/cmd/meroxa/root/apps/deploy_test.go
+++ b/cmd/meroxa/root/apps/deploy_test.go
@@ -726,15 +726,15 @@ func TestGetPlatformImage(t *testing.T) {
 		err            error
 	}{
 		{
-			name: "Successfully build image",
+			name: "Successfully build image with no env",
 			meroxaClient: func(ctrl *gomock.Controller) meroxa.Client {
 				client := mock.NewMockClient(ctrl)
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}))
-
+				input := meroxa.CreateSourceInputV2{}
 				client.EXPECT().
-					CreateSource(ctx).
+					CreateSourceV2(ctx, &input).
 					Return(&meroxa.Source{GetUrl: sourceGetURL, PutUrl: server.URL}, nil)
 
 				client.EXPECT().
@@ -813,9 +813,9 @@ func TestGetPlatformImage(t *testing.T) {
 			name: "Fail to create source",
 			meroxaClient: func(ctrl *gomock.Controller) meroxa.Client {
 				client := mock.NewMockClient(ctrl)
-
+				input := meroxa.CreateSourceInputV2{}
 				client.EXPECT().
-					CreateSource(ctx).
+					CreateSourceV2(ctx, &input).
 					Return(&meroxa.Source{GetUrl: sourceGetURL, PutUrl: sourcePutURL}, err)
 				return client
 			},
@@ -829,9 +829,9 @@ func TestGetPlatformImage(t *testing.T) {
 			name: "Fail to upload source",
 			meroxaClient: func(ctrl *gomock.Controller) meroxa.Client {
 				client := mock.NewMockClient(ctrl)
-
+				input := meroxa.CreateSourceInputV2{}
 				client.EXPECT().
-					CreateSource(ctx).
+					CreateSourceV2(ctx, &input).
 					Return(&meroxa.Source{GetUrl: sourceGetURL, PutUrl: sourcePutURL}, nil)
 				return client
 			},
@@ -848,13 +848,12 @@ func TestGetPlatformImage(t *testing.T) {
 			name: "Fail to create build",
 			meroxaClient: func(ctrl *gomock.Controller) meroxa.Client {
 				client := mock.NewMockClient(ctrl)
-
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}))
-
+				input := meroxa.CreateSourceInputV2{}
 				client.EXPECT().
-					CreateSource(ctx).
+					CreateSourceV2(ctx, &input).
 					Return(&meroxa.Source{GetUrl: sourceGetURL, PutUrl: server.URL}, nil)
 
 				client.EXPECT().
@@ -882,9 +881,9 @@ func TestGetPlatformImage(t *testing.T) {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}))
-
+				input := meroxa.CreateSourceInputV2{}
 				client.EXPECT().
-					CreateSource(ctx).
+					CreateSourceV2(ctx, &input).
 					Return(&meroxa.Source{GetUrl: sourceGetURL, PutUrl: server.URL}, nil)
 
 				client.EXPECT().
@@ -1467,9 +1466,10 @@ func TestDeploy_getAppSource(t *testing.T) {
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					w.WriteHeader(http.StatusOK)
 				}))
+				input := meroxa.CreateSourceInputV2{}
 
 				client.EXPECT().
-					CreateSource(ctx).
+					CreateSourceV2(ctx, &input).
 					Return(&meroxa.Source{GetUrl: sourceGetURL, PutUrl: server.URL}, nil)
 
 				return client


### PR DESCRIPTION
## Description of change

We want to consolidate source endpoints and always use v2 on application deploy. 

Fixes [<GitHub Issue>](https://github.com/meroxa/cli/issues/664)

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube
