### PR TITLE
Add tenant subdomain to env

### DIFF
--- a/cmd/meroxa/global/client.go
+++ b/cmd/meroxa/global/client.go
@@ -83,6 +83,7 @@ func GetCLIUserInfo() (actor, actorUUID string, err error) {
 		// write user information in config file
 		Config.Set(ActorEnv, actor)
 		Config.Set(ActorUUIDEnv, actorUUID)
+		Config.Set(TenantSubDomainEnv, GetTenantSubDomain())
 
 		// write existing feature flags enabled
 		Config.Set(UserFeatureFlagsEnv, strings.Join(user.Features, " "))
@@ -172,6 +173,7 @@ func NewClient() (meroxa.Client, error) {
 		}
 	}
 	options = append(options, meroxa.WithAccountUUID(Config.GetString(UserAccountUUID)))
+	options = append(options, meroxa.WithHeader(TenantSubDomainEnv, GetTenantSubDomain()))
 	options = append(options, meroxa.WithHeader("Meroxa-CLI-Version", Version))
 	return meroxa.New(options...)
 }

--- a/cmd/meroxa/global/config.go
+++ b/cmd/meroxa/global/config.go
@@ -53,6 +53,10 @@ func GetLocalTurbineJSSetting() string {
 	return getEnvVal([]string{"MEROXA_USE_LOCAL_TURBINE_JS"}, "false")
 }
 
+func GetTenantSubDomain() string {
+	return getEnvVal([]string{"MDPX_TENANT_SUBDOMAIN"}, os.Getenv("MDPX_TENANT_SUBDOMAIN"))
+}
+
 func getMeroxaAuthCallbackPort() string {
 	return getEnvVal([]string{MeroxaAuthCallbackPort}, "21900")
 }

--- a/cmd/meroxa/global/global.go
+++ b/cmd/meroxa/global/global.go
@@ -42,6 +42,7 @@ const (
 	AccessTokenEnv               = "ACCESS_TOKEN"
 	ActorEnv                     = "ACTOR"
 	ActorUUIDEnv                 = "ACTOR_UUID"
+	TenantSubDomainEnv           = "TENANT_SUBDOMAIN"
 	CasedDebugEnv                = "CASED_DEBUG"
 	CasedPublishKeyEnv           = "CASED_PUBLISH_KEY"
 	LatestCLIVersionUpdatedAtEnv = "LATEST_CLI_VERSION_UPDATED_AT"

--- a/cmd/meroxa/root/auth/logout.go
+++ b/cmd/meroxa/root/auth/logout.go
@@ -61,6 +61,7 @@ func (l *Logout) Execute(ctx context.Context) error {
 	l.config.Set(global.ActorEnv, "")
 	l.config.Set(global.ActorUUIDEnv, "")
 	l.config.Set(global.UserFeatureFlagsEnv, "")
+	l.config.Set(global.TenantSubDomainEnv, "")
 
 	l.logger.Infof(ctx, "Successfully logged out.")
 	return nil

--- a/cmd/meroxa/root/auth/whoami.go
+++ b/cmd/meroxa/root/auth/whoami.go
@@ -81,6 +81,7 @@ func (w *WhoAmI) Execute(ctx context.Context) error {
 	// Updates config file with actor information.
 	w.config.Set(global.ActorEnv, user.Email)
 	w.config.Set(global.ActorUUIDEnv, user.UUID)
+	w.config.Set(global.TenantSubDomainEnv, global.GetTenantSubDomain())
 	w.config.Set(global.UserFeatureFlagsEnv, strings.Join(user.Features, " "))
 	w.config.Set(global.UserInfoUpdatedAtEnv, time.Now().UTC())
 


### PR DESCRIPTION
## Description of change

We are adding tenant subdomain to cli env, it will be populated by exporting MDPX_TENANT_SUBDOMAIN in local 

Fixes https://github.com/meroxa/mdpx/issues/562#issue-1945752192

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [ ]  Refactor
- [ ]  Documentation

## How was this tested?

- [ ]  Unit Tests
- [ ]  Tested in staging
- [ ]  Tested in minikube

## Demo

How tenant domain looks in 'meroxa config" 

<img width="1220" alt="image" src="https://github.com/meroxa/cli/assets/96070127/1e089cff-8217-490b-9486-89aa97444cdb">
