### PR TITLE
Exit 1 when grpc requests fail (#771)

### DIFF
--- a/cmd/meroxa/turbine/golang/deploy.go
+++ b/cmd/meroxa/turbine/golang/deploy.go
@@ -55,7 +55,7 @@ func (t *turbineGoCLI) StartGrpcServer(ctx context.Context, gitSha string) (func
 	cmd.Dir = t.appPath
 	cmd.Env = os.Environ()
 
-	if err := turbine.RunCMD(ctx, t.logger, cmd); err != nil {
+	if _, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger); err != nil {
 		return nil, err
 	}
 

--- a/cmd/meroxa/turbine/golang/run.go
+++ b/cmd/meroxa/turbine/golang/run.go
@@ -23,5 +23,6 @@ func (t *turbineGoCLI) Run(ctx context.Context) error {
 	cmd.Dir = t.appPath
 	cmd.Env = os.Environ()
 
-	return turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return err
 }

--- a/cmd/meroxa/turbine/javascript/deploy.go
+++ b/cmd/meroxa/turbine/javascript/deploy.go
@@ -18,7 +18,8 @@ func (t *turbineJsCLI) CreateDockerfile(ctx context.Context, _ string) (string, 
 		map[string]string{},
 		t.appPath,
 	)
-	return t.appPath, turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return t.appPath, err
 }
 
 func (t *turbineJsCLI) StartGrpcServer(ctx context.Context, gitSha string) (func(), error) {
@@ -37,7 +38,7 @@ func (t *turbineJsCLI) StartGrpcServer(ctx context.Context, gitSha string) (func
 		gitSha,
 	)
 
-	if err := turbine.RunCMD(ctx, t.logger, cmd); err != nil {
+	if _, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger); err != nil {
 		return nil, err
 	}
 

--- a/cmd/meroxa/turbine/javascript/run.go
+++ b/cmd/meroxa/turbine/javascript/run.go
@@ -22,5 +22,6 @@ func (t *turbineJsCLI) Run(ctx context.Context) error {
 		"devel",
 	)
 
-	return utils.RunCMD(ctx, t.logger, cmd)
+	_, err := utils.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return err
 }

--- a/cmd/meroxa/turbine/python/deploy.go
+++ b/cmd/meroxa/turbine/python/deploy.go
@@ -13,7 +13,8 @@ func (t *turbinePyCLI) CreateDockerfile(ctx context.Context, _ string) (string, 
 		map[string]string{},
 		t.appPath,
 	)
-	return t.appPath, turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return t.appPath, err
 }
 
 func (t *turbinePyCLI) StartGrpcServer(ctx context.Context, gitSha string) (func(), error) {
@@ -31,7 +32,7 @@ func (t *turbinePyCLI) StartGrpcServer(ctx context.Context, gitSha string) (func
 		gitSha,
 	)
 
-	if err := turbine.RunCMD(ctx, t.logger, cmd); err != nil {
+	if _, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger); err != nil {
 		return nil, err
 	}
 

--- a/cmd/meroxa/turbine/python/run.go
+++ b/cmd/meroxa/turbine/python/run.go
@@ -19,5 +19,6 @@ func (t *turbinePyCLI) Run(ctx context.Context) error {
 		t.appPath,
 		"",
 	)
-	return turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return err
 }

--- a/cmd/meroxa/turbine/ruby/deploy.go
+++ b/cmd/meroxa/turbine/ruby/deploy.go
@@ -14,7 +14,8 @@ func (t *turbineRbCLI) CreateDockerfile(ctx context.Context, _ string) (string, 
 		internal.TurbineCommandBuild,
 		map[string]string{},
 	)
