### PR TITLE
chore: Upgrade to latest turbine-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 require (
 	github.com/briandowns/spinner v1.21.0
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-core v0.0.0-20230522172301-9867be85eb47
-	github.com/stretchr/testify v1.8.3
+	github.com/meroxa/turbine-core v0.0.0-20230605100209-67a6cf60fee6
+	github.com/stretchr/testify v1.8.4
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	golang.org/x/mod v0.10.0
 	google.golang.org/protobuf v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -190,8 +190,8 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/meroxa/meroxa-go v0.0.0-20230602200008-52f4437a6a26 h1:WyDJJuELd8iDIgcwY4PscfNazQY7YRRHqwD1+Z/z2HQ=
 github.com/meroxa/meroxa-go v0.0.0-20230602200008-52f4437a6a26/go.mod h1:zO5ivDagJFc+zejDNHe/GwtCvgN1zqfBIpIuSvgiUFc=
-github.com/meroxa/turbine-core v0.0.0-20230522172301-9867be85eb47 h1:bghd4ClyfYjFIvkeQkVMFVEPpB9pbikyPUxLLWi9Cxw=
-github.com/meroxa/turbine-core v0.0.0-20230522172301-9867be85eb47/go.mod h1:/83voxEvn+hi7nyEGMeOTi8wG9qRnINzTs5LwzDH7F4=
+github.com/meroxa/turbine-core v0.0.0-20230605100209-67a6cf60fee6 h1:G1i0yuVl2+WDAjTXf2VMh8NFsFQhzaj6RG8GGrBKAv8=
+github.com/meroxa/turbine-core v0.0.0-20230605100209-67a6cf60fee6/go.mod h1:FviXoY5aQnWGZad9Tv9+RT3bMlA6UjD9uVs1SGMyt8k=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da h1:qiPWuGGr+1GQE6s9NPSK8iggR/6x/V+0snIoOPYsBgc=
@@ -238,8 +238,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.4.2 h1:X1TuBLAMDFbaTAChgCBLu3DU3UPyELpnF2jjJ2cz/S8=
 github.com/subosito/gotenv v1.4.2/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1 h1:+dBg5k7nuTE38VVdoroRsT0Z88fmvdYrI2EjzJst35I=

--- a/vendor/github.com/meroxa/turbine-core/pkg/app/templates/javascript/package.json
+++ b/vendor/github.com/meroxa/turbine-core/pkg/app/templates/javascript/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
-    "@meroxa/turbine-js": "^2.0.0-alpha.6",
+    "@meroxa/turbine-js": "^2.0.0",
     "string-hash": "^1.1.3"
   },
   "devDependencies": {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.20
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-core v0.0.0-20230522172301-9867be85eb47
+# github.com/meroxa/turbine-core v0.0.0-20230605100209-67a6cf60fee6
 ## explicit; go 1.20
 github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core
 github.com/meroxa/turbine-core/pkg/app
@@ -180,7 +180,7 @@ github.com/spf13/viper/internal/encoding/javaproperties
 github.com/spf13/viper/internal/encoding/json
 github.com/spf13/viper/internal/encoding/toml
 github.com/spf13/viper/internal/encoding/yaml
-# github.com/stretchr/testify v1.8.3
+# github.com/stretchr/testify v1.8.4
 ## explicit; go 1.20
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require


### PR DESCRIPTION
The following commands were run to generate changes: go get -u github.com/meroxa/turbine-go@latest and make gomod