### PR TITLE
chore: Upgrade to latest turbine-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 require (
 	github.com/briandowns/spinner v1.21.0
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-core v0.0.0-20230522172301-9867be85eb47
+	github.com/meroxa/turbine-core v0.0.0-20230524100428-6a098aec183f
 	github.com/stretchr/testify v1.8.3
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	golang.org/x/mod v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/meroxa/meroxa-go v0.0.0-20230331072126-47c9496dfb9b h1:xIxLrz8h0QA0QmFZrW3ciIjmEnGDszS/z3yjfD3d+pY=
 github.com/meroxa/meroxa-go v0.0.0-20230331072126-47c9496dfb9b/go.mod h1:VaDn0fLKHG2VoI9MQVEqwtfum4BaGr8pcgtfWRe8/Dk=
-github.com/meroxa/turbine-core v0.0.0-20230522172301-9867be85eb47 h1:bghd4ClyfYjFIvkeQkVMFVEPpB9pbikyPUxLLWi9Cxw=
-github.com/meroxa/turbine-core v0.0.0-20230522172301-9867be85eb47/go.mod h1:/83voxEvn+hi7nyEGMeOTi8wG9qRnINzTs5LwzDH7F4=
+github.com/meroxa/turbine-core v0.0.0-20230524100428-6a098aec183f h1:5EPMVUM0ESE3SldVmp4HC69fgZ7QkTldNMG/WitGSd0=
+github.com/meroxa/turbine-core v0.0.0-20230524100428-6a098aec183f/go.mod h1:/83voxEvn+hi7nyEGMeOTi8wG9qRnINzTs5LwzDH7F4=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da h1:qiPWuGGr+1GQE6s9NPSK8iggR/6x/V+0snIoOPYsBgc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.20
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-core v0.0.0-20230522172301-9867be85eb47
+# github.com/meroxa/turbine-core v0.0.0-20230524100428-6a098aec183f
 ## explicit; go 1.20
 github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core
 github.com/meroxa/turbine-core/pkg/app


### PR DESCRIPTION
The following commands were run to generate changes: go get -u github.com/meroxa/turbine-go@latest and make gomod