-	return t.appPath, turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return t.appPath, err
 }
 
 func (t *turbineRbCLI) StartGrpcServer(ctx context.Context, gitSha string) (func(), error) {
@@ -33,7 +34,7 @@ func (t *turbineRbCLI) StartGrpcServer(ctx context.Context, gitSha string) (func
 		gitSha,
 	)
 
-	if err := turbine.RunCMD(ctx, t.logger, cmd); err != nil {
+	if _, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger); err != nil {
 		return nil, err
 	}
 

--- a/cmd/meroxa/turbine/ruby/run.go
+++ b/cmd/meroxa/turbine/ruby/run.go
@@ -18,5 +18,6 @@ func (t *turbineRbCLI) Run(ctx context.Context) error {
 		map[string]string{
 			"TURBINE_CORE_SERVER": grpcListenAddress,
 		})
-	return turbine.RunCMD(ctx, t.logger, cmd)
+	_, err := turbine.RunCmdWithErrorDetection(ctx, cmd, t.logger)
+	return err
 }

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -187,19 +187,6 @@ func GetTurbineResponseFromOutput(output string) (string, error) {
 	return trimmed, nil
 }
 
-func RunCMD(ctx context.Context, logger log.Logger, cmd *exec.Cmd) error {
-	if err := cmd.Start(); err != nil {
-		logger.Errorf(ctx, err.Error())
-		return err
-	}
-
-	if err := cmd.Wait(); err != nil {
-		logger.Errorf(ctx, err.Error())
-		return err
-	}
-	return nil
-}
-
 // RunCmdWithErrorDetection checks exit codes and stderr for failures and logs on success.
 func RunCmdWithErrorDetection(ctx context.Context, cmd *exec.Cmd, l log.Logger) (string, error) {
 	stdout, stderr := bytes.NewBuffer(nil), bytes.NewBuffer(nil)

--- a/cmd/meroxa/turbine/utils_test.go
+++ b/cmd/meroxa/turbine/utils_test.go
@@ -214,43 +214,6 @@ func TestGetPath(t *testing.T) {
 	}
 }
 
