### PR TITLE
Add stdOut to error message so they are printed together

### DIFF
--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -212,7 +212,7 @@ func RunCmdWithErrorDetection(ctx context.Context, cmd *exec.Cmd, l log.Logger) 
 		}
 		if errLog != "" {
 			if stdOutMsg != "" {
-				l.Info(ctx, "\n"+stdOutMsg+"\n")
+				errLog = stdOutMsg + errLog
 			}
 			return "", errors.New(errLog)
 		}

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -188,7 +188,7 @@ func GetTurbineResponseFromOutput(output string) (string, error) {
 }
 
 // RunCmdWithErrorDetection checks exit codes and stderr for failures and logs on success.
-func RunCmdWithErrorDetection(ctx context.Context, cmd *exec.Cmd, l log.Logger) (string, error) {
+func RunCmdWithErrorDetection(_ context.Context, cmd *exec.Cmd, _ log.Logger) (string, error) {
 	stdout, stderr := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr


### PR DESCRIPTION
## Description of change

Helps with making acceptance test errors clearer in particular

This affects run and deploy commands, in the least. 

Fixes <GitHub Issue>

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

BEFORE
```shell
=== RUN   TestAppMgmt/go:_Run_app
    shared_test.go:174: C:\Users\runneradmin\go\bin\meroxa.exe --cli-config-file C:\Users\runneradmin/meroxa.main.env app run --path ../apps/turbine_go/template/tmp/app/go-acceptance-app-9bd2fb52-8670-41d6-b4b2-80011866f0b3 --json
    shared_test.go:176: Error: exit status 1
```

AFTER
```shell
=== RUN   TestAppMgmt/go:_Run_app
    shared_test.go:174: C:\Users\runneradmin\go\bin\meroxa.exe --cli-config-file C:\Users\runneradmin/meroxa.main.env app run --path ../apps/turbine_go/template/tmp/app/go-acceptance-app-9bd2fb52-8670-41d6-b4b2-80011866f0b3 --json
    shared_test.go:176: Error: 2023/06/20 23:05:26 unable to find turbine-go in modules
        exit status 1
```

## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
