### PR TITLE
feat(flink): Add logs command

### DIFF
--- a/cmd/meroxa/root/apps/logs.go
+++ b/cmd/meroxa/root/apps/logs.go
@@ -117,7 +117,7 @@ func (l *Logs) Execute(ctx context.Context) error {
 		return getErr
 	}
 
-	output := display.AppLogsTable(appLogs)
+	output := display.LogsTable(appLogs)
 
 	l.logger.Info(ctx, output)
 	l.logger.JSON(ctx, appLogs)

--- a/cmd/meroxa/root/apps/logs_test.go
+++ b/cmd/meroxa/root/apps/logs_test.go
@@ -107,7 +107,7 @@ func TestApplicationLogsExecution(t *testing.T) {
 	}
 
 	gotLeveledOutput := logger.LeveledOutput()
-	wantLeveledOutput := display.AppLogsTable(appLogs)
+	wantLeveledOutput := display.LogsTable(appLogs)
 
 	// N.B. This comparison is undeterminstic when the test data map contains
 	//      more than one key. Maps in golang are not guaranteed ordered so the result
@@ -198,7 +198,7 @@ func TestApplicationLogsExecutionWithPath(t *testing.T) {
 	}
 
 	gotLeveledOutput := logger.LeveledOutput()
-	wantLeveledOutput := display.AppLogsTable(appLogs)
+	wantLeveledOutput := display.LogsTable(appLogs)
 
 	if !strings.Contains(gotLeveledOutput, wantLeveledOutput) {
 		t.Fatalf(cmp.Diff(wantLeveledOutput, gotLeveledOutput))

--- a/cmd/meroxa/root/flink/flink.go
+++ b/cmd/meroxa/root/flink/flink.go
@@ -52,6 +52,7 @@ func (*Job) SubCommands() []*cobra.Command {
 	return []*cobra.Command{
 		builder.BuildCobraCommand(&Deploy{}),
 		builder.BuildCobraCommand(&Describe{}),
+		builder.BuildCobraCommand(&Logs{}),
 		builder.BuildCobraCommand(&Remove{}),
 		builder.BuildCobraCommand(&List{}),
 	}

--- a/cmd/meroxa/root/flink/logs.go
+++ b/cmd/meroxa/root/flink/logs.go
@@ -1,0 +1,98 @@
+/*
+Copyright © 2022 Meroxa Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flink
+
+import (
+	"context"
+	"errors"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils/display"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+var (
+	_ builder.CommandWithAliases = (*Logs)(nil)
+	_ builder.CommandWithDocs    = (*Logs)(nil)
+	_ builder.CommandWithArgs    = (*Logs)(nil)
+	_ builder.CommandWithClient  = (*Logs)(nil)
+	_ builder.CommandWithLogger  = (*Logs)(nil)
+	_ builder.CommandWithExecute = (*Logs)(nil)
+)
+
+type Logs struct {
+	client flinkLogsClient
+	logger log.Logger
+
+	args struct {
+		NameOrUUID string
+	}
+}
+
+type flinkLogsClient interface {
+	GetFlinkLogsV2(ctx context.Context, nameOrUUID string) (*meroxa.Logs, error)
+}
+
+func (*Logs) Aliases() []string {
+	return []string{"log"}
+}
+
+func (l *Logs) Usage() string {
+	return `logs [NameOrUUID] [--path pwd]`
+}
+
+func (l *Logs) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "View relevant logs to the state of the given Flink Job",
+		Example: `meroxa jobs logs my-flink-job-name
+meroxa jobs logs my-flink-job-uuid`,
+	}
+}
+
+func (l *Logs) Execute(ctx context.Context) error {
+	nameOrUUID := l.args.NameOrUUID
+
+	appLogs, getErr := l.client.GetFlinkLogsV2(ctx, nameOrUUID)
+	if getErr != nil {
+		return getErr
+	}
+
+	output := display.LogsTable(appLogs)
+
+	l.logger.Info(ctx, output)
+	l.logger.JSON(ctx, appLogs)
+
+	return nil
+}
+
+func (l *Logs) Client(client meroxa.Client) {
+	l.client = client
+}
+
+func (l *Logs) Logger(logger log.Logger) {
+	l.logger = logger
+}
+
+func (l *Logs) ParseArgs(args []string) error {
+	if len(args) < 1 {
+		return errors.New("requires Flink Job name or UUID")
+	}
+
+	l.args.NameOrUUID = args[0]
+	return nil
+}

--- a/cmd/meroxa/root/flink/logs_test.go
+++ b/cmd/meroxa/root/flink/logs_test.go
@@ -1,0 +1,104 @@
+package flink
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meroxa/cli/utils"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils/display"
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+	"github.com/meroxa/meroxa-go/pkg/mock"
+)
+
+func TestLogsFlinkJobArgs(t *testing.T) {
+	tests := []struct {
+		args []string
+		err  error
+		name string
+	}{
+		{args: nil, err: errors.New("requires Flink Job name or UUID"), name: ""},
+		{args: []string{"job-name"}, err: nil, name: "job-name"},
+	}
+
+	for _, tt := range tests {
+		l := &Logs{}
+		err := l.ParseArgs(tt.args)
+
+		if err != nil && tt.err.Error() != err.Error() {
+			t.Fatalf("expected \"%s\" got \"%s\"", tt.err, err)
+		}
+
+		if tt.name != l.args.NameOrUUID {
+			t.Fatalf("expected \"%s\" got \"%s\"", tt.name, l.args.NameOrUUID)
+		}
+	}
+}
+
+func TestFlinkLogsExecution(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockClient(ctrl)
+	logger := log.NewTestLogger()
+
+	fj := utils.GenerateFlinkJob()
+
+	flinkLogs := &meroxa.Logs{
+		Data: []meroxa.LogData{
+			{
+				Timestamp: time.Now().UTC(),
+				Log:       "log just logging",
+				Source:    "connector",
+			},
+			{
+				Timestamp: time.Now().UTC(),
+				Log:       "another log",
+				Source:    "flink-job",
+			},
+		},
+		Metadata: meroxa.Metadata{
+			End:   time.Now().UTC(),
+			Start: time.Now().UTC().Add(-12 * time.Hour),
+			Limit: 10,
+		},
+	}
+
+	client.EXPECT().GetFlinkLogsV2(ctx, fj.Name).Return(flinkLogs, nil)
+
+	l := &Logs{
+		client: client,
+		logger: logger,
+	}
+	l.args.NameOrUUID = fj.Name
+
+	err := l.Execute(ctx)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	gotLeveledOutput := logger.LeveledOutput()
+	wantLeveledOutput := display.LogsTable(flinkLogs)
+
+	if !strings.Contains(gotLeveledOutput, wantLeveledOutput) {
+		t.Fatalf(cmp.Diff(wantLeveledOutput, gotLeveledOutput))
+	}
+
+	gotJSONOutput := logger.JSONOutput()
+	var gotAppLogs meroxa.Logs
+	err = json.Unmarshal([]byte(gotJSONOutput), &gotAppLogs)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	if !reflect.DeepEqual(gotAppLogs, *flinkLogs) {
+		t.Fatalf(cmp.Diff(*flinkLogs, gotAppLogs))
+	}
+}

--- a/etc/man/man1/meroxa-account-list.1
+++ b/etc/man/man1/meroxa-account-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-account-set.1
+++ b/etc/man/man1/meroxa-account-set.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-account.1
+++ b/etc/man/man1/meroxa-account.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-api.1
+++ b/etc/man/man1/meroxa-api.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-deploy.1
+++ b/etc/man/man1/meroxa-apps-deploy.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-describe.1
+++ b/etc/man/man1/meroxa-apps-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-init.1
+++ b/etc/man/man1/meroxa-apps-init.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-list.1
+++ b/etc/man/man1/meroxa-apps-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-logs.1
+++ b/etc/man/man1/meroxa-apps-logs.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-open.1
+++ b/etc/man/man1/meroxa-apps-open.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-remove.1
+++ b/etc/man/man1/meroxa-apps-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-run.1
+++ b/etc/man/man1/meroxa-apps-run.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps-upgrade.1
+++ b/etc/man/man1/meroxa-apps-upgrade.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-apps.1
+++ b/etc/man/man1/meroxa-apps.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-login.1
+++ b/etc/man/man1/meroxa-auth-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-logout.1
+++ b/etc/man/man1/meroxa-auth-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth-whoami.1
+++ b/etc/man/man1/meroxa-auth-whoami.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-auth.1
+++ b/etc/man/man1/meroxa-auth.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-billing.1
+++ b/etc/man/man1/meroxa-billing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-builds-describe.1
+++ b/etc/man/man1/meroxa-builds-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-builds-logs.1
+++ b/etc/man/man1/meroxa-builds-logs.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-builds.1
+++ b/etc/man/man1/meroxa-builds.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-completion.1
+++ b/etc/man/man1/meroxa-completion.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-config-describe.1
+++ b/etc/man/man1/meroxa-config-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-config-set.1
+++ b/etc/man/man1/meroxa-config-set.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-config.1
+++ b/etc/man/man1/meroxa-config.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-create.1
+++ b/etc/man/man1/meroxa-environments-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-describe.1
+++ b/etc/man/man1/meroxa-environments-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-list.1
+++ b/etc/man/man1/meroxa-environments-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-remove.1
+++ b/etc/man/man1/meroxa-environments-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-repair.1
+++ b/etc/man/man1/meroxa-environments-repair.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments-update.1
+++ b/etc/man/man1/meroxa-environments-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-environments.1
+++ b/etc/man/man1/meroxa-environments.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-login.1
+++ b/etc/man/man1/meroxa-login.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-logout.1
+++ b/etc/man/man1/meroxa-logout.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-open-billing.1
+++ b/etc/man/man1/meroxa-open-billing.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-open.1
+++ b/etc/man/man1/meroxa-open.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-create.1
+++ b/etc/man/man1/meroxa-resources-create.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-describe.1
+++ b/etc/man/man1/meroxa-resources-describe.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-list.1
+++ b/etc/man/man1/meroxa-resources-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-remove.1
+++ b/etc/man/man1/meroxa-resources-remove.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-rotate-tunnel-key.1
+++ b/etc/man/man1/meroxa-resources-rotate-tunnel-key.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-update.1
+++ b/etc/man/man1/meroxa-resources-update.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources-validate.1
+++ b/etc/man/man1/meroxa-resources-validate.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-resources.1
+++ b/etc/man/man1/meroxa-resources.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-transforms-list.1
+++ b/etc/man/man1/meroxa-transforms-list.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-transforms.1
+++ b/etc/man/man1/meroxa-transforms.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-version.1
+++ b/etc/man/man1/meroxa-version.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa-whoami.1
+++ b/etc/man/man1/meroxa-whoami.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/etc/man/man1/meroxa.1
+++ b/etc/man/man1/meroxa.1
@@ -1,5 +1,5 @@
 .nh
-.TH "Meroxa" "1" "May 2023" "Meroxa CLI " "Meroxa Manual"
+.TH "Meroxa" "1" "Aug 2023" "Meroxa CLI " "Meroxa Manual"
 
 .SH NAME
 .PP

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
-	github.com/meroxa/meroxa-go v0.0.0-20230818143040-4b0824efc9e7
+	github.com/meroxa/meroxa-go v0.0.0-20230825083516-b71959984f10
 	github.com/nirasan/go-oauth-pkce-code-verifier v0.0.0-20170819232839-0fbfe93532da
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/rivo/uniseg v0.2.0 // indirect
@@ -71,5 +71,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.mod
+++ b/go.mod
@@ -71,3 +71,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/meroxa/meroxa-go => ../meroxa-go

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,6 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
-github.com/meroxa/meroxa-go v0.0.0-20230818143040-4b0824efc9e7 h1:0/3guJe/N7lQAiVMAIjzf/H4s9c3VcfCa3zqQThMf2Q=
-github.com/meroxa/meroxa-go v0.0.0-20230818143040-4b0824efc9e7/go.mod h1:aGLMvOqFX9O+vgy5JkBFH1/OzKWjYXVCDg21hIE3WtE=
 github.com/meroxa/turbine-core v0.0.0-20230815153536-e0c914b74ea1 h1:4tx5X9TVepTLVYP2ZOokKwkCSBldtGZh69kArXZaI9c=
 github.com/meroxa/turbine-core v0.0.0-20230815153536-e0c914b74ea1/go.mod h1:03beJfCWdChsKHzbhiDlOcYKyAKkrtoC3y8ualUFOrI=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/go.sum
+++ b/go.sum
@@ -185,6 +185,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/meroxa/meroxa-go v0.0.0-20230825083516-b71959984f10 h1:SqmiKJXuwU4eTPYYlKXMICliVSxKlciBK3Ljbz3m9j0=
+github.com/meroxa/meroxa-go v0.0.0-20230825083516-b71959984f10/go.mod h1:aGLMvOqFX9O+vgy5JkBFH1/OzKWjYXVCDg21hIE3WtE=
 github.com/meroxa/turbine-core v0.0.0-20230815153536-e0c914b74ea1 h1:4tx5X9TVepTLVYP2ZOokKwkCSBldtGZh69kArXZaI9c=
 github.com/meroxa/turbine-core v0.0.0-20230815153536-e0c914b74ea1/go.mod h1:03beJfCWdChsKHzbhiDlOcYKyAKkrtoC3y8ualUFOrI=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=

--- a/utils/display/apps.go
+++ b/utils/display/apps.go
@@ -3,7 +3,6 @@ package display
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/alexeyco/simpletable"
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
@@ -172,17 +171,6 @@ func appFunctionsTable(functions []meroxa.EntityDetails) string {
 		subTable += fmt.Sprintf("\t    %s\n", f.Name)
 		subTable += fmt.Sprintf("\t\t%5s:   %s\n", "UUID", f.UUID)
 		subTable += fmt.Sprintf("\t\t%5s:   %s\n", "State", f.Status)
-	}
-
-	return subTable
-}
-
-func AppLogsTable(appLogs *meroxa.Logs) string {
-	var subTable string
-
-	for i := len(appLogs.Data) - 1; i >= 0; i-- {
-		l := appLogs.Data[i]
-		subTable += fmt.Sprintf("[%s]\t%s\t%q\n", l.Timestamp.Format(time.RFC3339), l.Source, l.Log)
 	}
 
 	return subTable

--- a/utils/display/apps_test.go
+++ b/utils/display/apps_test.go
@@ -1,50 +1,13 @@
 package display
 
 import (
-	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/meroxa/cli/utils"
 
 	"github.com/meroxa/meroxa-go/pkg/meroxa"
 )
-
-func TestAppLogsTable(t *testing.T) {
-	res := "res"
-	fun := "fun"
-	log := "custom log"
-	now := time.Now().UTC()
-	logs := meroxa.Logs{
-		Data: []meroxa.LogData{
-			{
-				Timestamp: now,
-				Log:       log,
-				Source:    fun,
-			},
-			{
-				Timestamp: now,
-				Log:       log,
-				Source:    res,
-			},
-		},
-		Metadata: meroxa.Metadata{
-			End:   now,
-			Start: now.Add(-12 * time.Hour),
-			Limit: 10,
-		},
-	}
-
-	out := AppLogsTable(&logs)
-
-	if want := fmt.Sprintf("[%s]\t%s\t%q", now.Format(time.RFC3339), res, log); !strings.Contains(out, want) {
-		t.Errorf("expected %q to be shown with logs, %s", want, out)
-	}
-	if want := fmt.Sprintf("[%s]\t%s\t%q", now.Format(time.RFC3339), fun, log); !strings.Contains(out, want) {
-		t.Errorf("expected %q to be shown with logs, %s", want, out)
-	}
-}
 
 func TestAppDescribeTable(t *testing.T) {
 	testCases := []struct {

--- a/utils/display/logs.go
+++ b/utils/display/logs.go
@@ -1,0 +1,19 @@
+package display
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+func LogsTable(ll *meroxa.Logs) string {
+	var subTable string
+
+	for i := len(ll.Data) - 1; i >= 0; i-- {
+		l := ll.Data[i]
+		subTable += fmt.Sprintf("[%s]\t%s\t%q\n", l.Timestamp.Format(time.RFC3339), l.Source, l.Log)
+	}
+
+	return subTable
+}

--- a/utils/display/logs_test.go
+++ b/utils/display/logs_test.go
@@ -1,0 +1,45 @@
+package display
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meroxa/meroxa-go/pkg/meroxa"
+)
+
+func TestLogsTable(t *testing.T) {
+	res := "res"
+	fun := "fun"
+	log := "custom log"
+	now := time.Now().UTC()
+	logs := meroxa.Logs{
+		Data: []meroxa.LogData{
+			{
+				Timestamp: now,
+				Log:       log,
+				Source:    fun,
+			},
+			{
+				Timestamp: now,
+				Log:       log,
+				Source:    res,
+			},
+		},
+		Metadata: meroxa.Metadata{
+			End:   now,
+			Start: now.Add(-12 * time.Hour),
+			Limit: 10,
+		},
+	}
+
+	out := LogsTable(&logs)
+
+	if want := fmt.Sprintf("[%s]\t%s\t%q", now.Format(time.RFC3339), res, log); !strings.Contains(out, want) {
+		t.Errorf("expected %q to be shown with logs, %s", want, out)
+	}
+	if want := fmt.Sprintf("[%s]\t%s\t%q", now.Format(time.RFC3339), fun, log); !strings.Contains(out, want) {
+		t.Errorf("expected %q to be shown with logs, %s", want, out)
+	}
+}

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/flink_job.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/flink_job.go
@@ -8,7 +8,8 @@ import (
 	"time"
 )
 
-const flinkJobsBasePath = "/v1/flink-jobs"
+const flinkJobsBasePathV1 = "/v1/flink-jobs"
+const flinkJobsBasePathV2 = "/v2/flink-jobs"
 
 type FlinkJobDesiredState string
 type FlinkJobLifecycleState string
@@ -70,7 +71,7 @@ type CreateFlinkJobInput struct {
 }
 
 func (c *client) GetFlinkJob(ctx context.Context, nameOrUUID string) (*FlinkJob, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", flinkJobsBasePath, nameOrUUID), nil, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, fmt.Sprintf("%s/%s", flinkJobsBasePathV1, nameOrUUID), nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +89,7 @@ func (c *client) GetFlinkJob(ctx context.Context, nameOrUUID string) (*FlinkJob,
 }
 
 func (c *client) ListFlinkJobs(ctx context.Context) ([]*FlinkJob, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodGet, flinkJobsBasePath, nil, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, flinkJobsBasePathV1, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +107,7 @@ func (c *client) ListFlinkJobs(ctx context.Context) ([]*FlinkJob, error) {
 }
 
 func (c *client) CreateFlinkJob(ctx context.Context, input *CreateFlinkJobInput) (*FlinkJob, error) {
-	resp, err := c.MakeRequest(ctx, http.MethodPost, flinkJobsBasePath, input, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodPost, flinkJobsBasePathV1, input, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -124,10 +125,31 @@ func (c *client) CreateFlinkJob(ctx context.Context, input *CreateFlinkJobInput)
 }
 
 func (c *client) DeleteFlinkJob(ctx context.Context, nameOrUUID string) error {
-	resp, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", flinkJobsBasePath, nameOrUUID), nil, nil, nil)
+	resp, err := c.MakeRequest(ctx, http.MethodDelete, fmt.Sprintf("%s/%s", flinkJobsBasePathV1, nameOrUUID), nil, nil, nil)
 	if err != nil {
 		return err
 	}
 
 	return handleAPIErrors(resp)
+}
+
+func (c *client) GetFlinkLogsV2(ctx context.Context, nameOrUUID string) (*Logs, error) {
+	path := fmt.Sprintf("%s/%s/logs", flinkJobsBasePathV2, nameOrUUID)
+	resp, err := c.MakeRequest(ctx, http.MethodGet, path, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = handleAPIErrors(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	var l *Logs
+	err = json.NewDecoder(resp.Body).Decode(&l)
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
 }

--- a/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/meroxa/meroxa.go
@@ -87,6 +87,7 @@ type Client interface {
 	DeleteFlinkJob(ctx context.Context, nameOrUUID string) error
 	GetFlinkJob(ctx context.Context, nameOrUUID string) (*FlinkJob, error)
 	ListFlinkJobs(ctx context.Context) ([]*FlinkJob, error)
+	GetFlinkLogsV2(ctx context.Context, nameOrUUID string) (*Logs, error)
 
 	CreateFunction(ctx context.Context, input *CreateFunctionInput) (*Function, error)
 	GetFunction(ctx context.Context, nameOrUUID string) (*Function, error)

--- a/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
+++ b/vendor/github.com/meroxa/meroxa-go/pkg/mock/mock_client.go
@@ -552,6 +552,21 @@ func (mr *MockClientMockRecorder) GetFlinkJob(ctx, nameOrUUID interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlinkJob", reflect.TypeOf((*MockClient)(nil).GetFlinkJob), ctx, nameOrUUID)
 }
 
+// GetFlinkLogsV2 mocks base method.
+func (m *MockClient) GetFlinkLogsV2(ctx context.Context, nameOrUUID string) (*meroxa.Logs, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFlinkLogsV2", ctx, nameOrUUID)
+	ret0, _ := ret[0].(*meroxa.Logs)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFlinkLogsV2 indicates an expected call of GetFlinkLogsV2.
+func (mr *MockClientMockRecorder) GetFlinkLogsV2(ctx, nameOrUUID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFlinkLogsV2", reflect.TypeOf((*MockClient)(nil).GetFlinkLogsV2), ctx, nameOrUUID)
+}
+
 // GetFunction mocks base method.
 func (m *MockClient) GetFunction(ctx context.Context, nameOrUUID string) (*meroxa.Function, error) {
 	m.ctrl.T.Helper()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,7 +107,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20230818143040-4b0824efc9e7
+# github.com/meroxa/meroxa-go v0.0.0-20230818143040-4b0824efc9e7 => ../meroxa-go
 ## explicit; go 1.20
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
@@ -328,3 +328,4 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/meroxa/meroxa-go => ../meroxa-go

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -107,7 +107,7 @@ github.com/mattn/go-runewidth
 # github.com/mattn/go-shellwords v1.0.12
 ## explicit; go 1.13
 github.com/mattn/go-shellwords
-# github.com/meroxa/meroxa-go v0.0.0-20230818143040-4b0824efc9e7 => ../meroxa-go
+# github.com/meroxa/meroxa-go v0.0.0-20230825083516-b71959984f10
 ## explicit; go 1.20
 github.com/meroxa/meroxa-go/pkg/meroxa
 github.com/meroxa/meroxa-go/pkg/mock
@@ -328,4 +328,3 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# github.com/meroxa/meroxa-go => ../meroxa-go


### PR DESCRIPTION
## Description of change

Fixes https://github.com/meroxa/cli/issues/794

⚠️ Depends on https://github.com/meroxa/platform-api/pull/2012 and https://github.com/meroxa/meroxa-go/pull/190

## Type of change

- [x]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

**Before**

```
$ meroxa jobs logs my-flink-job
 
# Shows help (not existing command)
```


**After**

⚠️ Requires `flink` feature flag.

```
$ meroxa jobs logs my-flink-job
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"ConnectorConfig values: \n\tconfig.action.reload = restart\n\tconnector.class = io.aiven.connect.jdbc.JdbcSourceConnector\n\terrors.log.enable = false\n\terrors.log.include.messages = false\n\terrors.retry.delay.max.ms = 60000\n\terrors.retry.timeout = 0\n\terrors.tolerance = none\n\theader.converter = null\n\tkey.converter = null\n\tname = connector-56763\n\ttasks.max = 1\n\ttransforms = []\n\tvalue.converter = null\n"
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"EnrichedConnectorConfig values: \n\tconfig.action.reload = restart\n\tconnector.class = io.aiven.connect.jdbc.JdbcSourceConnector\n\terrors.log.enable = false\n\terrors.log.include.messages = false\n\terrors.retry.delay.max.ms = 60000\n\terrors.retry.timeout = 0\n\terrors.tolerance = none\n\theader.converter = null\n\tkey.converter = null\n\tname = connector-56763\n\ttasks.max = 1\n\ttransforms = []\n\tvalue.converter = null\n"
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Creating connector connector-56763 of type io.aiven.connect.jdbc.JdbcSourceConnector"
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Instantiated connector connector-56763 with version 6.7.0_MEROXA of type class io.aiven.connect.jdbc.JdbcSourceConnector"
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Starting JDBC Source Connector"
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"JdbcSourceConnectorConfig values: \n\tbatch.max.rows = 100\n\tcatalog.pattern = null\n\tconnection.attempts = 3\n\tconnection.backoff.ms = 10000\n\tconnection.password = [hidden]\n\tconnection.url = jdbc:postgresql://diffuser-production-01h8ecnhrsxgavc6gbkzbqawj9.cg05juyjuelr.us-east-1.rds.amazonaws.com:5432/diffuser?ApplicationName=Meroxa+Data+Platform&OpenSourceSubProtocolOverride=true&defaultRowFetchSize=1000\n\tconnection.user = meroxa\n\tdb.timezone = UTC\n\tdialect.name = \n\tincrementing.column.name = id\n\tincrementing.initial = -1\n\tmode = incrementing\n\tnumeric.mapping = null\n\tnumeric.precision.mapping = false\n\tpoll.interval.ms = 1000\n\tquery = \n\tschema.pattern = null\n\tsql.quote.identifiers = true\n\ttable.blacklist = []\n\ttable.poll.interval.ms = 60000\n\ttable.types = [TABLE]\n\ttable.whitelist = [user_activity]\n\ttimestamp.column.name = []\n\ttimestamp.delay.interval.ms = 1000\n\ttimestamp.initial.ms = 0\n\ttopic.prefix = resource-62001-557333-\n\tvalidate.non.null = true\n"
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Attempting to open connection #1 to PostgreSql"
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Starting thread to monitor tables."
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Finished creating connector connector-56763"
[2023-08-25T08:27:13Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"After filtering the tables are: \"public\".\"user_activity\""
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Creating task connector-56763-0"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"ConnectorConfig values: \n\tconfig.action.reload = restart\n\tconnector.class = io.aiven.connect.jdbc.JdbcSourceConnector\n\terrors.log.enable = false\n\terrors.log.include.messages = false\n\terrors.retry.delay.max.ms = 60000\n\terrors.retry.timeout = 0\n\terrors.tolerance = none\n\theader.converter = null\n\tkey.converter = null\n\tname = connector-56763\n\ttasks.max = 1\n\ttransforms = []\n\tvalue.converter = null\n"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"EnrichedConnectorConfig values: \n\tconfig.action.reload = restart\n\tconnector.class = io.aiven.connect.jdbc.JdbcSourceConnector\n\terrors.log.enable = false\n\terrors.log.include.messages = false\n\terrors.retry.delay.max.ms = 60000\n\terrors.retry.timeout = 0\n\terrors.tolerance = none\n\theader.converter = null\n\tkey.converter = null\n\tname = connector-56763\n\ttasks.max = 1\n\ttransforms = []\n\tvalue.converter = null\n"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"TaskConfig values: \n\ttask.class = class io.aiven.connect.jdbc.source.JdbcSourceTask\n"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Instantiated task connector-56763-0 with version 6.7.0_MEROXA of type io.aiven.connect.jdbc.source.JdbcSourceTask"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"JsonConverterConfig values: \n\tconverter.type = key\n\tdecimal.format = BASE64\n\tschemas.cache.size = 1000\n\tschemas.enable = true\n"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Set up the key converter class org.apache.kafka.connect.json.JsonConverter for task connector-56763-0 using the worker config"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"JsonConverterConfig values: \n\tconverter.type = value\n\tdecimal.format = BASE64\n\tschemas.cache.size = 1000\n\tschemas.enable = true\n"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Set up the value converter class org.apache.kafka.connect.json.JsonConverter for task connector-56763-0 using the worker config"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Set up the header converter class org.apache.kafka.connect.storage.SimpleHeaderConverter for task connector-56763-0 using the worker config"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Initializing: org.apache.kafka.connect.runtime.TransformationChain{}"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"ProducerConfig values: \n\tacks = -1\n\tbatch.size = 16384\n\tbootstrap.servers = [b-3.meroxa-msk-d419bd4a-2.8d4w2q.c10.kafka.us-east-1.amazonaws.com:9094, b-4.meroxa-msk-d419bd4a-2.8d4w2q.c10.kafka.us-east-1.amazonaws.com:9094, b-1.meroxa-msk-d419bd4a-2.8d4w2q.c10.kafka.us-east-1.amazonaws.com:9094]\n\tbuffer.memory = 33554432\n\tclient.dns.lookup = default\n\tclient.id = connector-producer-connector-56763-0\n\tcompression.type = none\n\tconnections.max.idle.ms = 540000\n\tdelivery.timeout.ms = 2147483647\n\tenable.idempotence = false\n\tinterceptor.classes = []\n\tkey.serializer = class org.apache.kafka.common.serialization.ByteArraySerializer\n\tlinger.ms = 0\n\tmax.block.ms = 9223372036854775807\n\tmax.in.flight.requests.per.connection = 1\n\tmax.request.size = 1048576\n\tmetadata.max.age.ms = 300000\n\tmetadata.max.idle.ms = 300000\n\tmetric.reporters = []\n\tmetrics.num.samples = 2\n\tmetrics.recording.level = INFO\n\tmetrics.sample.window.ms = 30000\n\tpartitioner.class = class org.apache.kafka.clients.producer.internals.DefaultPartitioner\n\treceive.buffer.bytes = 32768\n\treconnect.backoff.max.ms = 1000\n\treconnect.backoff.ms = 50\n\trequest.timeout.ms = 2147483647\n\tretries = 2147483647\n\tretry.backoff.ms = 100\n\tsasl.client.callback.handler.class = null\n\tsasl.jaas.config = null\n\tsasl.kerberos.kinit.cmd = /usr/bin/kinit\n\tsasl.kerberos.min.time.before.relogin = 60000\n\tsasl.kerberos.service.name = null\n\tsasl.kerberos.ticket.renew.jitter = 0.05\n\tsasl.kerberos.ticket.renew.window.factor = 0.8\n\tsasl.login.callback.handler.class = null\n\tsasl.login.class = null\n\tsasl.login.refresh.buffer.seconds = 300\n\tsasl.login.refresh.min.period.seconds = 60\n\tsasl.login.refresh.window.factor = 0.8\n\tsasl.login.refresh.window.jitter = 0.05\n\tsasl.mechanism = GSSAPI\n\tsecurity.protocol = SSL\n\tsecurity.providers = null\n\tsend.buffer.bytes = 131072\n\tssl.cipher.suites = null\n\tssl.enabled.protocols = [TLSv1.2]\n\tssl.endpoint.identification.algorithm = https\n\tssl.key.password = null\n\tssl.keymanager.algorithm = SunX509\n\tssl.keystore.location = null\n\tssl.keystore.password = null\n\tssl.keystore.type = JKS\n\tssl.protocol = TLSv1.2\n\tssl.provider = null\n\tssl.secure.random.implementation = null\n\tssl.trustmanager.algorithm = PKIX\n\tssl.truststore.location = null\n\tssl.truststore.password = null\n\tssl.truststore.type = JKS\n\ttransaction.timeout.ms = 60000\n\ttransactional.id = null\n\tvalue.serializer = class org.apache.kafka.common.serialization.ByteArraySerializer\n"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Kafka version: 2.5.0"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Kafka commitId: 66563e712b0b9f84"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Kafka startTimeMs: 1692952036634"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Starting JDBC source task"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"JdbcSourceTaskConfig values: \n\tbatch.max.rows = 100\n\tcatalog.pattern = null\n\tconnection.attempts = 3\n\tconnection.backoff.ms = 10000\n\tconnection.password = [hidden]\n\tconnection.url = jdbc:postgresql://diffuser-production-01h8ecnhrsxgavc6gbkzbqawj9.cg05juyjuelr.us-east-1.rds.amazonaws.com:5432/diffuser?ApplicationName=Meroxa+Data+Platform&OpenSourceSubProtocolOverride=true&defaultRowFetchSize=1000\n\tconnection.user = meroxa\n\tdb.timezone = UTC\n\tdialect.name = \n\tincrementing.column.name = id\n\tincrementing.initial = -1\n\tmode = incrementing\n\tnumeric.mapping = null\n\tnumeric.precision.mapping = false\n\tpoll.interval.ms = 1000\n\tquery = \n\tschema.pattern = null\n\tsql.quote.identifiers = true\n\ttable.blacklist = []\n\ttable.poll.interval.ms = 60000\n\ttable.types = [TABLE]\n\ttable.whitelist = [user_activity]\n\ttables = [\"public\".\"user_activity\"]\n\ttimestamp.column.name = []\n\ttimestamp.delay.interval.ms = 1000\n\ttimestamp.initial.ms = 0\n\ttopic.prefix = resource-62001-557333-\n\tvalidate.non.null = true\n"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Using JDBC dialect PostgreSql"
[2023-08-25T08:27:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"[Producer clientId=connector-producer-connector-56763-0] Cluster ID: -AYSRNUoRm6Jgj_Fn5DqWA"
[2023-08-25T08:27:17Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Attempting to open connection #1 to PostgreSql"
[2023-08-25T08:27:17Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"Started JDBC source task"
[2023-08-25T08:27:17Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} Source task finished initialization and start"
[2023-08-25T08:27:17Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"[Producer clientId=connector-producer-connector-56763-0] Error while fetching metadata with correlation id 3 : {resource-62001-557333-user_activity=LEADER_NOT_AVAILABLE}"
[2023-08-25T08:28:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} Committing offsets"
[2023-08-25T08:28:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} flushing 0 outstanding messages for offset commit"
[2023-08-25T08:28:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} Finished commitOffsets successfully in 53 ms"
[2023-08-25T08:29:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} Committing offsets"
[2023-08-25T08:29:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} flushing 0 outstanding messages for offset commit"
[2023-08-25T08:30:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} Committing offsets"
[2023-08-25T08:30:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} flushing 0 outstanding messages for offset commit"
[2023-08-25T08:31:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} Committing offsets"
[2023-08-25T08:31:16Z]	source-5adc17d5-8e50-4321-912f-7a5adfb69d65-5943	"WorkerSourceTask{id=connector-56763-0} flushing 0 outstanding messages for offset commit"
```
