### PR TITLE
feat(flink): add command for listing flink jobs

### DIFF
--- a/cmd/meroxa/root/flink/flink.go
+++ b/cmd/meroxa/root/flink/flink.go
@@ -47,6 +47,7 @@ func (*Job) SubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		builder.BuildCobraCommand(&Deploy{}),
 		builder.BuildCobraCommand(&Remove{}),
+		builder.BuildCobraCommand(&List{}),
 	}
 }
 

--- a/cmd/meroxa/root/flink/list.go
+++ b/cmd/meroxa/root/flink/list.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 Meroxa Inc
+Copyright © 2023 Meroxa Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/meroxa/root/flink/list.go
+++ b/cmd/meroxa/root/flink/list.go
@@ -64,7 +64,7 @@ func (l *List) Execute(ctx context.Context) error {
 
 	l.logger.JSON(ctx, flinkJobs)
 	l.logger.Info(ctx, display.FlinkJobsTable(flinkJobs))
-	output := "\n ✨ To view your FlinkJobs, visit https://dashboard.meroxa.io/apps"
+	output := "\n ✨ To view your Flink Jobs, visit https://dashboard.meroxa.io/apps"
 	l.logger.Info(ctx, output)
 
 	return nil

--- a/cmd/meroxa/root/flink/list.go
+++ b/cmd/meroxa/root/flink/list.go
@@ -1,0 +1,79 @@
+/*
+Copyright © 2022 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flink
+
+import (
+	"context"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils/display"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+var (
+	_ builder.CommandWithDocs    = (*List)(nil)
+	_ builder.CommandWithClient  = (*List)(nil)
+	_ builder.CommandWithLogger  = (*List)(nil)
+	_ builder.CommandWithExecute = (*List)(nil)
+	_ builder.CommandWithAliases = (*List)(nil)
+)
+
+type listJobsClient interface {
+	ListFlinkJobs(ctx context.Context) ([]*meroxa.FlinkJob, error)
+}
+
+type List struct {
+	client listJobsClient
+	logger log.Logger
+}
+
+func (l *List) Usage() string {
+	return "list"
+}
+
+func (l *List) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "List Flink jobs",
+	}
+}
+
+func (l *List) Aliases() []string {
+	return []string{"ls"}
+}
+
+func (l *List) Execute(ctx context.Context) error {
+	flinkJobs, err := l.client.ListFlinkJobs(ctx)
+	if err != nil {
+		return err
+	}
+
+	l.logger.JSON(ctx, flinkJobs)
+	l.logger.Info(ctx, display.FlinkJobsTable(flinkJobs))
+	output := "\n ✨ To view your FlinkJobs, visit https://dashboard.meroxa.io/apps"
+	l.logger.Info(ctx, output)
+
+	return nil
+}
+
+func (l *List) Logger(logger log.Logger) {
+	l.logger = logger
+}
+
+func (l *List) Client(client meroxa.Client) {
+	l.client = client
+}

--- a/cmd/meroxa/root/flink/list_test.go
+++ b/cmd/meroxa/root/flink/list_test.go
@@ -88,6 +88,7 @@ func TestListFlinkJobsExecution(t *testing.T) {
 		t.Fatalf("expected \"%v\", got \"%v\"", lf, gotJobs)
 	}
 }
+
 func TestListFlinkJobsErrorHandling(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)

--- a/cmd/meroxa/root/flink/list_test.go
+++ b/cmd/meroxa/root/flink/list_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright © 2022 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flink
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/meroxa/cli/utils/display"
+
+	"github.com/golang/mock/gomock"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+	"github.com/meroxa/meroxa-go/pkg/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func getFlinkJobs() []*meroxa.FlinkJob {
+	var flinkJobs []*meroxa.FlinkJob
+	f := utils.GenerateFlinkJob()
+	return append(flinkJobs, &f)
+}
+
+func TestListFlinkJobsExecution(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockClient(ctrl)
+	logger := log.NewTestLogger()
+
+	flinkJobs := append(getFlinkJobs())
+
+	client.
+		EXPECT().
+		ListFlinkJobs(ctx).
+		Return(flinkJobs, nil)
+
+	l := &List{
+		client: client,
+		logger: logger,
+	}
+
+	err := l.Execute(ctx)
+	if err != nil {
+		t.Fatalf("not expected error, got \"%s\"", err.Error())
+	}
+
+	gotLeveledOutput := logger.LeveledOutput()
+	wantLeveledOutput := display.FlinkJobsTable(flinkJobs)
+
+	if !strings.Contains(gotLeveledOutput, wantLeveledOutput) {
+		t.Fatalf("expected output:\n%s\ngot:\n%s", wantLeveledOutput, gotLeveledOutput)
+	}
+
+	gotJSONOutput := logger.JSONOutput()
+	var gotJobs []meroxa.FlinkJob
+	err = json.Unmarshal([]byte(gotJSONOutput), &gotJobs)
+
+	var lf []meroxa.FlinkJob
+
+	for _, f := range flinkJobs {
+		lf = append(lf, *f)
+	}
+
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	if !reflect.DeepEqual(gotJobs, lf) {
+		t.Fatalf("expected \"%v\", got \"%v\"", lf, gotJobs)
+	}
+}
+func TestListFlinkJobsErrorHandling(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockClient(ctrl)
+	logger := log.NewTestLogger()
+
+	errMsg := "some API error"
+
+	client.
+		EXPECT().
+		ListFlinkJobs(ctx).
+		Return(nil, errors.New(errMsg))
+
+	l := &List{
+		client: client,
+		logger: logger,
+	}
+
+	err := l.Execute(ctx)
+	if err == nil {
+		t.Fatalf("expected error, got %q", err.Error())
+	}
+
+	assert.ErrorContains(t, err, errMsg)
+}

--- a/cmd/meroxa/root/flink/list_test.go
+++ b/cmd/meroxa/root/flink/list_test.go
@@ -24,14 +24,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/meroxa/cli/utils/display"
-
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	
 	"github.com/meroxa/cli/log"
 	"github.com/meroxa/cli/utils"
+	"github.com/meroxa/cli/utils/display"
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 	"github.com/meroxa/meroxa-go/pkg/mock"
-	"github.com/stretchr/testify/assert"
 )
 
 func getFlinkJobs() []*meroxa.FlinkJob {

--- a/cmd/meroxa/root/flink/list_test.go
+++ b/cmd/meroxa/root/flink/list_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 Meroxa Inc
+Copyright © 2023 Meroxa Inc
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	
+	"github.com/stretchr/testify/require"
+
 	"github.com/meroxa/cli/log"
 	"github.com/meroxa/cli/utils"
 	"github.com/meroxa/cli/utils/display"
@@ -112,6 +113,6 @@ func TestListFlinkJobsErrorHandling(t *testing.T) {
 		t.Fatalf("expected error, got %q", err.Error())
 	}
 
-        require.Error((t, err)
+	require.Error(t, err)
 	assert.ErrorContains(t, err, errMsg)
 }

--- a/cmd/meroxa/root/flink/list_test.go
+++ b/cmd/meroxa/root/flink/list_test.go
@@ -46,7 +46,7 @@ func TestListFlinkJobsExecution(t *testing.T) {
 	client := mock.NewMockClient(ctrl)
 	logger := log.NewTestLogger()
 
-	flinkJobs := append(getFlinkJobs())
+	flinkJobs := getFlinkJobs()
 
 	client.
 		EXPECT().

--- a/cmd/meroxa/root/flink/list_test.go
+++ b/cmd/meroxa/root/flink/list_test.go
@@ -112,5 +112,6 @@ func TestListFlinkJobsErrorHandling(t *testing.T) {
 		t.Fatalf("expected error, got %q", err.Error())
 	}
 
+        require.Error((t, err)
 	assert.ErrorContains(t, err, errMsg)
 }

--- a/utils/display/flink_jobs.go
+++ b/utils/display/flink_jobs.go
@@ -9,33 +9,43 @@ import (
 )
 
 func FlinkJobsTable(flinkJobs []*meroxa.FlinkJob) string {
-	if len(flinkJobs) != 0 {
-		table := simpletable.New()
-
-		table.Header = &simpletable.Header{
-			Cells: []*simpletable.Cell{
-				{Align: simpletable.AlignCenter, Text: "UUID"},
-				{Align: simpletable.AlignCenter, Text: "NAME"},
-				{Align: simpletable.AlignCenter, Text: "STATE"},
-				{Align: simpletable.AlignCenter, Text: "DEPLOYMENT STATE"},
-			},
-		}
-
-		for _, flinkJob := range flinkJobs {
-			r := []*simpletable.Cell{
-				{Align: simpletable.AlignRight, Text: flinkJob.UUID},
-				{Text: flinkJob.Name},
-				{Text: string(flinkJob.Status.State)},
-				{Text: string(flinkJob.Status.ManagerDeploymentState)},
-			}
-
-			table.Body.Cells = append(table.Body.Cells, r)
-		}
-		table.SetStyle(simpletable.StyleCompact)
-		return table.String()
+	if len(flinkJobs) == 0 {
+		return ""
 	}
 
-	return ""
+	table := simpletable.New()
+
+	table.Header = &simpletable.Header{
+		Cells: []*simpletable.Cell{
+			{Align: simpletable.AlignCenter, Text: "UUID"},
+			{Align: simpletable.AlignCenter, Text: "NAME"},
+			{Align: simpletable.AlignCenter, Text: "ENVIRONMENT"},
+			{Align: simpletable.AlignCenter, Text: "STATE"},
+			{Align: simpletable.AlignCenter, Text: "DEPLOYMENT STATE"},
+		},
+	}
+
+	for _, flinkJob := range flinkJobs {
+		var env string
+
+		if flinkJob.Environment.Name != "" {
+			env = flinkJob.Environment.Name
+		} else {
+			env = string(meroxa.EnvironmentTypeCommon)
+		}
+
+		r := []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: flinkJob.UUID},
+			{Text: flinkJob.Name},
+			{Text: env},
+			{Text: string(flinkJob.Status.State)},
+			{Text: string(flinkJob.Status.ManagerDeploymentState)},
+		}
+
+		table.Body.Cells = append(table.Body.Cells, r)
+	}
+	table.SetStyle(simpletable.StyleCompact)
+	return table.String()
 }
 
 func PrintFlinkJobsTable(jobs []*meroxa.FlinkJob) {

--- a/utils/display/flink_jobs.go
+++ b/utils/display/flink_jobs.go
@@ -1,0 +1,133 @@
+package display
+
+import (
+	"fmt"
+
+	"github.com/alexeyco/simpletable"
+
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+func FlinkJobsTable(flinkJobs []*meroxa.FlinkJob) string {
+	if len(flinkJobs) != 0 {
+		table := simpletable.New()
+
+		table.Header = &simpletable.Header{
+			Cells: []*simpletable.Cell{
+				{Align: simpletable.AlignCenter, Text: "UUID"},
+				{Align: simpletable.AlignCenter, Text: "NAME"},
+				// {Align: simpletable.AlignCenter, Text: "INPUTS TREAMS"},
+				// {Align: simpletable.AlignCenter, Text: "OUTPUT STREAMS"},
+				{Align: simpletable.AlignCenter, Text: "STATE"},
+				// {Align: simpletable.AlignCenter, Text: "LIFECYCLE STATE"},
+				// {Align: simpletable.AlignCenter, Text: "RECONCILIATION STATE"},
+				{Align: simpletable.AlignCenter, Text: "DEPLOYMENT STATE"},
+				// {Align: simpletable.AlignCenter, Text: "CREATED"},
+				// {Align: simpletable.AlignCenter, Text: "UPDATED"},
+			},
+		}
+
+		for _, flinkJob := range flinkJobs {
+			r := []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: flinkJob.UUID},
+				{Text: flinkJob.Name},
+				// {Text: fmt.Sprintf("%v", flinkJob.InputStreams)},
+				// {Text: fmt.Sprintf("%v", flinkJob.OutputStreams)},
+				{Text: string(flinkJob.Status.State)},
+				// {Text: string(flinkJob.Status.LifecycleState)},
+				// {Text: string(flinkJob.Status.ReconciliationState)},
+				{Text: string(flinkJob.Status.ManagerDeploymentState)},
+				// {Text: flinkJob.CreatedAt.String()},
+				// {Text: flinkJob.UpdatedAt.String()},
+			}
+
+			table.Body.Cells = append(table.Body.Cells, r)
+		}
+		table.SetStyle(simpletable.StyleCompact)
+		return table.String()
+	}
+
+	return ""
+}
+
+func PrintFlinkJobsTable(jobs []*meroxa.FlinkJob) {
+	fmt.Println(FlinkJobsTable(jobs))
+}
+
+/* func FlinkJobTable(flinkJob *meroxa.FlinkJob) string {
+	mainTable := simpletable.New()
+	mainTable.Body.Cells = [][]*simpletable.Cell{
+		{
+			{Align: simpletable.AlignRight, Text: "UUID:"},
+			{Text: flinkJob.UUID},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "Name:"},
+			{Text: flinkJob.Name},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "InputStreams:"},
+			{Text: fmt.Sprintf("%v", flinkJob.InputStreams)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "OutputStreams:"},
+			{Text: fmt.Sprintf("%v", flinkJob.OutputStreams)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "State:"},
+			{Text: string(flinkJob.Status.State)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "LifeCycleState:"},
+			{Text: string(flinkJob.Status.LifecycleState)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "ReconciliationState:"},
+			{Text: string(flinkJob.Status.ReconciliationState)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "ManagerDeploymentState:"},
+			{Text: string(flinkJob.Status.ManagerDeploymentState)},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "CreatedAt:"},
+			{Text: flinkJob.CreatedAt.String()},
+		},
+		{
+			{Align: simpletable.AlignRight, Text: "UpdatedAt:"},
+			{Text: flinkJob.UpdatedAt.String()},
+		},
+	}
+
+	if flinkJob.Status.Details != "" {
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "State details:"},
+			{Text: flinkJob.Status.Details},
+		})
+	}
+
+	if flinkJob.Environment != nil {
+		if flinkJob.Environment.UUID != "" {
+			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: "Environment UUID:"},
+				{Text: flinkJob.Environment.UUID},
+			})
+		}
+
+		if flinkJob.Environment.Name != "" {
+			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+				{Align: simpletable.AlignRight, Text: "Environment Name:"},
+				{Text: flinkJob.Environment.Name},
+			})
+		}
+	} else {
+		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
+			{Align: simpletable.AlignRight, Text: "Environment Name:"},
+			{Text: string(meroxa.EnvironmentTypeCommon)},
+		})
+	}
+
+	mainTable.SetStyle(simpletable.StyleCompact)
+
+	return mainTable.String()
+} */

--- a/utils/display/flink_jobs.go
+++ b/utils/display/flink_jobs.go
@@ -16,14 +16,8 @@ func FlinkJobsTable(flinkJobs []*meroxa.FlinkJob) string {
 			Cells: []*simpletable.Cell{
 				{Align: simpletable.AlignCenter, Text: "UUID"},
 				{Align: simpletable.AlignCenter, Text: "NAME"},
-				// {Align: simpletable.AlignCenter, Text: "INPUTS TREAMS"},
-				// {Align: simpletable.AlignCenter, Text: "OUTPUT STREAMS"},
 				{Align: simpletable.AlignCenter, Text: "STATE"},
-				// {Align: simpletable.AlignCenter, Text: "LIFECYCLE STATE"},
-				// {Align: simpletable.AlignCenter, Text: "RECONCILIATION STATE"},
 				{Align: simpletable.AlignCenter, Text: "DEPLOYMENT STATE"},
-				// {Align: simpletable.AlignCenter, Text: "CREATED"},
-				// {Align: simpletable.AlignCenter, Text: "UPDATED"},
 			},
 		}
 
@@ -31,14 +25,8 @@ func FlinkJobsTable(flinkJobs []*meroxa.FlinkJob) string {
 			r := []*simpletable.Cell{
 				{Align: simpletable.AlignRight, Text: flinkJob.UUID},
 				{Text: flinkJob.Name},
-				// {Text: fmt.Sprintf("%v", flinkJob.InputStreams)},
-				// {Text: fmt.Sprintf("%v", flinkJob.OutputStreams)},
 				{Text: string(flinkJob.Status.State)},
-				// {Text: string(flinkJob.Status.LifecycleState)},
-				// {Text: string(flinkJob.Status.ReconciliationState)},
 				{Text: string(flinkJob.Status.ManagerDeploymentState)},
-				// {Text: flinkJob.CreatedAt.String()},
-				// {Text: flinkJob.UpdatedAt.String()},
 			}
 
 			table.Body.Cells = append(table.Body.Cells, r)
@@ -53,81 +41,3 @@ func FlinkJobsTable(flinkJobs []*meroxa.FlinkJob) string {
 func PrintFlinkJobsTable(jobs []*meroxa.FlinkJob) {
 	fmt.Println(FlinkJobsTable(jobs))
 }
-
-/* func FlinkJobTable(flinkJob *meroxa.FlinkJob) string {
-	mainTable := simpletable.New()
-	mainTable.Body.Cells = [][]*simpletable.Cell{
-		{
-			{Align: simpletable.AlignRight, Text: "UUID:"},
-			{Text: flinkJob.UUID},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "Name:"},
-			{Text: flinkJob.Name},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "InputStreams:"},
-			{Text: fmt.Sprintf("%v", flinkJob.InputStreams)},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "OutputStreams:"},
-			{Text: fmt.Sprintf("%v", flinkJob.OutputStreams)},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "State:"},
-			{Text: string(flinkJob.Status.State)},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "LifeCycleState:"},
-			{Text: string(flinkJob.Status.LifecycleState)},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "ReconciliationState:"},
-			{Text: string(flinkJob.Status.ReconciliationState)},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "ManagerDeploymentState:"},
-			{Text: string(flinkJob.Status.ManagerDeploymentState)},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "CreatedAt:"},
-			{Text: flinkJob.CreatedAt.String()},
-		},
-		{
-			{Align: simpletable.AlignRight, Text: "UpdatedAt:"},
-			{Text: flinkJob.UpdatedAt.String()},
-		},
-	}
-
-	if flinkJob.Status.Details != "" {
-		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
-			{Align: simpletable.AlignRight, Text: "State details:"},
-			{Text: flinkJob.Status.Details},
-		})
-	}
-
-	if flinkJob.Environment != nil {
-		if flinkJob.Environment.UUID != "" {
-			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
-				{Align: simpletable.AlignRight, Text: "Environment UUID:"},
-				{Text: flinkJob.Environment.UUID},
-			})
-		}
-
-		if flinkJob.Environment.Name != "" {
-			mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
-				{Align: simpletable.AlignRight, Text: "Environment Name:"},
-				{Text: flinkJob.Environment.Name},
-			})
-		}
-	} else {
-		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
-			{Align: simpletable.AlignRight, Text: "Environment Name:"},
-			{Text: string(meroxa.EnvironmentTypeCommon)},
-		})
-	}
-
-	mainTable.SetStyle(simpletable.StyleCompact)
-
-	return mainTable.String()
-} */

--- a/utils/display/flink_jobs_test.go
+++ b/utils/display/flink_jobs_test.go
@@ -1,0 +1,110 @@
+package display
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meroxa/cli/utils"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlinkJobsTable(t *testing.T) {
+	fOne := &meroxa.FlinkJob{
+		UUID:          "424ec647-9f0f-45a5-8e4b-3e0441f12555",
+		Name:          "my-flink-job",
+		InputStreams:  []string{"inputstream_one", "inputstream_two"},
+		OutputStreams: []string{"outtt"},
+		Status: meroxa.FlinkJobStatus{
+			State:                  "running",
+			LifecycleState:         "success",
+			ReconciliationState:    "deployed",
+			ManagerDeploymentState: "ready",
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+
+	fTwo := &meroxa.FlinkJob{
+		UUID:          "123d4da3-9f0f-45a5-8e4b-77777777",
+		Name:          "squirrel-app",
+		InputStreams:  []string{"inputstream_one"},
+		OutputStreams: []string{"outtt", "anotheroutt"},
+		Status: meroxa.FlinkJobStatus{
+			State:                  "failed",
+			LifecycleState:         "suspended",
+			ReconciliationState:    "rolling back",
+			ManagerDeploymentState: "error",
+		},
+		CreatedAt: time.Time{},
+		UpdatedAt: time.Time{},
+	}
+
+	tests := map[string][]*meroxa.FlinkJob{
+		"Base":         {fOne},
+		"ID_Alignment": {fOne, fTwo},
+		"Empty":        {},
+	}
+
+	for name, flinkJobs := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := utils.CaptureOutput(func() {
+				PrintFlinkJobsTable(flinkJobs)
+			})
+
+			switch name {
+			case "Base":
+				verifyPrintFlinkJobsOutput(t, out, fOne)
+			case "ID_Alignment":
+				verifyPrintFlinkJobsOutput(t, out, fOne)
+				verifyPrintFlinkJobsOutput(t, out, fTwo)
+			case "Empty":
+				assert.Equal(t, out, "\n")
+			}
+			fmt.Println(out)
+		})
+	}
+}
+
+func verifyPrintFlinkJobsOutput(t *testing.T, out string, flinkJob *meroxa.FlinkJob) {
+	// verify header fields
+	tableHeaders := []string{"UUID", "NAME", "STATE", "DEPLOYMENT STATE"}
+
+	for _, header := range tableHeaders {
+		if !strings.Contains(out, header) {
+			t.Errorf("%s header is missing", header)
+		}
+	}
+
+	// verify fields that are supposed to be included in the output
+	if !strings.Contains(out, flinkJob.Name) {
+		t.Errorf("%s, not found", flinkJob.Name)
+	}
+	if !strings.Contains(out, flinkJob.UUID) {
+		t.Errorf("%s, not found", flinkJob.UUID)
+	}
+	if !strings.Contains(out, string(flinkJob.Status.State)) {
+		t.Errorf("state %s, not found", flinkJob.Status.State)
+	}
+	// verify fields that are supposed to be excluded from the output
+	if strings.Contains(out, fmt.Sprintf("%v", flinkJob.InputStreams)) {
+		t.Errorf("found unwanted output: %s", flinkJob.InputStreams)
+	}
+	if strings.Contains(out, fmt.Sprintf("%v", flinkJob.OutputStreams)) {
+		t.Errorf("found unwanted output: %s", flinkJob.OutputStreams)
+	}
+	if strings.Contains(out, string(flinkJob.Status.LifecycleState)) {
+		t.Errorf("found unwanted output: %s", string(flinkJob.Status.LifecycleState))
+	}
+	if strings.Contains(out, string(flinkJob.Status.ReconciliationState)) {
+		t.Errorf("found unwanted output: %s", string(flinkJob.Status.ReconciliationState))
+	}
+	if strings.Contains(out, flinkJob.CreatedAt.String()) {
+		t.Errorf("found unwanted output: %s", flinkJob.CreatedAt.String())
+	}
+	if strings.Contains(out, flinkJob.UpdatedAt.String()) {
+		t.Errorf("found unwanted output: %s", flinkJob.UpdatedAt.String())
+	}
+}

--- a/utils/display/flink_jobs_test.go
+++ b/utils/display/flink_jobs_test.go
@@ -88,6 +88,9 @@ func verifyPrintFlinkJobsOutput(t *testing.T, out string, flinkJob *meroxa.Flink
 	if !strings.Contains(out, string(flinkJob.Status.State)) {
 		t.Errorf("state %s, not found", flinkJob.Status.State)
 	}
+	if !strings.Contains(out, string(meroxa.EnvironmentTypeCommon)) {
+		t.Errorf("state %s, not found", string(meroxa.EnvironmentTypeCommon))
+	}
 	// verify fields that are supposed to be excluded from the output
 	if strings.Contains(out, fmt.Sprintf("%v", flinkJob.InputStreams)) {
 		t.Errorf("found unwanted output: %s", flinkJob.InputStreams)


### PR DESCRIPTION
## Description of change

<!-- Provide a brief description of the change, what it is and why it was made below.* -->

Fixes https://github.com/meroxa/turbine-project/issues/290

With this change, we're adding the `meroxa flink list` command to the CLI. This way, users will be able to see a list of their already deployed Flink jobs on the platform.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube


## Open todos

- [x] add additional test cases for command failure
- [x] add tests for empty list
- [x] create demo

## Demo

```
$ meroxa flink list
UUID                                    NAME              ENVIRONMENT       STATE             DEPLOYMENT STATE        
====================================== ================ ================== ================  ====================== 
118c7446-e60c-49a7-ac90-12e04d64df9e   my-first-flink       common           running           deployed                     
cb7a7d7c-8bb3-4549-9af7-4f9eaab9c2af   my-second-flink      common           failed            rolling back                
```

