### PR TITLE
Apps open should not open browser in tests

### DIFF
--- a/cmd/meroxa/root/apps/open_test.go
+++ b/cmd/meroxa/root/apps/open_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/meroxa/cli/cmd/meroxa/builder"
@@ -68,24 +69,10 @@ func TestOpenAppFlags(t *testing.T) {
 
 	for _, f := range expectedFlags {
 		cf := c.Flags().Lookup(f.name)
-		if cf == nil {
-			t.Fatalf("expected flag %q to be present", f.name)
-		}
-
-		if f.shorthand != cf.Shorthand {
-			t.Fatalf("expected shorthand %q got %q for flag %q", f.shorthand, cf.Shorthand, f.name)
-		}
-
-		if f.required && !utils.IsFlagRequired(cf) {
-			t.Fatalf("expected flag %q to be required", f.name)
-		}
-
-		if cf.Hidden != f.hidden {
-			if cf.Hidden {
-				t.Fatalf("expected flag %q not to be hidden", f.name)
-			}
-			t.Fatalf("expected flag %q to be hidden", f.name)
-		}
+		require.NotNil(t, cf)
+		assert.Equal(t, f.shorthand, cf.Shorthand)
+		assert.Equal(t, f.required, utils.IsFlagRequired(cf))
+		assert.Equal(t, f.hidden, cf.Hidden)
 	}
 }
 
@@ -145,9 +132,7 @@ func TestOpenAppExecution(t *testing.T) {
 			}
 
 			err := cc.Execute(context.Background())
-			if err != nil {
-				t.Fatalf("unexpected error \"%s\"", err)
-			}
+			require.NoError(t, err)
 
 			opener := &mockOpener{}
 			o := &Open{


### PR DESCRIPTION
## Description of change

The test for `meroxa apps open` will open a browser every time the test is executed. The browser
step can be skipped, since that should be tested in the underlying library.


## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
