### PR TITLE
fix: unify access token

### DIFF
--- a/cmd/meroxa/global/basic_client.go
+++ b/cmd/meroxa/global/basic_client.go
@@ -198,7 +198,12 @@ func (r *client) newRequest(
 	if len(r.headers) > 0 {
 		req.Header = r.headers
 	}
-	req.Header.Add("Authorization", getAuthToken())
+
+	accessToken, _, err := GetUserToken()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", accessToken)
 	req.Header.Add("Content-Type", jsonContentType)
 	req.Header.Add("Accept", jsonContentType)
 	req.Header.Add("User-Agent", r.userAgent)

--- a/cmd/meroxa/global/config.go
+++ b/cmd/meroxa/global/config.go
@@ -98,10 +98,6 @@ func getEnvVal(keys []string, defaultVal string) string {
 	return defaultVal
 }
 
-func getAuthToken() string {
-	return Config.GetString("token")
-}
-
 func readConfig() (*viper.Viper, error) {
 	cfg := viper.New()
 


### PR DESCRIPTION
## Description of change

Fixes the difference between doing requests via `api` commands and others using the Basic client.

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [x]  Bug fix
- [ ]  Refactor
- [ ]  Documentation