### PR TITLE
Add secrets command to CLI 

### DIFF
--- a/cmd/meroxa/root/apps/apps.go
+++ b/cmd/meroxa/root/apps/apps.go
@@ -168,7 +168,7 @@ func addTurbineHeaders(c addHeader, lang ir.Lang, version string) {
 	c.AddHeader("Meroxa-CLI-App-Version", version)
 }
 
-func (a Applications) RetrieveApplicationID(ctx context.Context, client global.BasicClient, nameOrID, path string) (*Applications, error) {
+func RetrieveApplicationByNameOrID(ctx context.Context, client global.BasicClient, nameOrID, path string) (*Applications, error) {
 	var getPath string
 	apps := Applications{}
 	if path != "" {
@@ -209,5 +209,12 @@ func (a Applications) RetrieveApplicationID(ctx context.Context, client global.B
 	} else {
 		return nil, fmt.Errorf("supply either ID/Name argument or --path flag")
 	}
+
+	if apps.TotalItems == 0 {
+		return nil, fmt.Errorf("no applications found")
+	} else if apps.TotalItems > 1 {
+		return nil, fmt.Errorf("multiple applications found")
+	}
+
 	return &apps, nil
 }

--- a/cmd/meroxa/root/apps/deploy.go
+++ b/cmd/meroxa/root/apps/deploy.go
@@ -415,11 +415,20 @@ func (d *Deploy) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if _, err = d.client.CollectionRequest(ctx, "POST", collectionName, "", input, nil); err != nil {
+
+	response, err := d.client.CollectionRequest(ctx, "POST", collectionName, "", input, nil)
+	if err != nil {
 		return err
 	}
 
-	dashboardURL := fmt.Sprintf("%s/apps/%s/detail", global.GetMeroxaAPIURL(), input.ID)
+	apps := &Application{}
+	err = json.NewDecoder(response.Body).Decode(&apps)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	dashboardURL := fmt.Sprintf("%s/apps/%s/detail", global.GetMeroxaAPIURL(), apps.ID)
 	output := fmt.Sprintf("Application %q successfully deployed!\n\n  ✨ To view your application, visit %s",
 		d.appName, dashboardURL)
 

--- a/cmd/meroxa/root/apps/describe.go
+++ b/cmd/meroxa/root/apps/describe.go
@@ -96,7 +96,7 @@ func (d *Describe) Execute(ctx context.Context) error {
 	}
 	addTurbineHeaders(d.client, d.lang, turbineVersion)
 
-	apps, err = apps.RetrieveApplicationID(ctx, d.client, d.args.idOrName, d.flags.Path)
+	apps, err = RetrieveApplicationByNameOrID(ctx, d.client, d.args.idOrName, d.flags.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/meroxa/root/apps/describe.go
+++ b/cmd/meroxa/root/apps/describe.go
@@ -44,7 +44,7 @@ type Describe struct {
 	turbineCLI turbine.CLI
 	lang       ir.Lang
 	args       struct {
-		idOrName string
+		nameOrUUID string
 	}
 	flags struct {
 		Path string `long:"path" usage:"Path to the app directory (default is local directory)"`
@@ -52,7 +52,7 @@ type Describe struct {
 }
 
 func (d *Describe) Usage() string {
-	return "describe [IDorName] [--path pwd]"
+	return "describe [nameOrUUID] [--path pwd]"
 }
 
 func (d *Describe) Flags() []builder.Flag {
@@ -96,7 +96,7 @@ func (d *Describe) Execute(ctx context.Context) error {
 	}
 	addTurbineHeaders(d.client, d.lang, turbineVersion)
 
-	apps, err = RetrieveApplicationByNameOrID(ctx, d.client, d.args.idOrName, d.flags.Path)
+	apps, err = RetrieveApplicationByNameOrID(ctx, d.client, d.args.nameOrUUID, d.flags.Path)
 	if err != nil {
 		return err
 	}
@@ -121,7 +121,7 @@ func (d *Describe) Logger(logger log.Logger) {
 
 func (d *Describe) ParseArgs(args []string) error {
 	if len(args) > 0 {
-		d.args.idOrName = args[0]
+		d.args.nameOrUUID = args[0]
 	}
 
 	return nil

--- a/cmd/meroxa/root/apps/describe_test.go
+++ b/cmd/meroxa/root/apps/describe_test.go
@@ -126,8 +126,8 @@ func TestDescribeApplicationArgs(t *testing.T) {
 			t.Fatalf("expected \"%s\" got \"%s\"", tt.err, err)
 		}
 
-		if tt.name != ar.args.idOrName {
-			t.Fatalf("expected \"%s\" got \"%s\"", tt.name, ar.args.idOrName)
+		if tt.name != ar.args.nameOrUUID {
+			t.Fatalf("expected \"%s\" got \"%s\"", tt.name, ar.args.nameOrUUID)
 		}
 	}
 }
@@ -198,7 +198,7 @@ func TestDescribeApplicationExecution(t *testing.T) {
 		client:     client,
 		logger:     logger,
 		turbineCLI: mockTurbineCLI,
-		args:       struct{ idOrName string }{idOrName: a.Name},
+		args:       struct{ nameOrUUID string }{nameOrUUID: a.Name},
 		flags: struct {
 			Path string "long:\"path\" usage:\"Path to the app directory (default is local directory)\""
 		}{Path: filepath.Join(path, appName)},

--- a/cmd/meroxa/root/apps/list.go
+++ b/cmd/meroxa/root/apps/list.go
@@ -71,7 +71,7 @@ func (l *List) Execute(ctx context.Context) error {
 	l.logger.Info(ctx, display.PrintList(apps.Items, displayDetails))
 	l.logger.JSON(ctx, apps)
 
-	output := fmt.Sprintf("✨ To view your applications, visit %s/apps", global.GetMeroxaAPIURL())
+	output := fmt.Sprintf("\n ✨ To view your applications, visit %s/apps", global.GetMeroxaAPIURL())
 	l.logger.Info(ctx, output)
 	return nil
 }

--- a/cmd/meroxa/root/apps/open.go
+++ b/cmd/meroxa/root/apps/open.go
@@ -97,7 +97,7 @@ func (o *Open) Execute(ctx context.Context) error {
 	}
 
 	apps := &Applications{}
-	apps, err := apps.RetrieveApplicationID(ctx, o.client, o.args.NameOrUUID, o.flags.Path)
+	apps, err := RetrieveApplicationByNameOrID(ctx, o.client, o.args.NameOrUUID, o.flags.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/meroxa/root/apps/open.go
+++ b/cmd/meroxa/root/apps/open.go
@@ -96,7 +96,6 @@ func (o *Open) Execute(ctx context.Context) error {
 		o.Opener = &browserOpener{}
 	}
 
-	apps := &Applications{}
 	apps, err := RetrieveApplicationByNameOrID(ctx, o.client, o.args.NameOrUUID, o.flags.Path)
 	if err != nil {
 		return err

--- a/cmd/meroxa/root/apps/remove.go
+++ b/cmd/meroxa/root/apps/remove.go
@@ -38,7 +38,7 @@ type Remove struct {
 	turbineCLI turbine.CLI
 
 	args struct {
-		idOrName string
+		nameOrUUID string
 	}
 	flags struct {
 		Path  string `long:"path" usage:"Path to the app directory (default is local directory)"`
@@ -62,20 +62,20 @@ func (r *Remove) Docs() builder.Docs {
 or the Application specified by the given name or UUID identifier.`,
 		Example: `meroxa apps remove # assumes that the Application is in the current directory
 meroxa apps remove --path /my/app
-meroxa apps remove IDorName`,
+meroxa apps remove nameOrUUID`,
 	}
 }
 
 func (r *Remove) Execute(ctx context.Context) error {
 	if !r.flags.Force {
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Printf("To proceed, type %q or re-run this command with --force\n▸ ", r.args.idOrName)
+		fmt.Printf("To proceed, type %q or re-run this command with --force\n▸ ", r.args.nameOrUUID)
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			return err
 		}
 
-		if r.args.idOrName != strings.TrimRight(input, "\r\n") {
+		if r.args.nameOrUUID != strings.TrimRight(input, "\r\n") {
 			return errors.New("action aborted")
 		}
 	}
@@ -101,18 +101,18 @@ func (r *Remove) Execute(ctx context.Context) error {
 	}
 	addTurbineHeaders(r.client, r.lang, turbineVersion)
 
-	apps, err = RetrieveApplicationByNameOrID(ctx, r.client, r.args.idOrName, r.flags.Path)
+	apps, err = RetrieveApplicationByNameOrID(ctx, r.client, r.args.nameOrUUID, r.flags.Path)
 	if err != nil {
 		return err
 	}
 
-	r.logger.Infof(ctx, "Removing application %q...", r.args.idOrName)
+	r.logger.Infof(ctx, "Removing application %q...", r.args.nameOrUUID)
 	response, err := r.client.CollectionRequest(ctx, "DELETE", collectionName, apps.Items[0].ID, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	r.logger.Infof(ctx, "Application %q successfully removed", r.args.idOrName)
+	r.logger.Infof(ctx, "Application %q successfully removed", r.args.nameOrUUID)
 	r.logger.JSON(ctx, response)
 
 	return nil
@@ -128,7 +128,7 @@ func (r *Remove) BasicClient(client global.BasicClient) {
 
 func (r *Remove) ParseArgs(args []string) error {
 	if len(args) > 0 {
-		r.args.idOrName = args[0]
+		r.args.nameOrUUID = args[0]
 	}
 
 	return nil

--- a/cmd/meroxa/root/apps/remove.go
+++ b/cmd/meroxa/root/apps/remove.go
@@ -101,7 +101,7 @@ func (r *Remove) Execute(ctx context.Context) error {
 	}
 	addTurbineHeaders(r.client, r.lang, turbineVersion)
 
-	apps, err = apps.RetrieveApplicationID(ctx, r.client, r.args.idOrName, r.flags.Path)
+	apps, err = RetrieveApplicationByNameOrID(ctx, r.client, r.args.idOrName, r.flags.Path)
 	if err != nil {
 		return err
 	}

--- a/cmd/meroxa/root/apps/remove_test.go
+++ b/cmd/meroxa/root/apps/remove_test.go
@@ -39,8 +39,8 @@ func TestRemoveAppArgs(t *testing.T) {
 			t.Fatalf("expected \"%s\" got \"%s\"", tt.err, err)
 		}
 
-		if tt.name != cc.args.idOrName {
-			t.Fatalf("expected \"%s\" got \"%s\"", tt.name, cc.args.idOrName)
+		if tt.name != cc.args.nameOrUUID {
+			t.Fatalf("expected \"%s\" got \"%s\"", tt.name, cc.args.nameOrUUID)
 		}
 	}
 }

--- a/cmd/meroxa/root/root.go
+++ b/cmd/meroxa/root/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/meroxa/cli/cmd/meroxa/root/login"
 	"github.com/meroxa/cli/cmd/meroxa/root/logout"
 	"github.com/meroxa/cli/cmd/meroxa/root/open"
+	"github.com/meroxa/cli/cmd/meroxa/root/secrets"
 	"github.com/meroxa/cli/cmd/meroxa/root/version"
 	"github.com/meroxa/cli/cmd/meroxa/root/whoami"
 
@@ -81,6 +82,7 @@ meroxa resources list --types
 	cmd.AddCommand(builder.BuildCobraCommand(&open.Open{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&version.Version{}))
 	cmd.AddCommand(builder.BuildCobraCommand(&whoami.WhoAmI{}))
+	cmd.AddCommand(builder.BuildCobraCommand(&secrets.Secrets{}))
 
 	return cmd
 }

--- a/cmd/meroxa/root/secrets/create.go
+++ b/cmd/meroxa/root/secrets/create.go
@@ -94,7 +94,10 @@ func (d *Create) Execute(ctx context.Context) error {
 	secret := &Secrets{
 		Name: d.args.secretName,
 	}
-	json.Unmarshal([]byte(d.flags.Data), &secret.Data)
+	err := json.Unmarshal([]byte(d.flags.Data), &secret.Data)
+	if err != nil {
+		return err
+	}
 
 	d.logger.Infof(ctx, "Adding a secret %q...", d.args.secretName)
 	response, err := d.client.CollectionRequest(ctx, "POST", collectionName, "", secret, nil)

--- a/cmd/meroxa/root/secrets/create.go
+++ b/cmd/meroxa/root/secrets/create.go
@@ -1,0 +1,117 @@
+package secrets
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/meroxa/cli/log"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/global"
+	"github.com/meroxa/cli/config"
+)
+
+type Create struct {
+	flags struct {
+		Data string `long:"data" usage:"Secret's data, passed as a JSON string"`
+	}
+	args struct {
+		secretName string
+	}
+	client global.BasicClient
+	config config.Config
+	logger log.Logger
+}
+
+var (
+	_ builder.CommandWithBasicClient = (*Create)(nil)
+	_ builder.CommandWithConfig      = (*Create)(nil)
+	_ builder.CommandWithDocs        = (*Create)(nil)
+	_ builder.CommandWithExecute     = (*Create)(nil)
+	_ builder.CommandWithFlags       = (*Create)(nil)
+	_ builder.CommandWithLogger      = (*Create)(nil)
+	_ builder.CommandWithArgs        = (*Create)(nil)
+)
+
+func (*Create) Usage() string {
+	return "create NAME --data '{}'"
+}
+
+func (*Create) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Create a Turbine Secret",
+		Long: `This command will create a secret as promted by the user.'
+After successful creation, the secret can be used in a connector. 
+`,
+		Example: `meroxa secret create NAME
+		          meroxa secret create NAME --data '{}'
+		`,
+	}
+}
+
+func (d *Create) ParseArgs(args []string) error {
+	if len(args) > 0 {
+		d.args.secretName = args[0]
+	}
+	return nil
+}
+
+func (d *Create) Config(cfg config.Config) {
+	d.config = cfg
+}
+
+func (d *Create) BasicClient(client global.BasicClient) {
+	d.client = client
+}
+
+func (d *Create) Flags() []builder.Flag {
+	return builder.BuildFlags(&d.flags)
+}
+
+func (d *Create) Logger(logger log.Logger) {
+	d.logger = logger
+}
+
+func (d *Create) Execute(ctx context.Context) error {
+	if d.flags.Data == "" {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Printf("To proceed, enter the secret's data as a JSON string: ")
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if len(input) == 0 {
+			return errors.New("action aborted")
+		}
+		d.flags.Data = strings.TrimRight(input, "\r\n")
+	}
+
+	secret := &Secrets{
+		Name: d.args.secretName,
+	}
+	json.Unmarshal([]byte(d.flags.Data), &secret.Data)
+
+	d.logger.Infof(ctx, "Adding a secret %q...", d.args.secretName)
+	response, err := d.client.CollectionRequest(ctx, "POST", collectionName, "", secret, nil)
+	if err != nil {
+		return err
+	}
+
+	responseSecret := Secrets{}
+	err = json.NewDecoder(response.Body).Decode(&responseSecret)
+	if err != nil {
+		return err
+	}
+
+	d.logger.Infof(ctx, "Secret %q successfully added", responseSecret.Name)
+	d.logger.JSON(ctx, responseSecret)
+	dashboardURL := fmt.Sprintf("\n ✨ To view your secrets, visit %s/secrets/%s", global.GetMeroxaAPIURL(), responseSecret.ID)
+	d.logger.Info(ctx, dashboardURL)
+
+	return nil
+}

--- a/cmd/meroxa/root/secrets/create_test.go
+++ b/cmd/meroxa/root/secrets/create_test.go
@@ -1,0 +1,91 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	basicMock "github.com/meroxa/cli/cmd/meroxa/global/mock"
+	"github.com/meroxa/cli/log"
+)
+
+func TestCreateSecrets(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := basicMock.NewMockBasicClient(ctrl)
+	logger := log.NewTestLogger()
+	// mockTurbineCLI := turbineMock.NewMockCLI(ctrl)
+
+	create := &Create{
+		client: client,
+		logger: logger,
+		flags: struct {
+			Data string "long:\"data\" usage:\"Secret's data, passed as a JSON string\""
+		}{Data: `{"ok": "ok"}`},
+		args: struct {
+			secretName string
+		}{secretName: "test"},
+	}
+	body := `{
+		"collectionId": "pmm1jxdx100l3ux",
+		"collectionName": "secrets",
+		"created": "2023-11-01 06:12:12.682Z",
+		"data": {
+		  "ok": "ok"
+		},
+		"id": "o7kh2ekz3rdagrv",
+		"name": "test",
+		"updated": "2023-11-01 06:12:12.682Z"
+	  }`
+
+	httpResp := &http.Response{
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Status:     "200 OK",
+		StatusCode: 200,
+	}
+
+	secret := &Secrets{
+		Name: "test",
+		Data: map[string]interface{}{
+			"ok": "ok",
+		},
+	}
+	client.EXPECT().CollectionRequest(ctx, "POST", collectionName, "", secret, nil).Return(
+		httpResp,
+		nil,
+	)
+
+	err := create.Execute(ctx)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	gotJSONOutput := logger.JSONOutput()
+
+	var gotSecret Secrets
+	err = json.Unmarshal([]byte(gotJSONOutput), &gotSecret)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	if gotSecret.Name != secret.Name {
+		t.Fatalf("expected \"%s\" got \"%s\"", gotSecret.Name, secret.Name)
+	}
+	if fmt.Sprintf("%v", gotSecret.Data) != fmt.Sprintf("%v", secret.Data) {
+		t.Fatalf("expected \"%s\" got \"%s\"", gotSecret.Name, secret.Name)
+	}
+	if gotSecret.ID == "" {
+		t.Fatalf("secret ID cannot be empty")
+	}
+	if gotSecret.Created.String() == "" {
+		t.Fatalf("secret created time cannot be empty")
+	}
+	if gotSecret.Updated.String() == "" {
+		t.Fatalf("secret updated time cannot be empty")
+	}
+}

--- a/cmd/meroxa/root/secrets/describe.go
+++ b/cmd/meroxa/root/secrets/describe.go
@@ -1,0 +1,87 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils/display"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/global"
+	"github.com/meroxa/cli/config"
+)
+
+type Describe struct {
+	args struct {
+		idOrName string
+	}
+
+	client global.BasicClient
+	config config.Config
+	logger log.Logger
+}
+
+var (
+	_ builder.CommandWithBasicClient = (*Describe)(nil)
+	_ builder.CommandWithConfig      = (*Describe)(nil)
+	_ builder.CommandWithDocs        = (*Describe)(nil)
+	_ builder.CommandWithExecute     = (*Describe)(nil)
+	_ builder.CommandWithLogger      = (*Describe)(nil)
+	_ builder.CommandWithArgs        = (*Describe)(nil)
+)
+
+func (*Describe) Usage() string {
+	return "describe idOrName"
+}
+
+func (*Describe) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Describe a Turbine Secret",
+		Long: `This command will describe a turbine secret by id or name.
+`,
+		Example: `meroxa secrets describe idOrName
+`,
+	}
+}
+
+func (d *Describe) Config(cfg config.Config) {
+	d.config = cfg
+}
+
+func (d *Describe) ParseArgs(args []string) error {
+	if len(args) > 0 {
+		d.args.idOrName = args[0]
+	}
+	return nil
+}
+
+func (d *Describe) BasicClient(client global.BasicClient) {
+	d.client = client
+}
+
+func (d *Describe) Logger(logger log.Logger) {
+	d.logger = logger
+}
+
+func (d *Describe) Execute(ctx context.Context) error {
+	if d.args.idOrName != "" {
+
+		getSecrets, err := RetrieveSecretsID(ctx, d.client, d.args.idOrName)
+		if err != nil {
+			return err
+		}
+
+		for _, secret := range getSecrets.Items {
+			d.logger.Info(ctx, display.PrintTable(secret, displayDetails))
+			dashboardURL := fmt.Sprintf("%s/secrets/%s", global.GetMeroxaAPIURL(), secret.ID)
+			d.logger.Info(ctx, fmt.Sprintf("\n ✨ To view your secret, visit %s", dashboardURL))
+		}
+		d.logger.JSON(ctx, getSecrets)
+
+	} else {
+		return errors.New("action aborted")
+	}
+	return nil
+}

--- a/cmd/meroxa/root/secrets/describe.go
+++ b/cmd/meroxa/root/secrets/describe.go
@@ -15,7 +15,7 @@ import (
 
 type Describe struct {
 	args struct {
-		idOrName string
+		nameOrUUID string
 	}
 
 	client global.BasicClient
@@ -33,7 +33,7 @@ var (
 )
 
 func (*Describe) Usage() string {
-	return "describe idOrName"
+	return "describe nameOrUUID"
 }
 
 func (*Describe) Docs() builder.Docs {
@@ -41,7 +41,7 @@ func (*Describe) Docs() builder.Docs {
 		Short: "Describe a Turbine Secret",
 		Long: `This command will describe a turbine secret by id or name.
 `,
-		Example: `meroxa secrets describe idOrName
+		Example: `meroxa secrets describe nameOrUUID
 `,
 	}
 }
@@ -52,7 +52,7 @@ func (d *Describe) Config(cfg config.Config) {
 
 func (d *Describe) ParseArgs(args []string) error {
 	if len(args) > 0 {
-		d.args.idOrName = args[0]
+		d.args.nameOrUUID = args[0]
 	}
 	return nil
 }
@@ -66,9 +66,8 @@ func (d *Describe) Logger(logger log.Logger) {
 }
 
 func (d *Describe) Execute(ctx context.Context) error {
-	if d.args.idOrName != "" {
-
-		getSecrets, err := RetrieveSecretsID(ctx, d.client, d.args.idOrName)
+	if d.args.nameOrUUID != "" {
+		getSecrets, err := RetrieveSecretsID(ctx, d.client, d.args.nameOrUUID)
 		if err != nil {
 			return err
 		}
@@ -79,7 +78,6 @@ func (d *Describe) Execute(ctx context.Context) error {
 			d.logger.Info(ctx, fmt.Sprintf("\n ✨ To view your secret, visit %s", dashboardURL))
 		}
 		d.logger.JSON(ctx, getSecrets)
-
 	} else {
 		return errors.New("action aborted")
 	}

--- a/cmd/meroxa/root/secrets/describe_test.go
+++ b/cmd/meroxa/root/secrets/describe_test.go
@@ -1,0 +1,101 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	basicMock "github.com/meroxa/cli/cmd/meroxa/global/mock"
+	"github.com/meroxa/cli/log"
+)
+
+func TestDescribeSecrets(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := basicMock.NewMockBasicClient(ctrl)
+	logger := log.NewTestLogger()
+	// mockTurbineCLI := turbineMock.NewMockCLI(ctrl)
+
+	describe := &Describe{
+		client: client,
+		logger: logger,
+		args:   struct{ idOrName string }{idOrName: "test"},
+	}
+	body := `
+	{
+        "page": 1,
+        "perPage": 30,
+        "totalItems": 2,
+        "totalPages": 1,
+        "items": [
+                {
+                        "id": "ukip276znrvo2bs",
+                        "name": "test",
+                        "data": {
+                                "ok": "ok"
+                        },
+                        "created": "2023-10-31T18:15:01.169Z",
+                        "updated": "2023-10-31T18:15:01.169Z"
+                }           
+        ]
+}
+	`
+
+	httpResp := &http.Response{
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Status:     "200 OK",
+		StatusCode: 200,
+	}
+
+	secret := &Secrets{
+		Name: "test",
+		Data: map[string]interface{}{
+			"ok": "ok",
+		},
+	}
+
+	a := &url.Values{}
+	a.Add("filter", fmt.Sprintf("(id='%s' || name='%s')", secret.Name, secret.Name))
+
+	client.EXPECT().CollectionRequest(ctx, "GET", collectionName, "", nil, *a).Return(
+		httpResp,
+		nil,
+	)
+
+	err := describe.Execute(ctx)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	gotJSONOutput := logger.JSONOutput()
+
+	var listSecrets ListSecrets
+	err = json.Unmarshal([]byte(gotJSONOutput), &listSecrets)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	for _, gotSecret := range listSecrets.Items {
+		if gotSecret.Name != secret.Name {
+			t.Fatalf("expected \"%s\" got \"%s\"", gotSecret.Name, secret.Name)
+		}
+		if fmt.Sprintf("%v", gotSecret.Data) != fmt.Sprintf("%v", secret.Data) {
+			t.Fatalf("expected \"%s\" got \"%s\"", fmt.Sprintf("%v", gotSecret.Data), fmt.Sprintf("%v", secret.Data))
+		}
+		if gotSecret.ID == "" {
+			t.Fatalf("secret ID cannot be empty")
+		}
+		if gotSecret.Created.String() == "" {
+			t.Fatalf("secret created time cannot be empty")
+		}
+		if gotSecret.Updated.String() == "" {
+			t.Fatalf("secret updated time cannot be empty")
+		}
+	}
+}

--- a/cmd/meroxa/root/secrets/describe_test.go
+++ b/cmd/meroxa/root/secrets/describe_test.go
@@ -25,13 +25,13 @@ func TestDescribeSecrets(t *testing.T) {
 	describe := &Describe{
 		client: client,
 		logger: logger,
-		args:   struct{ idOrName string }{idOrName: "test"},
+		args:   struct{ nameOrUUID string }{nameOrUUID: "test"},
 	}
 	body := `
 	{
         "page": 1,
         "perPage": 30,
-        "totalItems": 2,
+        "totalItems": 1,
         "totalPages": 1,
         "items": [
                 {

--- a/cmd/meroxa/root/secrets/list.go
+++ b/cmd/meroxa/root/secrets/list.go
@@ -1,0 +1,79 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/meroxa/cli/log"
+	"github.com/meroxa/cli/utils/display"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/global"
+	"github.com/meroxa/cli/config"
+)
+
+type List struct {
+	client global.BasicClient
+	config config.Config
+	logger log.Logger
+}
+
+var (
+	_ builder.CommandWithBasicClient = (*List)(nil)
+	_ builder.CommandWithConfig      = (*List)(nil)
+	_ builder.CommandWithDocs        = (*List)(nil)
+	_ builder.CommandWithExecute     = (*List)(nil)
+	_ builder.CommandWithLogger      = (*List)(nil)
+	_ builder.CommandWithAliases     = (*List)(nil)
+)
+
+func (*List) Usage() string {
+	return "list [--path pwd]"
+}
+
+func (*List) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "List all Turbine Secrets",
+		Long: `This command will list all the secrets defined on the platform.
+`,
+		Example: `meroxa secrets list`,
+	}
+}
+
+func (d *List) Aliases() []string {
+	return []string{"ls"}
+}
+
+func (d *List) Config(cfg config.Config) {
+	d.config = cfg
+}
+
+func (d *List) BasicClient(client global.BasicClient) {
+	d.client = client
+}
+
+func (d *List) Logger(logger log.Logger) {
+	d.logger = logger
+}
+
+func (d *List) Execute(ctx context.Context) error {
+	secrets := &ListSecrets{}
+
+	response, err := d.client.CollectionRequest(ctx, "GET", collectionName, "", nil, nil)
+	if err != nil {
+		return err
+	}
+
+	err = json.NewDecoder(response.Body).Decode(&secrets)
+	if err != nil {
+		return err
+	}
+
+	d.logger.Info(ctx, display.PrintList(secrets.Items, displayDetails))
+	d.logger.JSON(ctx, secrets)
+	output := fmt.Sprintf("\n ✨ To view your secrets, visit %s/secrets", global.GetMeroxaAPIURL())
+	d.logger.Info(ctx, output)
+
+	return nil
+}

--- a/cmd/meroxa/root/secrets/list_test.go
+++ b/cmd/meroxa/root/secrets/list_test.go
@@ -1,0 +1,97 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	basicMock "github.com/meroxa/cli/cmd/meroxa/global/mock"
+	"github.com/meroxa/cli/log"
+)
+
+func TestListSecrets(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := basicMock.NewMockBasicClient(ctrl)
+	logger := log.NewTestLogger()
+	// mockTurbineCLI := turbineMock.NewMockCLI(ctrl)
+
+	list := &List{
+		client: client,
+		logger: logger,
+	}
+	body := `
+	{
+        "page": 1,
+        "perPage": 30,
+        "totalItems": 2,
+        "totalPages": 1,
+        "items": [
+                {
+                        "id": "ukip276znrvo2bs",
+                        "name": "test",
+                        "data": {
+                                "ok": "ok"
+                        },
+                        "created": "2023-10-31T18:15:01.169Z",
+                        "updated": "2023-10-31T18:15:01.169Z"
+                }  , 
+				{
+					"id": "ukip276znrvo2bs",
+					"name": "test2",
+					"data": {
+							"ok": "ok"
+					},
+					"created": "2023-10-31T18:15:01.169Z",
+					"updated": "2023-10-31T18:15:01.169Z"
+				}       
+        ]
+	}`
+
+	httpResp := &http.Response{
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Status:     "200 OK",
+		StatusCode: 200,
+	}
+
+	client.EXPECT().CollectionRequest(ctx, "GET", collectionName, "", nil, nil).Return(
+		httpResp,
+		nil,
+	)
+
+	err := list.Execute(ctx)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	gotJSONOutput := logger.JSONOutput()
+
+	var listSecrets ListSecrets
+	err = json.Unmarshal([]byte(gotJSONOutput), &listSecrets)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+
+	for _, gotSecret := range listSecrets.Items {
+		if gotSecret.Name == "" {
+			t.Fatalf("secret name cannot be empty")
+		}
+		if fmt.Sprintf("%v", gotSecret.Data) == "" {
+			t.Fatalf("secret data cannot be empty")
+		}
+		if gotSecret.ID == "" {
+			t.Fatalf("secret ID cannot be empty")
+		}
+		if gotSecret.Created.String() == "" {
+			t.Fatalf("secret created time cannot be empty")
+		}
+		if gotSecret.Updated.String() == "" {
+			t.Fatalf("secret updated time cannot be empty")
+		}
+	}
+}

--- a/cmd/meroxa/root/secrets/remove.go
+++ b/cmd/meroxa/root/secrets/remove.go
@@ -1,0 +1,109 @@
+package secrets
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/meroxa/cli/log"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/global"
+	"github.com/meroxa/cli/config"
+)
+
+type Remove struct {
+	flags struct {
+		Force bool `long:"force" short:"f" default:"false" usage:"skip confirmation"`
+	}
+	args struct {
+		idOrName string
+	}
+
+	client global.BasicClient
+	config config.Config
+	logger log.Logger
+}
+
+var (
+	_ builder.CommandWithBasicClient = (*Remove)(nil)
+	_ builder.CommandWithConfig      = (*Remove)(nil)
+	_ builder.CommandWithDocs        = (*Remove)(nil)
+	_ builder.CommandWithExecute     = (*Remove)(nil)
+	_ builder.CommandWithFlags       = (*Remove)(nil)
+	_ builder.CommandWithLogger      = (*Remove)(nil)
+	_ builder.CommandWithArgs        = (*Remove)(nil)
+	_ builder.CommandWithAliases     = (*Remove)(nil)
+)
+
+func (*Remove) Usage() string {
+	return "remove [--path pwd]"
+}
+
+func (*Remove) Docs() builder.Docs {
+	return builder.Docs{
+		Short:   "Remove a Turbine Secret",
+		Long:    `This command will remove the secret specified either by name or id`,
+		Example: `meroxa apps remove idOrName`,
+	}
+}
+
+func (d *Remove) Config(cfg config.Config) {
+	d.config = cfg
+}
+
+func (d *Remove) Aliases() []string {
+	return []string{"rm", "delete"}
+}
+
+func (d *Remove) BasicClient(client global.BasicClient) {
+	d.client = client
+}
+
+func (d *Remove) Flags() []builder.Flag {
+	return builder.BuildFlags(&d.flags)
+}
+
+func (d *Remove) Logger(logger log.Logger) {
+	d.logger = logger
+}
+
+func (d *Remove) ParseArgs(args []string) error {
+	if len(args) > 0 {
+		d.args.idOrName = args[0]
+	}
+	return nil
+}
+
+func (d *Remove) Execute(ctx context.Context) error {
+	if !d.flags.Force {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Printf("To proceed, type %q or re-run this command with --force\n▸ ", d.args.idOrName)
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+
+		if d.args.idOrName != strings.TrimRight(input, "\r\n") {
+			return errors.New("action aborted")
+		}
+	}
+
+	getSecrets, err := RetrieveSecretsID(ctx, d.client, d.args.idOrName)
+	if err != nil {
+		return err
+	}
+
+	d.logger.Infof(ctx, "Removing secret %q...", d.args.idOrName)
+	_, err = d.client.CollectionRequest(ctx, "DELETE", collectionName, getSecrets.Items[0].ID, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	d.logger.Infof(ctx, "Secret %q successfully removed", d.args.idOrName)
+
+	return nil
+}

--- a/cmd/meroxa/root/secrets/remove.go
+++ b/cmd/meroxa/root/secrets/remove.go
@@ -20,7 +20,7 @@ type Remove struct {
 		Force bool `long:"force" short:"f" default:"false" usage:"skip confirmation"`
 	}
 	args struct {
-		idOrName string
+		nameOrUUID string
 	}
 
 	client global.BasicClient
@@ -47,7 +47,7 @@ func (*Remove) Docs() builder.Docs {
 	return builder.Docs{
 		Short:   "Remove a Turbine Secret",
 		Long:    `This command will remove the secret specified either by name or id`,
-		Example: `meroxa apps remove idOrName`,
+		Example: `meroxa apps remove nameOrUUID`,
 	}
 }
 
@@ -73,7 +73,7 @@ func (d *Remove) Logger(logger log.Logger) {
 
 func (d *Remove) ParseArgs(args []string) error {
 	if len(args) > 0 {
-		d.args.idOrName = args[0]
+		d.args.nameOrUUID = args[0]
 	}
 	return nil
 }
@@ -81,29 +81,29 @@ func (d *Remove) ParseArgs(args []string) error {
 func (d *Remove) Execute(ctx context.Context) error {
 	if !d.flags.Force {
 		reader := bufio.NewReader(os.Stdin)
-		fmt.Printf("To proceed, type %q or re-run this command with --force\n▸ ", d.args.idOrName)
+		fmt.Printf("To proceed, type %q or re-run this command with --force\n▸ ", d.args.nameOrUUID)
 		input, err := reader.ReadString('\n')
 		if err != nil {
 			return err
 		}
 
-		if d.args.idOrName != strings.TrimRight(input, "\r\n") {
+		if d.args.nameOrUUID != strings.TrimRight(input, "\r\n") {
 			return errors.New("action aborted")
 		}
 	}
 
-	getSecrets, err := RetrieveSecretsID(ctx, d.client, d.args.idOrName)
+	getSecrets, err := RetrieveSecretsID(ctx, d.client, d.args.nameOrUUID)
 	if err != nil {
 		return err
 	}
 
-	d.logger.Infof(ctx, "Removing secret %q...", d.args.idOrName)
+	d.logger.Infof(ctx, "Removing secret %q...", d.args.nameOrUUID)
 	_, err = d.client.CollectionRequest(ctx, "DELETE", collectionName, getSecrets.Items[0].ID, nil, nil)
 	if err != nil {
 		return err
 	}
 
-	d.logger.Infof(ctx, "Secret %q successfully removed", d.args.idOrName)
+	d.logger.Infof(ctx, "Secret %q successfully removed", d.args.nameOrUUID)
 
 	return nil
 }

--- a/cmd/meroxa/root/secrets/remove_test.go
+++ b/cmd/meroxa/root/secrets/remove_test.go
@@ -1,0 +1,79 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	basicMock "github.com/meroxa/cli/cmd/meroxa/global/mock"
+	"github.com/meroxa/cli/log"
+)
+
+func TestRemoveSecrets(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	client := basicMock.NewMockBasicClient(ctrl)
+	logger := log.NewTestLogger()
+	// mockTurbineCLI := turbineMock.NewMockCLI(ctrl)
+
+	remove := &Remove{
+		client: client,
+		logger: logger,
+		args:   struct{ idOrName string }{idOrName: "test"},
+		flags: struct {
+			Force bool "long:\"force\" short:\"f\" default:\"false\" usage:\"skip confirmation\""
+		}{Force: true},
+	}
+
+	body := `
+	{
+        "page": 1,
+        "perPage": 30,
+        "totalItems": 1,
+        "totalPages": 1,
+        "items": [
+                {
+                        "id": "ukip276znrvo2bs",
+                        "name": "test",
+                        "data": {
+                                "ok": "ok"
+                        },
+                        "created": "2023-10-31T18:15:01.169Z",
+                        "updated": "2023-10-31T18:15:01.169Z"
+                }           
+        ]
+}
+	`
+
+	httpResp := &http.Response{
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Status:     "200 OK",
+		StatusCode: 200,
+	}
+
+	a := &url.Values{}
+	a.Add("filter", fmt.Sprintf("(id='%s' || name='%s')", remove.args.idOrName, remove.args.idOrName))
+
+	client.EXPECT().CollectionRequest(ctx, "GET", collectionName, "", nil, *a).Return(
+		httpResp,
+		nil,
+	)
+
+	client.EXPECT().CollectionRequest(ctx, "DELETE", collectionName, "ukip276znrvo2bs", nil, nil).Return(
+		&http.Response{
+			Status:     "204 OK",
+			StatusCode: 204,
+		},
+		nil,
+	)
+
+	err := remove.Execute(ctx)
+	if err != nil {
+		t.Fatalf("not expected error, got %q", err.Error())
+	}
+}

--- a/cmd/meroxa/root/secrets/remove_test.go
+++ b/cmd/meroxa/root/secrets/remove_test.go
@@ -24,7 +24,7 @@ func TestRemoveSecrets(t *testing.T) {
 	remove := &Remove{
 		client: client,
 		logger: logger,
-		args:   struct{ idOrName string }{idOrName: "test"},
+		args:   struct{ nameOrUUID string }{nameOrUUID: "test"},
 		flags: struct {
 			Force bool "long:\"force\" short:\"f\" default:\"false\" usage:\"skip confirmation\""
 		}{Force: true},
@@ -57,7 +57,7 @@ func TestRemoveSecrets(t *testing.T) {
 	}
 
 	a := &url.Values{}
-	a.Add("filter", fmt.Sprintf("(id='%s' || name='%s')", remove.args.idOrName, remove.args.idOrName))
+	a.Add("filter", fmt.Sprintf("(id='%s' || name='%s')", remove.args.nameOrUUID, remove.args.nameOrUUID))
 
 	client.EXPECT().CollectionRequest(ctx, "GET", collectionName, "", nil, *a).Return(
 		httpResp,

--- a/cmd/meroxa/root/secrets/secrets.go
+++ b/cmd/meroxa/root/secrets/secrets.go
@@ -1,0 +1,130 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	pb "github.com/pocketbase/pocketbase/tools/types"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/global"
+	"github.com/meroxa/cli/utils/display"
+	"github.com/spf13/cobra"
+)
+
+const (
+	collectionName = "secrets"
+)
+
+type ListSecrets struct {
+	Page       int       `json:"page"`
+	PerPage    int       `json:"perPage"`
+	TotalItems int       `json:"totalItems"`
+	TotalPages int       `json:"totalPages"`
+	Items      []Secrets `json:"items"`
+}
+
+type Secrets struct {
+	ID             string                 `json:"id"`
+	Name           string                 `json:"name"`
+	Data           map[string]interface{} `json:"data"`
+	Created        SecretTime             `json:"created"`
+	Updated        SecretTime             `json:"updated"`
+	CollectionID   string                 `json:"collectionId"`
+	CollectionName string                 `json:"collectionName"`
+}
+
+var displayDetails = display.Details{
+	"ID":      "id",
+	"Name":    "name",
+	"Data":    "data",
+	"Created": "created",
+	"Updated": "updated",
+}
+
+var (
+	_ builder.CommandWithDocs        = (*Secrets)(nil)
+	_ builder.CommandWithAliases     = (*Secrets)(nil)
+	_ builder.CommandWithSubCommands = (*Secrets)(nil)
+)
+
+type SecretTime struct {
+	time.Time
+}
+
+func (at *SecretTime) UnmarshalJSON(b []byte) error {
+	appTime, err := strconv.Unquote(string(b))
+	if err != nil {
+		return err
+	}
+
+	dt, err := pb.ParseDateTime(appTime) // time.Parse(pb.DefaultDateLayout, appTime)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+	at.Time = dt.Time()
+	return nil
+}
+
+func (at *SecretTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(at.Time)
+}
+
+func (at *SecretTime) Format(s string) string {
+	t := at.Time
+	return t.Format(s)
+}
+
+func (*Secrets) Aliases() []string {
+	return []string{"secrets"}
+}
+
+func (*Secrets) Usage() string {
+	return "secrets"
+}
+
+func (*Secrets) Docs() builder.Docs {
+	return builder.Docs{
+		Short: "Manage Turbine Data Applications",
+	}
+}
+
+func (*Secrets) SubCommands() []*cobra.Command {
+	return []*cobra.Command{
+		builder.BuildCobraCommand(&Create{}),
+		builder.BuildCobraCommand(&Describe{}),
+		builder.BuildCobraCommand(&List{}),
+		builder.BuildCobraCommand(&Update{}),
+		builder.BuildCobraCommand(&Remove{}),
+	}
+}
+
+func RetrieveSecretsID(ctx context.Context, client global.BasicClient, nameOrID string) (*ListSecrets, error) {
+	getSecrets := &ListSecrets{}
+
+	a := &url.Values{}
+	a.Add("filter", fmt.Sprintf("(id='%s' || name='%s')", nameOrID, nameOrID))
+
+	response, err := client.CollectionRequest(ctx, "GET", collectionName, "", nil, *a)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.NewDecoder(response.Body).Decode(&getSecrets)
+	if err != nil {
+		return nil, err
+	}
+
+	if getSecrets.TotalItems == 0 {
+		return nil, fmt.Errorf("secret %q not found", nameOrID)
+	} else if getSecrets.TotalItems > 1 {
+		return nil, fmt.Errorf("multiple secrets found with name %q", nameOrID)
+	}
+
+	return getSecrets, nil
+}

--- a/cmd/meroxa/root/secrets/update.go
+++ b/cmd/meroxa/root/secrets/update.go
@@ -1,0 +1,104 @@
+package secrets
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/meroxa/cli/log"
+
+	"github.com/meroxa/cli/cmd/meroxa/builder"
+	"github.com/meroxa/cli/cmd/meroxa/global"
+	"github.com/meroxa/cli/config"
+)
+
+type Update struct {
+	args struct {
+		idOrName string
+	}
+
+	client global.BasicClient
+	config config.Config
+	logger log.Logger
+}
+
+var (
+	_ builder.CommandWithBasicClient = (*Update)(nil)
+	_ builder.CommandWithConfig      = (*Update)(nil)
+	_ builder.CommandWithDocs        = (*Update)(nil)
+	_ builder.CommandWithExecute     = (*Update)(nil)
+	_ builder.CommandWithLogger      = (*Update)(nil)
+	_ builder.CommandWithArgs        = (*Update)(nil)
+)
+
+func (*Update) Usage() string {
+	return "update idOrName --data '{}'"
+}
+
+func (*Update) Docs() builder.Docs {
+	return builder.Docs{
+		Short:   "Update a Turbine Secret",
+		Long:    `This command will update the specified Turbine Secret's data.`,
+		Example: `meroxa secrets update idOrName --data '{"key": "value"}' `,
+	}
+}
+
+func (d *Update) Config(cfg config.Config) {
+	d.config = cfg
+}
+
+// ParseArgs implements builder.CommandWithArgs.
+func (d *Update) ParseArgs(args []string) error {
+	if len(args) > 0 {
+		d.args.idOrName = args[0]
+	}
+	return nil
+}
+
+func (d *Update) BasicClient(client global.BasicClient) {
+	d.client = client
+}
+
+func (d *Update) Logger(logger log.Logger) {
+	d.logger = logger
+}
+
+func (d *Update) Execute(ctx context.Context) error {
+	getSecrets, err := RetrieveSecretsID(ctx, d.client, d.args.idOrName)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("To proceed, enter new data for each key or press enter to skip. ")
+	for k := range getSecrets.Items[0].Data {
+		fmt.Printf("%q: ", k)
+		reader := bufio.NewReader(os.Stdin)
+		input, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if len(strings.TrimRight(input, "\r\n")) != 0 {
+			getSecrets.Items[0].Data[k] = strings.TrimRight(input, "\r\n")
+		}
+	}
+
+	d.logger.Infof(ctx, "Updating secret %q...", d.args.idOrName)
+	response, err := d.client.CollectionRequest(ctx, "PATCH", collectionName, getSecrets.Items[0].ID, getSecrets.Items[0], nil)
+	if err != nil {
+		return err
+	}
+
+	updatedSecret := &Secrets{}
+	err = json.NewDecoder(response.Body).Decode(&updatedSecret)
+	if err != nil {
+		return err
+	}
+
+	d.logger.Infof(ctx, "Secret %q has been updated.", updatedSecret.Name)
+	d.logger.JSON(ctx, updatedSecret)
+
+	return nil
+}

--- a/cmd/meroxa/root/secrets/update.go
+++ b/cmd/meroxa/root/secrets/update.go
@@ -88,7 +88,7 @@ func (d *Update) Execute(ctx context.Context) error {
 	for k := range getSecrets.Items[0].Data {
 		fmt.Printf("\n %q: ", k)
 		reader := bufio.NewReader(os.Stdin)
-		input, err := reader.ReadString('\n') //nolint:shadow
+		input, err := reader.ReadString('\n') //nolint
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func (d *Update) Execute(ctx context.Context) error {
 
 	if d.flags.Data != "" {
 		appendData := make(map[string]interface{})
-		err := json.Unmarshal([]byte(d.flags.Data), &appendData) //nolint:shadow
+		err := json.Unmarshal([]byte(d.flags.Data), &appendData) //nolint
 		if err != nil {
 			return err
 		}

--- a/cmd/meroxa/root/secrets/update.go
+++ b/cmd/meroxa/root/secrets/update.go
@@ -88,7 +88,7 @@ func (d *Update) Execute(ctx context.Context) error {
 	for k := range getSecrets.Items[0].Data {
 		fmt.Printf("\n %q: ", k)
 		reader := bufio.NewReader(os.Stdin)
-		input, err := reader.ReadString('\n')
+		input, err := reader.ReadString('\n') //nolint:shadow
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ func (d *Update) Execute(ctx context.Context) error {
 
 	if d.flags.Data != "" {
 		appendData := make(map[string]interface{})
-		err := json.Unmarshal([]byte(d.flags.Data), &appendData)
+		err := json.Unmarshal([]byte(d.flags.Data), &appendData) //nolint:shadow
 		if err != nil {
 			return err
 		}

--- a/utils/display/display.go
+++ b/utils/display/display.go
@@ -55,8 +55,10 @@ func interfaceSlice(slice interface{}) []interface{} {
 func PrintList(input interface{}, details Details) string {
 	table := simpletable.New()
 	headers := []*simpletable.Cell{}
-	for column := range details {
+	var hh []string
+	for column, js := range details {
 		headers = append(headers, &simpletable.Cell{Align: simpletable.AlignCenter, Text: strings.ToUpper(column)})
+		hh = append(hh, js)
 	}
 	objs := interfaceSlice(input)
 	for _, o := range objs {
@@ -71,11 +73,13 @@ func PrintList(input interface{}, details Details) string {
 			fmt.Printf("err: %v\n", err)
 			return ""
 		}
-
 		row := []*simpletable.Cell{}
-		for _, field := range details {
+
+		for _, o := range hh {
+			// fmt.Printf("Field: %s\n", o)
+			// fmt.Printf("Value: %v\n", amorphous[o])
 			row = append(row,
-				&simpletable.Cell{Align: simpletable.AlignCenter, Text: fmt.Sprintf("%v", amorphous[field])})
+				&simpletable.Cell{Align: simpletable.AlignCenter, Text: fmt.Sprintf("%v", amorphous[o])})
 		}
 		table.Body.Cells = append(table.Body.Cells, row)
 	}

--- a/utils/display/display.go
+++ b/utils/display/display.go
@@ -24,9 +24,11 @@ func PrintTable(obj interface{}, details Details) string {
 
 	mainTable := simpletable.New()
 	for row, field := range details {
+		cellData, _ := json.Marshal(amorphous[field])
+		jsonStr := string(cellData)
 		mainTable.Body.Cells = append(mainTable.Body.Cells, []*simpletable.Cell{
 			{Align: simpletable.AlignRight, Text: row + ":"},
-			{Text: fmt.Sprintf("%v", amorphous[field])},
+			{Text: fmt.Sprintf("%v", jsonStr)},
 		})
 	}
 	mainTable.SetStyle(simpletable.StyleCompact)
@@ -75,11 +77,11 @@ func PrintList(input interface{}, details Details) string {
 		}
 		row := []*simpletable.Cell{}
 
-		for _, o := range hh {
-			// fmt.Printf("Field: %s\n", o)
-			// fmt.Printf("Value: %v\n", amorphous[o])
+		for _, h := range hh {
+			cellData, _ := json.Marshal(amorphous[h])
+			jsonStr := string(cellData)
 			row = append(row,
-				&simpletable.Cell{Align: simpletable.AlignCenter, Text: fmt.Sprintf("%v", amorphous[o])})
+				&simpletable.Cell{Align: simpletable.AlignCenter, Text: fmt.Sprintf("%v", jsonStr)})
 		}
 		table.Body.Cells = append(table.Body.Cells, row)
 	}


### PR DESCRIPTION
## Description of change

We want to be able to add, list, describe , remove and update secrets from CLI. 

Fixes https://github.com/meroxa/mdpx/issues/656

## Type of change

<!-- Please tick off the correct checkbox after saving the PR description. -->

- [ ]  New feature
- [ ]  Bug fix
- [x]  Refactor
- [ ]  Documentation

## How was this tested?

- [x]  Unit Tests
- [x]  Tested in staging
- [ ]  Tested in minikube

## Demo

(In slack) 

