### PR TITLE
bug: use spinning logs correctly in flink deploy command

### DIFF
--- a/cmd/meroxa/root/flink/deploy.go
+++ b/cmd/meroxa/root/flink/deploy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/meroxa/turbine-core/pkg/ir"
 	"path/filepath"
 
 	"github.com/meroxa/cli/cmd/meroxa/builder"
@@ -30,6 +29,7 @@ import (
 	"github.com/meroxa/cli/log"
 	"github.com/meroxa/cli/utils"
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
+	"github.com/meroxa/turbine-core/pkg/ir"
 )
 
 type deployFlinkJobClient interface {


### PR DESCRIPTION
## Description of change

when the start and stop spinners don't line up, log lines get garbled

Fixes https://github.com/meroxa/product/issues/959

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

<!-- Provide examples of how the feature looked before and after this change in the table below -->
| before | after |
|--------|-------|
|
![Screenshot from 2023-08-08 17-50-53](https://github.com/meroxa/cli/assets/12731615/2be9288b-5df1-4b41-8aca-98db9f7cc9ff)

|
![deployRedo](https://github.com/meroxa/cli/assets/12731615/63f35668-3219-4767-9637-58ba617d555f)
|


## Additional references

<!-- Post any additional links (if appropriate) below -->

## Documentation updated

<!-- Make sure that our [documentation](https://docs.meroxa.com/) is accordingly updated when necessary.

You can do that by opening a pull-request to our (🔒 private, for now) repository: https://github.com/meroxa/meroxa-docs.

✨ In the future, there will be a GitHub action taking care of these updates automatically. ✨ -->

<!-- Provide a PR link below -->
