### PR TITLE
Exit 1 when grpc requests fail

### DIFF
--- a/cmd/meroxa/turbine/golang/deploy.go
+++ b/cmd/meroxa/turbine/golang/deploy.go
@@ -55,7 +55,7 @@ func (t *turbineGoCLI) StartGrpcServer(ctx context.Context, gitSha string) (func
 	cmd.Dir = t.appPath
 	cmd.Env = os.Environ()
 
-	if err := turbine.RunCMD(ctx, t.logger, cmd); err != nil {
+	if _, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger); err != nil {
 		return nil, err
 	}
 

--- a/cmd/meroxa/turbine/golang/run.go
+++ b/cmd/meroxa/turbine/golang/run.go
@@ -23,5 +23,6 @@ func (t *turbineGoCLI) Run(ctx context.Context) error {
 	cmd.Dir = t.appPath
 	cmd.Env = os.Environ()
 
-	return turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return err
 }

--- a/cmd/meroxa/turbine/javascript/deploy.go
+++ b/cmd/meroxa/turbine/javascript/deploy.go
@@ -18,7 +18,8 @@ func (t *turbineJsCLI) CreateDockerfile(ctx context.Context, _ string) (string, 
 		map[string]string{},
 		t.appPath,
 	)
-	return t.appPath, turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return t.appPath, err
 }
 
 func (t *turbineJsCLI) StartGrpcServer(ctx context.Context, gitSha string) (func(), error) {
@@ -37,7 +38,7 @@ func (t *turbineJsCLI) StartGrpcServer(ctx context.Context, gitSha string) (func
 		gitSha,
 	)
 
-	if err := turbine.RunCMD(ctx, t.logger, cmd); err != nil {
+	if _, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger); err != nil {
 		return nil, err
 	}
 

--- a/cmd/meroxa/turbine/javascript/run.go
+++ b/cmd/meroxa/turbine/javascript/run.go
@@ -22,5 +22,6 @@ func (t *turbineJsCLI) Run(ctx context.Context) error {
 		"devel",
 	)
 
-	return utils.RunCMD(ctx, t.logger, cmd)
+	_, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return err
 }

--- a/cmd/meroxa/turbine/python/deploy.go
+++ b/cmd/meroxa/turbine/python/deploy.go
@@ -13,7 +13,8 @@ func (t *turbinePyCLI) CreateDockerfile(ctx context.Context, _ string) (string, 
 		map[string]string{},
 		t.appPath,
 	)
-	return t.appPath, turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return t.appPath, err
 }
 
 func (t *turbinePyCLI) StartGrpcServer(ctx context.Context, gitSha string) (func(), error) {
@@ -31,7 +32,7 @@ func (t *turbinePyCLI) StartGrpcServer(ctx context.Context, gitSha string) (func
 		gitSha,
 	)
 
-	if err := turbine.RunCMD(ctx, t.logger, cmd); err != nil {
+	if _, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger); err != nil {
 		return nil, err
 	}
 

--- a/cmd/meroxa/turbine/python/run.go
+++ b/cmd/meroxa/turbine/python/run.go
@@ -19,5 +19,6 @@ func (t *turbinePyCLI) Run(ctx context.Context) error {
 		t.appPath,
 		"",
 	)
-	return turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return err
 }

--- a/cmd/meroxa/turbine/ruby/deploy.go
+++ b/cmd/meroxa/turbine/ruby/deploy.go
@@ -14,7 +14,8 @@ func (t *turbineRbCLI) CreateDockerfile(ctx context.Context, _ string) (string, 
 		internal.TurbineCommandBuild,
 		map[string]string{},
 	)
-	return t.appPath, turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return t.appPath, err
 }
 
 func (t *turbineRbCLI) StartGrpcServer(ctx context.Context, gitSha string) (func(), error) {
@@ -33,7 +34,7 @@ func (t *turbineRbCLI) StartGrpcServer(ctx context.Context, gitSha string) (func
 		gitSha,
 	)
 
-	if err := turbine.RunCMD(ctx, t.logger, cmd); err != nil {
+	if _, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger); err != nil {
 		return nil, err
 	}
 

--- a/cmd/meroxa/turbine/ruby/run.go
+++ b/cmd/meroxa/turbine/ruby/run.go
@@ -18,5 +18,6 @@ func (t *turbineRbCLI) Run(ctx context.Context) error {
 		map[string]string{
 			"TURBINE_CORE_SERVER": grpcListenAddress,
 		})
-	return turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return err
 }


### PR DESCRIPTION
## Description of change

the process library may not detect all of the potential errors in the command it's running.  we need to look at stderr explicitly. 

Fixes https://github.com/meroxa/cli/issues/770

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
BEFORE
```shell
$ meroxa apps run
<_InactiveRpcError of RPC that terminated with:
status = StatusCode.UNKNOWN
details = "json: cannot unmarshal object into Go struct field fixtureRecord.Key of type string"
debug_error_string = "UNKNOWN:Error received from peer {created_time:"2023-06-08T16:49:06.304472766-07:00", grpc_status:2, grpc_message:"json: cannot unmarshal object into Go struct field fixtureRecord.Key of type string"}"

e(2023) janelle@janelle-thinkpad:~/go/src/github.com/meroxa/turbine-examples/python/notion-s3-python (restore-python-actions) $ echo $?
0 |
```

AFTER
```shell
$ m apps run
Error: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNKNOWN
	details = "json: cannot unmarshal object into Go struct field fixtureRecord.Key of type string"
	debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2023-06-09T08:00:34.482320432-07:00", grpc_status:2, grpc_message:"json: cannot unmarshal object into Go struct field fixtureRecord.Key of type string"}"
>

(2023) janelle@janelle-thinkpad:~/go/src/github.com/meroxa/turbine-examples/python/notion-s3-python  (restore-python-actions) $ echo $?
1
```

![Screenshot from 2023-06-09 12-05-11](https://github.com/meroxa/cli/assets/12731615/2a257667-f8a6-436d-962e-4465f21d8cf0)




## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
