### PR TITLE
Also print accessible dev preview types in the Resource Types list

### DIFF
--- a/utils/display/resources.go
+++ b/utils/display/resources.go
@@ -135,6 +135,8 @@ func ResourceTypesTable(types []meroxa.ResourceType, hideHeaders bool) string {
 	gaResourceTypes := make(map[string]string)
 	betaResourceNames := []string{}
 	betaResourceTypes := make(map[string]string)
+	developerPreviewResourceNames := []string{}
+	developerPreviewResourceTypes := make(map[string]string)
 
 	for _, t := range types {
 		label, ok := t.FormConfig[meroxa.ResourceTypeFormConfigHumanReadableKey]
@@ -151,10 +153,14 @@ func ResourceTypesTable(types []meroxa.ResourceType, hideHeaders bool) string {
 		} else if t.ReleaseStage == meroxa.ResourceTypeReleaseStageBeta {
 			betaResourceNames = append(betaResourceNames, val)
 			betaResourceTypes[val] = t.Name
+		} else if t.ReleaseStage == meroxa.ResourceTypeReleaseStageDevPreview && t.HasAccess {
+			developerPreviewResourceNames = append(developerPreviewResourceNames, val)
+			developerPreviewResourceTypes[val] = t.Name
 		}
 	}
 	sort.Strings(gaResourceNames)
 	sort.Strings(betaResourceNames)
+	sort.Strings(developerPreviewResourceNames)
 
 	table := simpletable.New()
 
@@ -182,6 +188,15 @@ func ResourceTypesTable(types []meroxa.ResourceType, hideHeaders bool) string {
 			{Align: simpletable.AlignLeft, Text: t},
 			{Align: simpletable.AlignLeft, Text: betaResourceTypes[t]},
 			{Align: simpletable.AlignLeft, Text: string(meroxa.ResourceTypeReleaseStageBeta)},
+		}
+
+		table.Body.Cells = append(table.Body.Cells, r)
+	}
+	for _, t := range developerPreviewResourceNames {
+		r := []*simpletable.Cell{
+			{Align: simpletable.AlignLeft, Text: t},
+			{Align: simpletable.AlignLeft, Text: developerPreviewResourceTypes[t]},
+			{Align: simpletable.AlignLeft, Text: string(meroxa.ResourceTypeReleaseStageDevPreview)},
 		}
 
 		table.Body.Cells = append(table.Body.Cells, r)

--- a/utils/display/resources_test.go
+++ b/utils/display/resources_test.go
@@ -127,6 +127,14 @@ var types = []meroxa.ResourceType{
 		},
 	},
 	{
+		Name:         string(meroxa.ResourceTypeGoogleSheets),
+		ReleaseStage: meroxa.ResourceTypeReleaseStageDevPreview,
+		HasAccess:    true,
+		FormConfig: map[string]interface{}{
+			meroxa.ResourceTypeFormConfigHumanReadableKey: "Google Sheets",
+		},
+	},
+	{
 		Name:         string(meroxa.ResourceTypeGoogleAnalytics),
 		ReleaseStage: meroxa.ResourceTypeReleaseStageDevPreview,
 		FormConfig: map[string]interface{}{

--- a/utils/display/resources_test.go
+++ b/utils/display/resources_test.go
@@ -126,6 +126,13 @@ var types = []meroxa.ResourceType{
 			meroxa.ResourceTypeFormConfigHumanReadableKey: "PostgreSQL",
 		},
 	},
+	{
+		Name:         string(meroxa.ResourceTypeGoogleAnalytics),
+		ReleaseStage: meroxa.ResourceTypeReleaseStageDevPreview,
+		FormConfig: map[string]interface{}{
+			meroxa.ResourceTypeFormConfigHumanReadableKey: "Googs",
+		},
+	},
 }
 
 func TestResourceTypesTable(t *testing.T) {
@@ -144,6 +151,9 @@ func TestResourceTypesTable(t *testing.T) {
 	}
 
 	for _, rType := range types {
+		if rType.ReleaseStage == meroxa.ResourceTypeReleaseStageDevPreview && !rType.HasAccess {
+			continue
+		}
 		if !strings.Contains(
 			out,
 			fmt.Sprintf("%s", rType.FormConfig[meroxa.ResourceTypeFormConfigHumanReadableKey])) {
@@ -168,6 +178,9 @@ func TestResourceTypesTableWithoutHeaders(t *testing.T) {
 	}
 
 	for _, rType := range types {
+		if rType.ReleaseStage == meroxa.ResourceTypeReleaseStageDevPreview && !rType.HasAccess {
+			continue
+		}
 		if !strings.Contains(
 			out,
 			fmt.Sprintf("%s", rType.FormConfig[meroxa.ResourceTypeFormConfigHumanReadableKey])) {


### PR DESCRIPTION
## Description of change

Customers should be able to find the flag value of a resource type that they have access to 

Fixes https://github.com/meroxa/cli/issues/685

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|

```shell
     NAME            TYPE          RELEASE STAGE   
=============== =============== ===================
 PostgreSQL      postgres        beta              
 Google Sheets   google_sheets   developer_preview 
```


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
