### PR TITLE
Validate environment exists before turbine app is deployed

### DIFF
--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package apps
 
 import (

--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -917,9 +917,9 @@ func (d *Deploy) validateEnvironmentFlagCompatibility() error {
 func (d *Deploy) validateEnvExists(ctx context.Context) error {
 	if _, err := d.client.GetEnvironment(ctx, d.env.nameOrUUID()); err != nil {
 		if strings.Contains(err.Error(), "could not find environment") {
-			return fmt.Errorf("Environment %q does not exist.", d.flags.Environment)
+			return fmt.Errorf("environment %q does not exist", d.flags.Environment)
 		}
-		return fmt.Errorf("Unable to retrieve environment %q: %w", d.flags.Environment, err)
+		return fmt.Errorf("unable to retrieve environment %q: %w", d.flags.Environment, err)
 	}
 	return nil
 }

--- a/cmd/meroxa/root/apps/deploy_test.go
+++ b/cmd/meroxa/root/apps/deploy_test.go
@@ -1555,7 +1555,7 @@ func Test_validateEnvExists(t *testing.T) {
 				d.flags.Environment = "your-env"
 				return d
 			},
-			wantErr: fmt.Errorf(`Environment "your-env" does not exist.`),
+			wantErr: fmt.Errorf(`environment "your-env" does not exist`),
 		},
 		{
 			desc: "failed to retrieve environment",
@@ -1571,7 +1571,7 @@ func Test_validateEnvExists(t *testing.T) {
 				d.flags.Environment = "your-env"
 				return d
 			},
-			wantErr: fmt.Errorf(`Unable to retrieve environment "your-env": boom`),
+			wantErr: fmt.Errorf(`unable to retrieve environment "your-env": boom`),
 		},
 	}
 
@@ -1587,5 +1587,4 @@ func Test_validateEnvExists(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
## Description of change

Ensure environment exists when the `--env` flag is specified before the turbine deploy begins.

Fixes #621 

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
