### PR TITLE
Clarify grpc errors for missing source collection

### DIFF
--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -37,7 +37,7 @@ https://docs.meroxa.com/beta-overview#updated-meroxa-cli-and-outdated-turbine-li
 	grpcDestCollectionErr = "invalid WriteCollectionRequest.SourceCollection: embedded message failed validation | " +
 		"caused by: invalid Collection.Name: value length must be at least 1 runes"
 	missingSourceCollectionErr = `missing source or source collection, please ensure that you have configured your source correctly:
-https://docs.meroxa.com/turbine/troubleshooting"`
+https://docs.meroxa.com/turbine/troubleshooting#troubleshooting-checklist"`
 )
 
 type AppConfig struct {

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -36,7 +36,7 @@ https://docs.meroxa.com/beta-overview#updated-meroxa-cli-and-outdated-turbine-li
 		"caused by: invalid Collection.Name: value length must be at least 1 runes"
 	grpcDestCollectionErr = "invalid WriteCollectionRequest.SourceCollection: embedded message failed validation | " +
 		"caused by: invalid Collection.Name: value length must be at least 1 runes"
-	missingSourceCollectionErr = `missing source collection, please ensure that you have configured your source correctly:
+	missingSourceCollectionErr = `missing source or source collection, please ensure that you have configured your source correctly:
 https://docs.meroxa.com/turbine/troubleshooting"`
 )
 

--- a/cmd/meroxa/turbine/utils.go
+++ b/cmd/meroxa/turbine/utils.go
@@ -195,7 +195,7 @@ func GetTurbineResponseFromOutput(output string) (string, error) {
 }
 
 // RunCmdWithErrorDetection checks exit codes and stderr for failures and logs on success.
-func RunCmdWithErrorDetection(_ context.Context, cmd *exec.Cmd, _ log.Logger) (string, error) {
+func RunCmdWithErrorDetection(ctx context.Context, cmd *exec.Cmd, logger log.Logger) (string, error) {
 	stdout, stderr := bytes.NewBuffer(nil), bytes.NewBuffer(nil)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -223,6 +223,7 @@ func RunCmdWithErrorDetection(_ context.Context, cmd *exec.Cmd, _ log.Logger) (s
 			}
 
 			if strings.Contains(errLog, "rpc error") {
+				logger.Debug(ctx, errLog)
 				errLog = clarifyGrpcErrors(errLog)
 			}
 


### PR DESCRIPTION
## Description of change

Adds more clarity to gRPC errors from turbine-core when an app has no sources defined.

Fixes https://github.com/meroxa/product/issues/936

## Type of change

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?
- [x] Manual Tests
- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

### Before
```
❯ ../cli/meroxa apps deploy     
Validating your app.json...
        ✔ Checked your language is "golang"
        ✔ Checked your application name is "notion-s3"
Checking for uncommitted changes...
        ✔ No uncommitted changes!
Error: 2023/08/07 14:13:23 rpc error: code = Unknown desc = invalid ProcessCollectionRequest.Collection: embedded message failed validation | caused by: invalid Collection.Name: value length must be at least 1 runes
exit status 1
```
### After
```
❯ ../cli/meroxa apps deploy
Validating your app.json...
        ✔ Checked your language is "golang"
        ✔ Checked your application name is "notion-s3"
Checking for uncommitted changes...
        ✔ No uncommitted changes!
Error: missing source collection, please ensure that you have configured your source correctly:
https://docs.meroxa.com/turbine/troubleshooting"
```

## Documentation updated

Will need to make an adjustment to the docs before merging this PR, to link directly to the new high-level troubleshooting checklist: https://github.com/meroxa/meroxa-docs/pull/431
