### PR TITLE
Warn users when --url value is ignored

### DIFF
--- a/cmd/meroxa/root/resources/create.go
+++ b/cmd/meroxa/root/resources/create.go
@@ -182,15 +182,25 @@ func (c *Create) Execute(ctx context.Context) error {
 	input := meroxa.CreateResourceInput{
 		Type:     meroxa.ResourceTypeName(c.flags.Type),
 		Name:     c.args.Name,
-		URL:      c.flags.URL,
 		Metadata: nil,
 	}
 
-	if (c.flags.Type != string(meroxa.ResourceTypeNotion) &&
-		c.flags.Type != string(meroxa.ResourceTypeSpireMaritimeAIS)) &&
-		c.flags.URL == "" {
+	if c.flags.Type == string(meroxa.ResourceTypeNotion) {
+		url := c.flags.URL
+		c.flags.URL = ""
+		if url != "" && url != "https://api.notion.com" {
+			c.logger.Warnf(ctx, "Ignoring API URL override (%s) for Notion resource configuration.", url)
+		}
+	} else if c.flags.Type == string(meroxa.ResourceTypeSpireMaritimeAIS) {
+		url := c.flags.URL
+		c.flags.URL = ""
+		if url != "" && url != "https://api.spire.com/graphql" {
+			c.logger.Warnf(ctx, "Ignoring API URL override (%s) for Spire Maritime AIS resource configuration.", url)
+		}
+	} else if c.flags.URL == "" {
 		return fmt.Errorf("required flag(s) \"url\" not set")
 	}
+	input.URL = c.flags.URL
 
 	if c.flags.Environment != "" {
 		err := builder.CheckCMDFeatureFlag(c, &environments.Environments{})

--- a/cmd/meroxa/root/resources/create.go
+++ b/cmd/meroxa/root/resources/create.go
@@ -185,20 +185,8 @@ func (c *Create) Execute(ctx context.Context) error {
 		Metadata: nil,
 	}
 
-	if c.flags.Type == string(meroxa.ResourceTypeNotion) {
-		url := c.flags.URL
-		c.flags.URL = ""
-		if url != "" && url != "https://api.notion.com" {
-			c.logger.Warnf(ctx, "Ignoring API URL override (%s) for Notion resource configuration.", url)
-		}
-	} else if c.flags.Type == string(meroxa.ResourceTypeSpireMaritimeAIS) {
-		url := c.flags.URL
-		c.flags.URL = ""
-		if url != "" && url != "https://api.spire.com/graphql" {
-			c.logger.Warnf(ctx, "Ignoring API URL override (%s) for Spire Maritime AIS resource configuration.", url)
-		}
-	} else if c.flags.URL == "" {
-		return fmt.Errorf("required flag(s) \"url\" not set")
+	if err := c.processURLFlag(ctx); err != nil {
+		return err
 	}
 	input.URL = c.flags.URL
 
@@ -301,6 +289,25 @@ func (c *Create) handlePrivateKeyFlags(ctx context.Context) error {
 				c.flags.Password = key
 			}
 		}
+	}
+	return nil
+}
+
+func (c *Create) processURLFlag(ctx context.Context) error {
+	if c.flags.Type == string(meroxa.ResourceTypeNotion) {
+		url := c.flags.URL
+		c.flags.URL = ""
+		if url != "" && url != "https://api.notion.com" {
+			c.logger.Warnf(ctx, "Ignoring API URL override (%s) for Notion resource configuration.", url)
+		}
+	} else if c.flags.Type == string(meroxa.ResourceTypeSpireMaritimeAIS) {
+		url := c.flags.URL
+		c.flags.URL = ""
+		if url != "" && url != "https://api.spire.com/graphql" {
+			c.logger.Warnf(ctx, "Ignoring API URL override (%s) for Spire Maritime AIS resource configuration.", url)
+		}
+	} else if c.flags.URL == "" {
+		return fmt.Errorf("required flag(s) \"url\" not set")
 	}
 	return nil
 }

--- a/cmd/meroxa/root/resources/create_test.go
+++ b/cmd/meroxa/root/resources/create_test.go
@@ -467,6 +467,7 @@ func TestCreateResourceExecutionPrivateKeyFlags(t *testing.T) {
 	}
 }
 
+//nolint:funlen
 func TestCreateResourceURLFlag(t *testing.T) {
 	resourceName := "my-resource"
 	tests := []struct {


### PR DESCRIPTION
## Description of change
Notion and Spire Maritime AIS require a token and not a URL, so be clear about the behavior

Fixes https://github.com/meroxa/cli/issues/676

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo
BEFORE
![Screenshot from 2023-04-05 12-38-57](https://user-images.githubusercontent.com/12731615/230057401-1c4936d1-38a7-4129-955f-f8b071b8b406.png)


AFTER
![Screenshot from 2023-04-05 12-38-00](https://user-images.githubusercontent.com/12731615/230057381-6afb86c1-f3bc-4b93-822d-83c318d05b0e.png)


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