-func TestRunCMD(t *testing.T) {
-	ctx := context.Background()
-	logger := log.NewTestLogger()
-
-	tests := []struct {
-		name  string
-		input *exec.Cmd
-		err   error
-	}{
-		{
-			name:  "Successfully execute command",
-			input: exec.Command("date"),
-			err:   nil,
-		},
-		{
-			name:  "Fail to find command",
-			input: exec.Command("not-a-thing"),
-			err:   fmt.Errorf("exec: \"not-a-thing\": executable file not found in $PATH"),
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := RunCMD(ctx, logger, tc.input)
-			if err != nil {
-				if tc.err == nil {
-					t.Fatalf("unexpected err: %v", err)
-				} else {
-					assert.Equal(t, tc.err.Error(), err.Error())
-				}
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestRunCMDWithErrorDetection(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewTestLogger()

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-core v0.0.0-20230605100209-67a6cf60fee6
+	github.com/meroxa/turbine-core v0.0.0-20230609143328-ff4d4ed7edbb
 	github.com/stretchr/testify v1.8.4
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	golang.org/x/mod v0.10.0
@@ -42,7 +42,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dewski/jsonpath v0.0.0-20210103075638-af6da8f1a897 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/envoyproxy/protoc-gen-validate v1.0.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.0.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/envoyproxy/protoc-gen-validate v1.0.0 h1:FPFO7LWZ2pfphahSUMX8L5p/6FqSzRYRxq6V74eG8ZI=
-github.com/envoyproxy/protoc-gen-validate v1.0.0/go.mod h1:0vj8bNkYbSTNS2PIyH87KZaeN4x9zpL9Qt8fQC7d+vs=
+github.com/envoyproxy/protoc-gen-validate v1.0.1 h1:kt9FtLiooDc0vbwTLhdg3dyNX1K9Qwa1EK9LcD4jVUQ=
+github.com/envoyproxy/protoc-gen-validate v1.0.1/go.mod h1:0vj8bNkYbSTNS2PIyH87KZaeN4x9zpL9Qt8fQC7d+vs=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
@@ -187,8 +187,8 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/meroxa/meroxa-go v0.0.0-20230602200008-52f4437a6a26 h1:WyDJJuELd8iDIgcwY4PscfNazQY7YRRHqwD1+Z/z2HQ=
 github.com/meroxa/meroxa-go v0.0.0-20230602200008-52f4437a6a26/go.mod h1:zO5ivDagJFc+zejDNHe/GwtCvgN1zqfBIpIuSvgiUFc=
-github.com/meroxa/turbine-core v0.0.0-20230605100209-67a6cf60fee6 h1:G1i0yuVl2+WDAjTXf2VMh8NFsFQhzaj6RG8GGrBKAv8=
-github.com/meroxa/turbine-core v0.0.0-20230605100209-67a6cf60fee6/go.mod h1:FviXoY5aQnWGZad9Tv9+RT3bMlA6UjD9uVs1SGMyt8k=
+github.com/meroxa/turbine-core v0.0.0-20230609143328-ff4d4ed7edbb h1:leYdqM+JczQgyAzTkjqn+w0mQEa+P6hspEFMvRvKC3g=
+github.com/meroxa/turbine-core v0.0.0-20230609143328-ff4d4ed7edbb/go.mod h1:FviXoY5aQnWGZad9Tv9+RT3bMlA6UjD9uVs1SGMyt8k=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da h1:qiPWuGGr+1GQE6s9NPSK8iggR/6x/V+0snIoOPYsBgc=

--- a/vendor/github.com/meroxa/turbine-core/pkg/app/config.go
+++ b/vendor/github.com/meroxa/turbine-core/pkg/app/config.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/meroxa/turbine-core/pkg/ir"
 )
@@ -43,7 +44,7 @@ var ReadConfig = func(appName, appPath string) (Config, error) {
 		appPath = path.Dir(exePath)
 	}
 
-	b, err := os.ReadFile(appPath + "/" + "app.json")
+	b, err := os.ReadFile(filepath.Join(appPath, "app.json"))
 	if err != nil {
 		return Config{}, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -32,7 +32,7 @@ github.com/emirpasic/gods/queues/linkedlistqueue
 github.com/emirpasic/gods/stacks
 github.com/emirpasic/gods/stacks/linkedliststack
 github.com/emirpasic/gods/utils
-# github.com/envoyproxy/protoc-gen-validate v1.0.0
+# github.com/envoyproxy/protoc-gen-validate v1.0.1
 ## explicit; go 1.19
 github.com/envoyproxy/protoc-gen-validate/validate
 # github.com/fatih/color v1.15.0
@@ -111,7 +111,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.20
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-core v0.0.0-20230605100209-67a6cf60fee6
+# github.com/meroxa/turbine-core v0.0.0-20230609143328-ff4d4ed7edbb
 ## explicit; go 1.20
 github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core
 github.com/meroxa/turbine-core/pkg/app


### PR DESCRIPTION
## Description of change

<!-- Provide a brief description of the change, what it is and why it was made below.* -->

Fixes https://github.com/meroxa/cli/issues/770
Related to https://github.com/meroxa/turbine-go/issues/162

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

BEFORE
```shell
$ meroxa apps run
<_InactiveRpcError of RPC that terminated with:
status = StatusCode.UNKNOWN
details = "json: cannot unmarshal object into Go struct field fixtureRecord.Key of type string"
debug_error_string = "UNKNOWN:Error received from peer {created_time:"2023-06-08T16:49:06.304472766-07:00", grpc_status:2, grpc_message:"json: cannot unmarshal object into Go struct field fixtureRecord.Key of type string"}"

e(2023) janelle@janelle-thinkpad:~/go/src/github.com/meroxa/turbine-examples/python/notion-s3-python (restore-python-actions) $ echo $?
0 |
```

AFTER
```shell
$ m apps run
Error: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.UNKNOWN
	details = "json: cannot unmarshal object into Go struct field fixtureRecord.Key of type string"
	debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2023-06-09T08:00:34.482320432-07:00", grpc_status:2, grpc_message:"json: cannot unmarshal object into Go struct field fixtureRecord.Key of type string"}"
>

(2023) janelle@janelle-thinkpad:~/go/src/github.com/meroxa/turbine-examples/python/notion-s3-python  (restore-python-actions) $ echo $?
1
```

![Screenshot from 2023-06-09 12-05-11](https://github.com/meroxa/cli/assets/12731615/2a257667-f8a6-436d-962e-4465f21d8cf0)



## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
