### PR TITLE
Update references to turbine-go because of proper v2 tagging

### DIFF
--- a/cmd/meroxa/turbine/golang/utils.go
+++ b/cmd/meroxa/turbine/golang/utils.go
@@ -10,7 +10,7 @@ import (
 // GoGetDeps updates the latest Meroxa mods.
 func GoGetDeps(l log.Logger) error {
 	l.StartSpinner("\t", "Getting latest turbine-go and turbine-go/running dependencies...")
-	cmd := exec.Command("go", "get", "-u", "github.com/meroxa/turbine-go@main")
+	cmd := exec.Command("go", "get", "-u", "github.com/meroxa/turbine-go/v2@latest")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		l.StopSpinnerWithStatus(fmt.Sprintf("%s", string(output)), log.Failed)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 require (
 	github.com/briandowns/spinner v1.23.0
 	github.com/mattn/go-shellwords v1.0.12
-	github.com/meroxa/turbine-core v0.0.0-20230614165646-663965381cd4
+	github.com/meroxa/turbine-core v0.0.0-20230614233233-044d997b9e71
 	github.com/stretchr/testify v1.8.4
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	golang.org/x/mod v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebG
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/meroxa/meroxa-go v0.0.0-20230602200008-52f4437a6a26 h1:WyDJJuELd8iDIgcwY4PscfNazQY7YRRHqwD1+Z/z2HQ=
 github.com/meroxa/meroxa-go v0.0.0-20230602200008-52f4437a6a26/go.mod h1:zO5ivDagJFc+zejDNHe/GwtCvgN1zqfBIpIuSvgiUFc=
-github.com/meroxa/turbine-core v0.0.0-20230614165646-663965381cd4 h1:YYBn3DBKVc4XmksDWLT43S4ELHkcRUYEBLAkCkAPlkg=
-github.com/meroxa/turbine-core v0.0.0-20230614165646-663965381cd4/go.mod h1:FKlgNtdLKmoLM+qQwIOc5+yLDmB/WlBRLHKnS5qoRzY=
+github.com/meroxa/turbine-core v0.0.0-20230614233233-044d997b9e71 h1:OQY0JWZzr+fw4jgysaYCw4CWlCbu5uTUhJ0dJdJrPG8=
+github.com/meroxa/turbine-core v0.0.0-20230614233233-044d997b9e71/go.mod h1:W3hnKV7ClJBkDOQThEYVFYPw7UnRl73pF551H9pfyA8=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da h1:qiPWuGGr+1GQE6s9NPSK8iggR/6x/V+0snIoOPYsBgc=

--- a/vendor/github.com/meroxa/turbine-core/pkg/app/templates/golang/app.go
+++ b/vendor/github.com/meroxa/turbine-core/pkg/app/templates/golang/app.go
@@ -8,8 +8,8 @@ import (
 	"log"
 
 	// Dependencies of Turbine
-	"github.com/meroxa/turbine-go/pkg/turbine"
-	"github.com/meroxa/turbine-go/pkg/turbine/cmd"
+	"github.com/meroxa/turbine-go/v2/pkg/turbine"
+	"github.com/meroxa/turbine-go/v2/pkg/turbine/cmd"
 )
 
 func main() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/mattn/go-shellwords
 ## explicit; go 1.20
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
-# github.com/meroxa/turbine-core v0.0.0-20230614165646-663965381cd4
+# github.com/meroxa/turbine-core v0.0.0-20230614233233-044d997b9e71
 ## explicit; go 1.20
 github.com/meroxa/turbine-core/lib/go/github.com/meroxa/turbine/core
 github.com/meroxa/turbine-core/pkg/app


### PR DESCRIPTION
## Description of change

Must refer to turbine-go in a new way after proper v2 tagging

Related to meroxa/product#822

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|<!-- Replace this with a screenshot/gif -->|<!-- Replace this with a screenshot/gif -->|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
