### PR TITLE
fix: cleanup turbine-py related items

### DIFF
--- a/cmd/meroxa/turbine/python/run.go
+++ b/cmd/meroxa/turbine/python/run.go
@@ -10,17 +10,13 @@ import (
 func (t *turbinePyCLI) Run(ctx context.Context) error {
 	go t.runner.RunAddr(ctx, t.grpcListenAddress)
 	defer t.runner.GracefulStop()
-	gitSha, err := t.GetGitSha(ctx)
-	if err != nil {
-		return err
-	}
 	cmd := internal.NewTurbineCmd(t.appPath,
 		internal.TurbineCommandRun,
 		map[string]string{
 			"TURBINE_CORE_SERVER": t.grpcListenAddress,
 		},
 		t.appPath,
-		gitSha,
+		"git_sha",
 	)
 	return turbine.RunCMD(ctx, t.logger, cmd)
 }

--- a/cmd/meroxa/turbine/python/run.go
+++ b/cmd/meroxa/turbine/python/run.go
@@ -16,7 +16,7 @@ func (t *turbinePyCLI) Run(ctx context.Context) error {
 			"TURBINE_CORE_SERVER": t.grpcListenAddress,
 		},
 		t.appPath,
-		"git_sha",
+		"",
 	)
 	return turbine.RunCMD(ctx, t.logger, cmd)
 }

--- a/cmd/meroxa/turbine/python/version.go
+++ b/cmd/meroxa/turbine/python/version.go
@@ -16,7 +16,7 @@ func (t *turbinePyCLI) GetVersion(_ context.Context) (string, error) {
 		t.appPath,
 	)
 	if err != nil {
-		return "", fmt.Errorf("cannot determine turbine-rb gem version in %s", t.appPath)
+		return "", fmt.Errorf("cannot determine turbine-py version in %s", t.appPath)
 	}
 	return ver, nil
 }


### PR DESCRIPTION
## Description of change

Small cleanup on python turbine related items, cleaning up error message, and we don't need to actually pass git-sha on run. 


## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [x]  Tested in minikube
