### PR TITLE
Ensure label exist and is `string` in resource types

### DIFF
--- a/utils/display/resources.go
+++ b/utils/display/resources.go
@@ -137,8 +137,12 @@ func ResourceTypesTable(types []meroxa.ResourceType, hideHeaders bool) string {
 	betaResourceTypes := make(map[string]string)
 
 	for _, t := range types {
-		val := fmt.Sprintf("%s", t.FormConfig[meroxa.ResourceTypeFormConfigHumanReadableKey])
-		if val == "" {
+		label, ok := t.FormConfig[meroxa.ResourceTypeFormConfigHumanReadableKey]
+		if !ok {
+			continue
+		}
+		val, ok := label.(string)
+		if !ok {
 			continue
 		}
 		if t.ReleaseStage == meroxa.ResourceTypeReleaseStageGA {


### PR DESCRIPTION
## Description of change

When the label is wrong, it will render  `%!s(<nil>)` .

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [x]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
