### PR TITLE
fix: depguard errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ^1.18
+        go-version: ^1.20
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
     - name: Build
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.20
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.20
       - name: Generated files
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin

--- a/.github/workflows/dispatch_turbine_go_dependency.yml
+++ b/.github/workflows/dispatch_turbine_go_dependency.yml
@@ -17,7 +17,7 @@ jobs:
           ref: master
       - uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.20
       - name: Inject insteadOf configuration
         env:
           MEROXA_MACHINE: ${{ secrets.MEROXA_MACHINE }}

--- a/.github/workflows/fig.yml
+++ b/.github/workflows/fig.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: ^1.18
+        go-version: ^1.20
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3  
     - name: Run make fig

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 1.20.x
       -
         name: Import GPG key
         id: import_gpg

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,32 @@ linters-settings:
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
 
+  depguard:
+    rules:
+      # Name of a rule.
+      main:
+        allow:
+          - $gostd
+          - github.com/meroxa
+          - github.com/alexeyco/simpletable
+          - github.com/briandowns/spinner
+          - github.com/cased/cased-go
+          - github.com/fatih/color
+          - github.com/golang/mock/gomock
+          - github.com/google/go-cmp
+          - github.com/google/uuid
+          - github.com/gorilla/mux
+          - github.com/manifoldco/promptui
+          - github.com/mattn/go-shellwords
+          - github.com/nirasan/go-oauth-pkce-code-verifier
+          - github.com/pkg/browser
+          - github.com/skratchdot/open-golang/open
+          - github.com/spf13/cobra
+          - github.com/spf13/pflag
+          - github.com/spf13/viper
+          - github.com/stretchr/testify
+          - github.com/withfig/autocomplete-tools/integrations/cobra
+
 linters:
   # please, do not use `enable-all`: it's deprecated and will be removed soon.
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint


### PR DESCRIPTION
## Description of change

Fixes CI errors on depguard. An alternative is disabled that check altogether...


## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Tested on CI

## Demo

**Before**


```
...
import 'github.com/fatih/color' is not allowed from list 'main' (depguard)
import 'github.com/briandowns/spinner' is not allowed from list 'main' (depguard)
import 'github.com/spf13/cobra' is not allowed from list 'main' (depguard)
import 'github.com/pkg/browser' is not allowed from list 'main' (depguard)
import 'github.com/spf13/cobra' is not allowed from list 'main' (depguard)
import 'github.com/spf13/cobra' is not allowed from list 'main' (depguard)
import 'github.com/spf13/cobra/doc' is not allowed from list 'main' (depguard)
import 'github.com/withfig/autocomplete-tools/integrations/cobra' is not allowed from list 'main' 
import 'github.com/gorilla/mux' is not allowed from list 'main' (depguard)
import 'github.com/google/uuid' is not allowed from list 'main' (depguard)
import 'github.com/spf13/pflag' is not allowed from list 'main' (depguard)
import 'github.com/cased/cased-go' is not allowed from list 'main' (depguard)
import 'github.com/spf13/pflag' is not allowed from list 'main' (depguard)
import 'github.com/spf13/viper' is not allowed from list 'main' (depguard)
```

**After**

No errors.
